### PR TITLE
ci: run CI only on main pushes and PRs targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,9 @@ permissions:
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
   pull_request:
+    branches: ["main"]
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## Summary

- Now that `main` is protected and all changes land via PR, `ci.yml`'s `push: ["**"]` trigger was firing CI twice for every PR — once on the feature-branch push, again on `pull_request` open/sync.
- Trim to the standard idiom used by `codeql.yml`, `cve.yml`, and `docker-publish.yml`:
  - `push: main` — covers merge commits so `main`'s HEAD carries the required status check contexts the tag release gate needs
  - `pull_request: main` — feeds the PR merge gate
- No change to `docker-publish.yml`'s `tags: v*` trigger (release publish path is untouched).

## Test plan

- [ ] Confirm CI runs on this PR (pull_request: main trigger fires)
- [ ] After merge, confirm CI runs once on the merge commit to main (push: main trigger fires)
- [ ] Next feature-branch push after merge should **not** trigger CI until a PR is opened