### PR TITLE
feat(oidc): add key-id config field for stable kid in private_key_jwt assertions

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -416,6 +416,15 @@ auth:
     # Generate: openssl req -new -x509 -key private.pem -out cert.pem -days 365
     # cert-path: /run/secrets/gitproxy-oidc-cert.pem
 
+    # Optional: explicit kid to embed in the private_key_jwt assertion header.
+    # Use this for providers that match the assertion against a registered JWKS by kid
+    # (Keycloak, Okta, Auth0, Dex). Without it, a random UUID kid is generated on each
+    # restart, which breaks authentication with those providers.
+    # Find the kid by inspecting your provider's JWKS endpoint and matching it to the
+    # public key you registered.
+    # Not needed when cert-path is set (Entra ID uses x5t instead of kid).
+    # key-id: my-registered-kid
+
   # OIDC claim containing the user's group memberships. Defaults to "groups",
   # which is standard for Keycloak, Okta, and most Entra ID configurations.
   groups-claim: groups

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SecurityConfig.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SecurityConfig.java
@@ -415,7 +415,8 @@ public class SecurityConfig {
                                     userInfo.oidcUserService(buildOidcUserService(roleMappings, groupsClaim)));
 
                     if (usePrivateKeyJwt) {
-                        RSAKey rsaKey = loadRsaKey(oidcCfg.getPrivateKeyPath(), oidcCfg.getCertPath());
+                        RSAKey rsaKey = loadRsaKey(
+                                oidcCfg.getPrivateKeyPath(), oidcCfg.getCertPath(), oidcCfg.getKeyId());
                         Function<ClientRegistration, JWK> jwkResolver = reg ->
                                 ClientAuthenticationMethod.PRIVATE_KEY_JWT.equals(reg.getClientAuthenticationMethod())
                                         ? rsaKey
@@ -595,10 +596,12 @@ public class SecurityConfig {
      * {@link NimbusJwtClientAuthenticationParametersConverter}. The public key is derived from the CRT parameters
      * embedded in the private key — no separate public key file is needed.
      *
-     * <p>When {@code certPath} is non-blank, the SHA-256 thumbprint of the certificate is computed and set as
-     * {@code x5t#S256} on the key. This is required for Entra ID, which matches registered certificates by thumbprint
-     * rather than {@code kid}. Providers that match on {@code kid} (Keycloak, Dex) leave {@code certPath} blank and
-     * receive a random {@code kid} instead.
+     * <p>Key-ID precedence when {@code private-key-path} is set:
+     * <ol>
+     *   <li>{@code certPath} non-blank → SHA-256 thumbprint set as {@code x5t#S256} (Entra ID)
+     *   <li>{@code keyId} non-blank → used as explicit {@code kid} (Keycloak, Okta, Auth0, Dex)
+     *   <li>Neither → random UUID {@code kid} (suitable only for providers that accept any {@code kid})
+     * </ol>
      *
      * <p>Generate a suitable key pair with:
      *
@@ -608,7 +611,7 @@ public class SecurityConfig {
      * openssl req -new -x509 -key private.pem -out cert.pem -days 365   # Entra ID only
      * </pre>
      */
-    private static RSAKey loadRsaKey(String pemPath, String certPath) {
+    static RSAKey loadRsaKey(String pemPath, String certPath, String keyId) {
         try {
             String pem = Files.readString(Path.of(pemPath))
                     .replaceAll("-----[^-]+-----", "")
@@ -626,6 +629,8 @@ public class SecurityConfig {
                     byte[] sha256 = MessageDigest.getInstance("SHA-256").digest(cert.getEncoded());
                     builder.x509CertSHA256Thumbprint(Base64URL.encode(sha256));
                 }
+            } else if (keyId != null && !keyId.isBlank()) {
+                builder.keyID(keyId);
             } else {
                 builder.keyID(UUID.randomUUID().toString());
             }

--- a/git-proxy-java-dashboard/src/test/java/org/finos/gitproxy/dashboard/LoadRsaKeyTest.java
+++ b/git-proxy-java-dashboard/src/test/java/org/finos/gitproxy/dashboard/LoadRsaKeyTest.java
@@ -1,0 +1,58 @@
+package org.finos.gitproxy.dashboard;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.util.Base64;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LoadRsaKeyTest {
+
+    @TempDir
+    static Path tempDir;
+
+    static Path keyFile;
+
+    @BeforeAll
+    static void generateKey() throws Exception {
+        var kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        var kp = kpg.generateKeyPair();
+        var privateKey = (RSAPrivateCrtKey) kp.getPrivate();
+        String pem = "-----BEGIN PRIVATE KEY-----\n"
+                + Base64.getMimeEncoder(64, new byte[] {'\n'}).encodeToString(privateKey.getEncoded())
+                + "\n-----END PRIVATE KEY-----\n";
+        keyFile = tempDir.resolve("test-key.pem");
+        Files.writeString(keyFile, pem);
+    }
+
+    @Test
+    void explicitKeyId_usedAsKid() throws Exception {
+        var rsaKey = SecurityConfig.loadRsaKey(keyFile.toString(), "", "my-registered-kid");
+
+        assertEquals("my-registered-kid", rsaKey.getKeyID());
+        assertNull(rsaKey.getX509CertSHA256Thumbprint(), "x5t#S256 should not be set when using key-id");
+    }
+
+    @Test
+    void noKeyIdNoCert_randomUuidKid() throws Exception {
+        var rsaKey = SecurityConfig.loadRsaKey(keyFile.toString(), "", "");
+
+        assertNotNull(rsaKey.getKeyID(), "A kid should always be set");
+        assertDoesNotThrow(() -> java.util.UUID.fromString(rsaKey.getKeyID()), "kid should be a UUID");
+        assertNull(rsaKey.getX509CertSHA256Thumbprint());
+    }
+
+    @Test
+    void randomUuidKid_changesOnEachCall() throws Exception {
+        var key1 = SecurityConfig.loadRsaKey(keyFile.toString(), "", "");
+        var key2 = SecurityConfig.loadRsaKey(keyFile.toString(), "", "");
+
+        assertNotEquals(key1.getKeyID(), key2.getKeyID(), "Each call without key-id should produce a distinct kid");
+    }
+}

--- a/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/OidcAuthConfig.java
+++ b/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/OidcAuthConfig.java
@@ -95,4 +95,24 @@ public class OidcAuthConfig {
      * <p>Example: {@code /run/secrets/gitproxy-oidc-cert.pem}
      */
     private String certPath = "";
+
+    /**
+     * Explicit {@code kid} (key ID) to include in the {@code private_key_jwt} assertion header. Use this when the IdP
+     * matches the client assertion against a registered JWKS by {@code kid} — Keycloak, Okta, Auth0, and Dex all work
+     * this way.
+     *
+     * <p>Find the correct value by inspecting your provider's JWKS endpoint (e.g.
+     * {@code <issuer>/protocol/openid-connect/certs} on Keycloak) and matching it to the public key you registered.
+     *
+     * <p>Precedence when {@code private-key-path} is set:
+     *
+     * <ol>
+     *   <li>{@code cert-path} set → {@code x5t#S256} thumbprint (Entra ID)
+     *   <li>{@code key-id} set → explicit {@code kid} (Keycloak, Okta, Auth0, Dex)
+     *   <li>Neither → random UUID {@code kid} (only suitable for providers that accept any {@code kid})
+     * </ol>
+     *
+     * <p>Example: {@code my-registered-kid}
+     */
+    private String keyId = "";
 }


### PR DESCRIPTION
## Summary

- Adds optional `key-id` field to `OidcAuthConfig` (`auth.oidc.key-id` in YAML)
- Fixes broken `private_key_jwt` auth with Keycloak, Okta, Auth0, and Dex — without this, a random UUID `kid` is generated on every restart and never matches the `kid` registered with the provider's JWKS
- Precedence in `loadRsaKey`: `cert-path` → `x5t#S256` (Entra ID); `key-id` → explicit `kid`; neither → random UUID (backward compat)
- Extracts `loadRsaKey` to package-private and adds unit tests covering all three branches

closes #150

## Test plan

- [ ] Unit tests in `LoadRsaKeyTest` cover all three `kid` precedence branches
- [ ] Existing OIDC e2e tests (`OidcAuthE2ETest`, `OidcRoleMappingE2ETest`) pass unmodified