### PR TITLE
feat(mongo): add session store + rename colliding collections

### DIFF
--- a/docker-compose.mongo.yml
+++ b/docker-compose.mongo.yml
@@ -21,6 +21,7 @@ services:
       GITPROXY_DATABASE_TYPE: mongo
       GITPROXY_DATABASE_URL: mongodb://gitproxy:gitproxy@mongo:27017
       GITPROXY_DATABASE_NAME: gitproxy
+      GITPROXY_SERVER_SESSION_STORE: mongo
     depends_on:
       mongo:
         condition: service_healthy

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -22,6 +22,7 @@ services:
       GITPROXY_DATABASE_URL: "jdbc:postgresql://postgres:5432/gitproxy?sslmode=disable"
       GITPROXY_DATABASE_USERNAME: gitproxy
       GITPROXY_DATABASE_PASSWORD: gitproxy
+      GITPROXY_SERVER_SESSION_STORE: jdbc
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -130,6 +130,7 @@ server:
   # Options:
   #   none   — in-memory (default); sessions lost on restart, not shared across pods
   #   jdbc   — persisted to the configured JDBC database; zero new infrastructure required
+  #   mongo   — persisted to the configured MongoDB database; zero new infrastructure required
   #   redis  — persisted to a Redis or Valkey instance; configure via server.redis.*
   # Use jdbc or redis for multi-instance deployments so sessions survive pod restarts
   # and remain valid across all replicas.
@@ -181,7 +182,18 @@ server:
 
 A minimal single-replica Redis or Valkey pod is sufficient — sessions are small and low-throughput. No persistence or clustering required for this use case.
 
-> **MongoDB deployments:** MongoDB-backed session storage is planned (#139). In the meantime, use `session-store: jdbc` with a separate PostgreSQL instance, or stand up a Redis pod.
+**MongoDB:**
+
+```yaml
+server:
+  session-store: mongo
+
+database:
+  type: mongo
+  url: mongodb://gitproxy:secret@mongo.internal:27017/gitproxy
+```
+
+Sessions are stored in the `proxy_sessions` collection alongside the other `proxy_*` collections. A TTL index on `expireAt` lets MongoDB expire idle sessions server-side — no background cleanup task runs in the proxy. The session store reuses the same connection pool as the rest of the MongoDB-backed stores, so no extra configuration is needed. Requires `database.type: mongo`.
 
 ## TLS
 
@@ -311,6 +323,22 @@ database:
   url: mongodb://gitproxy:secret@mongo.internal:27017
   name: gitproxy
 ```
+
+### MongoDB: coexisting with the upstream Node.js git-proxy
+
+If you are migrating from [finos/git-proxy](https://github.com/finos/git-proxy) (the Node.js implementation) and pointing this proxy at a database that previously held its data, the two applications use incompatible document schemas. The safest path is to **provision a new MongoDB database** (e.g. `gitproxy-java`) and point `database.url` at it. This avoids all collision risk and keeps indexes, backups, and ops tooling cleanly separated.
+
+If provisioning a separate database is not feasible, this proxy now uses collection names that do not collide with the upstream Node.js implementation:
+
+| Collection         | Written by                        | Notes                                                                  |
+| ------------------ | --------------------------------- | ---------------------------------------------------------------------- |
+| `proxy_users`      | `MongoUserStore`                  | Renamed from `users` to avoid collision with upstream's `users`.       |
+| `proxy_pushes`     | `MongoPushStore`                  | Renamed from `pushes` to avoid collision with upstream's `pushes`.     |
+| `repo_permissions` | `MongoRepoPermissionStore`        | No upstream equivalent.                                                |
+| `access_rules`     | `MongoUrlRuleRegistry`            | No upstream equivalent.                                                |
+| `fetch_records`    | `MongoFetchStore`                 | No upstream equivalent.                                                |
+
+This means you _can_ point both apps at the same MongoDB database without corrupting each other's data. We still recommend separate databases for operational clarity — shared databases make backups, restores, and index tuning harder to reason about — but it is no longer a correctness hazard. Starting with 1.0.0, these collection names are part of the project's stability contract and will not be renamed without an in-place migration path.
 
 ## Authentication
 

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/db/MongoStoreFactory.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/db/MongoStoreFactory.java
@@ -25,6 +25,16 @@ public final class MongoStoreFactory implements AutoCloseable {
         this.databaseName = databaseName;
     }
 
+    /** Returns the shared {@link MongoClient} so callers (e.g. session store) can reuse the connection pool. */
+    public MongoClient getMongoClient() {
+        return client;
+    }
+
+    /** Returns the configured database name. */
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
     /** Create and initialize a {@link PushStore} backed by this factory's client. */
     public PushStore pushStore() {
         MongoPushStore store = new MongoPushStore(client, databaseName);

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/db/mongo/MongoPushStore.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/db/mongo/MongoPushStore.java
@@ -28,7 +28,7 @@ import tools.jackson.databind.ObjectMapper;
 public class MongoPushStore implements PushStore {
 
     private static final Logger log = LoggerFactory.getLogger(MongoPushStore.class);
-    private static final String COLLECTION_NAME = "pushes";
+    private static final String COLLECTION_NAME = "proxy_pushes";
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final TypeReference<Map<String, String>> ANSWERS_TYPE = new TypeReference<>() {};
 

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/MongoUserStore.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/MongoUserStore.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 public class MongoUserStore implements UserStore {
 
     private static final Logger log = LoggerFactory.getLogger(MongoUserStore.class);
-    private static final String COLLECTION_NAME = "users";
+    private static final String COLLECTION_NAME = "proxy_users";
 
     private final MongoDatabase database;
 

--- a/git-proxy-java-dashboard/build.gradle
+++ b/git-proxy-java-dashboard/build.gradle
@@ -158,7 +158,8 @@ dependencies {
     // Database drivers at runtime (whichever store is configured)
     runtimeOnly "com.h2database:h2:${h2Version}"
     runtimeOnly "org.postgresql:postgresql:${postgresVersion}"
-    runtimeOnly "org.mongodb:mongodb-driver-sync:${mongoVersion}"
+    // MongoDB driver — compile-scoped because MongoSessionRepository uses the sync client directly.
+    implementation "org.mongodb:mongodb-driver-sync:${mongoVersion}"
 
     // Gestalt config (needed to catch GestaltException from GitProxyConfigLoader)
     implementation "com.github.gestalt-config:gestalt-core:${gestaltVersion}"
@@ -180,6 +181,7 @@ dependencies {
     // Testcontainers for e2e tests (LDAP + OIDC provider integration)
     testImplementation "org.testcontainers:testcontainers:${testContainersVersion}"
     testImplementation "org.testcontainers:testcontainers-junit-jupiter:${testContainersVersion}"
+    testImplementation "org.testcontainers:testcontainers-mongodb:${testContainersVersion}"
 
     // Include core + server coverage in the aggregated JaCoCo report
     jacocoAggregation project(':git-proxy-java-core')

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/GitProxyWithDashboardApplication.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/GitProxyWithDashboardApplication.java
@@ -104,6 +104,7 @@ public class GitProxyWithDashboardApplication {
 
         // Spring MVC DispatcherServlet at /* - git-specific paths take precedence per servlet spec
         var jdbcDataSource = configBuilder.getJdbcDataSourceOrNull();
+        var mongoFactory = configBuilder.getMongoStoreFactoryOrNull();
         registerSpringServlet(
                 context,
                 ctx,
@@ -112,7 +113,8 @@ public class GitProxyWithDashboardApplication {
                 configHolder,
                 liveConfigLoader,
                 urlRuleRegistry,
-                jdbcDataSource);
+                jdbcDataSource,
+                mongoFactory);
 
         server.setHandler(context);
         server.start();
@@ -133,7 +135,8 @@ public class GitProxyWithDashboardApplication {
             ConfigHolder configHolder,
             LiveConfigLoader liveConfigLoader,
             UrlRuleRegistry urlRuleRegistry,
-            javax.sql.DataSource jdbcDataSource) {
+            javax.sql.DataSource jdbcDataSource,
+            org.finos.gitproxy.db.MongoStoreFactory mongoFactory) {
         var appContext = new AnnotationConfigWebApplicationContext();
         appContext.register(SpringWebConfig.class, SecurityConfig.class, SessionStoreConfig.class);
         appContext.addBeanFactoryPostProcessor(bf -> {
@@ -152,6 +155,11 @@ public class GitProxyWithDashboardApplication {
             // when session-store=jdbc. Null for MongoDB deployments (no JDBC DataSource available).
             if (jdbcDataSource != null) {
                 bf.registerSingleton("dataSource", jdbcDataSource);
+            }
+            // Expose the shared MongoClient + database name for session-store=mongo. Null for JDBC deployments.
+            if (mongoFactory != null) {
+                bf.registerSingleton("mongoClient", mongoFactory.getMongoClient());
+                bf.registerSingleton("mongoDatabaseName", mongoFactory.getDatabaseName());
             }
         });
 

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SessionStoreConfig.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SessionStoreConfig.java
@@ -1,13 +1,16 @@
 package org.finos.gitproxy.dashboard;
 
+import com.mongodb.client.MongoClient;
 import jakarta.servlet.Filter;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
+import org.finos.gitproxy.dashboard.session.MongoSessionRepository;
 import org.finos.gitproxy.jetty.config.GitProxyConfig;
 import org.finos.gitproxy.jetty.config.ServerConfig.RedisConfig;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
@@ -31,6 +34,7 @@ import org.springframework.transaction.support.TransactionTemplate;
  *   <li>{@code none} (default) — in-memory {@link MapSessionRepository}; sessions are lost on restart
  *   <li>{@code jdbc} — {@link JdbcIndexedSessionRepository}; persisted to the configured JDBC database
  *   <li>{@code redis} — {@link RedisIndexedSessionRepository}; persisted to Redis/Valkey
+ *   <li>{@code mongo} — {@link MongoSessionRepository}; persisted to the configured MongoDB database
  * </ul>
  *
  * <p>The {@code springSessionRepositoryFilter} bean is always registered so that
@@ -48,6 +52,14 @@ public class SessionStoreConfig {
     @Autowired(required = false)
     private DataSource dataSource;
 
+    /** Injected only for MongoDB deployments — null for JDBC deployments. */
+    @Autowired(required = false)
+    private MongoClient mongoClient;
+
+    @Autowired(required = false)
+    @Qualifier("mongoDatabaseName")
+    private String mongoDatabaseName;
+
     @Bean
     @SuppressWarnings("unchecked")
     public SessionRepository<?> sessionRepository() {
@@ -56,6 +68,7 @@ public class SessionStoreConfig {
         return switch (store) {
             case "jdbc" -> buildJdbc(timeout);
             case "redis" -> buildRedis(timeout);
+            case "mongo" -> buildMongo(timeout);
             default -> {
                 log.info("Session store: in-memory (server.session-store=none). Sessions will not survive restarts.");
                 var repo = new MapSessionRepository(new ConcurrentHashMap<>());
@@ -77,7 +90,7 @@ public class SessionStoreConfig {
         if (dataSource == null) {
             throw new IllegalStateException(
                     "server.session-store=jdbc requires a JDBC database (h2-file, h2-mem, or postgres)."
-                            + " Current database.type is mongo — use session-store: none or provision a JDBC database.");
+                            + " Current database.type is mongo — use session-store: mongo (or none/redis).");
         }
         log.info("Session store: JDBC (server.session-store=jdbc)");
         var jdbcOps = new JdbcTemplate(dataSource);
@@ -117,5 +130,16 @@ public class SessionStoreConfig {
         var repo = new RedisIndexedSessionRepository(template);
         repo.setDefaultMaxInactiveInterval(timeout);
         return repo;
+    }
+
+    // ── MongoDB ───────────────────────────────────────────────────────────────
+
+    private MongoSessionRepository buildMongo(Duration timeout) {
+        if (mongoClient == null || mongoDatabaseName == null) {
+            throw new IllegalStateException("server.session-store=mongo requires database.type=mongo."
+                    + " Current database.type is not mongo — use session-store: jdbc, redis, or none.");
+        }
+        log.info("Session store: MongoDB (server.session-store=mongo)");
+        return new MongoSessionRepository(mongoClient, mongoDatabaseName, timeout);
     }
 }

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/session/MongoSessionRepository.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/session/MongoSessionRepository.java
@@ -1,0 +1,142 @@
+package org.finos.gitproxy.dashboard.session;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.ReplaceOptions;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.bson.Document;
+import org.bson.types.Binary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.session.MapSession;
+import org.springframework.session.SessionRepository;
+
+/**
+ * Spring Session {@link SessionRepository} backed directly by the MongoDB sync driver — no spring-data-mongodb
+ * dependency. Sessions are stored as documents in the {@code proxy_sessions} collection with attributes serialized as
+ * JDK-serialized {@link HashMap} in a BSON {@link Binary} field. A TTL index on {@code expireAt} lets Mongo handle
+ * idle-session cleanup server-side.
+ *
+ * <p>Document shape:
+ *
+ * <pre>{@code
+ * {
+ *   "_id":                "<session-id>",
+ *   "createdAt":          <Date>,
+ *   "lastAccessedAt":     <Date>,
+ *   "maxInactiveSeconds": <long>,
+ *   "expireAt":           <Date>,   // TTL anchor — Mongo deletes when now() > expireAt
+ *   "attributes":         <Binary> // JDK-serialized HashMap<String,Object>
+ * }
+ * }</pre>
+ *
+ * <p>JDK serialization is used because Spring Security's {@code SecurityContextImpl} and all standard
+ * {@code Authentication} tokens are {@link java.io.Serializable}. If a future attribute is not serializable,
+ * {@link #save(MapSession)} will fail fast with an {@link UncheckedIOException}.
+ */
+public class MongoSessionRepository implements SessionRepository<MapSession> {
+
+    private static final Logger log = LoggerFactory.getLogger(MongoSessionRepository.class);
+    private static final String COLLECTION_NAME = "proxy_sessions";
+
+    private final MongoCollection<Document> collection;
+    private final Duration defaultMaxInactiveInterval;
+
+    public MongoSessionRepository(MongoClient mongoClient, String databaseName, Duration defaultMaxInactiveInterval) {
+        MongoDatabase database = mongoClient.getDatabase(databaseName);
+        this.collection = database.getCollection(COLLECTION_NAME);
+        this.defaultMaxInactiveInterval = defaultMaxInactiveInterval;
+        collection.createIndex(Indexes.ascending("expireAt"), new IndexOptions().expireAfter(0L, TimeUnit.SECONDS));
+        log.info(
+                "Mongo session store initialized: db={}, collection={}, default-timeout={}s",
+                databaseName,
+                COLLECTION_NAME,
+                defaultMaxInactiveInterval.getSeconds());
+    }
+
+    @Override
+    public MapSession createSession() {
+        MapSession session = new MapSession();
+        session.setMaxInactiveInterval(defaultMaxInactiveInterval);
+        return session;
+    }
+
+    @Override
+    public void save(MapSession session) {
+        Map<String, Object> attrs = new HashMap<>();
+        for (String name : session.getAttributeNames()) {
+            attrs.put(name, session.getAttribute(name));
+        }
+        Date expireAt = Date.from(session.getLastAccessedTime().plus(session.getMaxInactiveInterval()));
+        Document doc = new Document()
+                .append("_id", session.getId())
+                .append("createdAt", Date.from(session.getCreationTime()))
+                .append("lastAccessedAt", Date.from(session.getLastAccessedTime()))
+                .append("maxInactiveSeconds", session.getMaxInactiveInterval().getSeconds())
+                .append("expireAt", expireAt)
+                .append("attributes", new Binary(serialize(attrs)));
+        collection.replaceOne(Filters.eq("_id", session.getId()), doc, new ReplaceOptions().upsert(true));
+    }
+
+    @Override
+    public MapSession findById(String id) {
+        Document doc = collection.find(Filters.eq("_id", id)).first();
+        if (doc == null) {
+            return null;
+        }
+        MapSession session = new MapSession(id);
+        session.setCreationTime(doc.getDate("createdAt").toInstant());
+        session.setLastAccessedTime(doc.getDate("lastAccessedAt").toInstant());
+        session.setMaxInactiveInterval(Duration.ofSeconds(doc.getLong("maxInactiveSeconds")));
+        Binary attrBlob = doc.get("attributes", Binary.class);
+        if (attrBlob != null) {
+            Map<String, Object> attrs = deserialize(attrBlob.getData());
+            attrs.forEach(session::setAttribute);
+        }
+        if (session.isExpired()) {
+            deleteById(id);
+            return null;
+        }
+        return session;
+    }
+
+    @Override
+    public void deleteById(String id) {
+        collection.deleteOne(Filters.eq("_id", id));
+    }
+
+    private static byte[] serialize(Map<String, Object> attrs) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(new HashMap<>(attrs));
+            oos.flush();
+            return baos.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to serialize session attributes", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> deserialize(byte[] data) {
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(data))) {
+            return (Map<String, Object>) ois.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            throw new UncheckedIOException(
+                    "Failed to deserialize session attributes", e instanceof IOException io ? io : new IOException(e));
+        }
+    }
+}

--- a/git-proxy-java-dashboard/src/test/java/org/finos/gitproxy/dashboard/session/MongoSessionRepositoryIntegrationTest.java
+++ b/git-proxy-java-dashboard/src/test/java/org/finos/gitproxy/dashboard/session/MongoSessionRepositoryIntegrationTest.java
@@ -1,0 +1,102 @@
+package org.finos.gitproxy.dashboard.session;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.*;
+import org.springframework.session.MapSession;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+@Tag("integration")
+class MongoSessionRepositoryIntegrationTest {
+
+    @Container
+    static final MongoDBContainer MONGO = new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
+
+    private MongoClient client;
+    private MongoSessionRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        client = MongoClients.create(MONGO.getConnectionString());
+        String db = "sessions_" + UUID.randomUUID().toString().replace("-", "");
+        repo = new MongoSessionRepository(client, db, Duration.ofMinutes(30));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (client != null) client.close();
+    }
+
+    @Test
+    void createSession_hasConfiguredTimeout() {
+        MapSession s = repo.createSession();
+        assertEquals(Duration.ofMinutes(30), s.getMaxInactiveInterval());
+    }
+
+    @Test
+    void save_then_findById_roundTripsAttributes() {
+        MapSession s = repo.createSession();
+        s.setAttribute("username", "alice");
+        s.setAttribute("role-count", 3);
+        repo.save(s);
+
+        MapSession loaded = repo.findById(s.getId());
+        assertNotNull(loaded);
+        assertEquals(s.getId(), loaded.getId());
+        assertEquals("alice", loaded.getAttribute("username"));
+        assertEquals(Integer.valueOf(3), loaded.getAttribute("role-count"));
+    }
+
+    @Test
+    void findById_unknownId_returnsNull() {
+        assertNull(repo.findById("does-not-exist"));
+    }
+
+    @Test
+    void deleteById_removesSession() {
+        MapSession s = repo.createSession();
+        s.setAttribute("k", "v");
+        repo.save(s);
+        assertNotNull(repo.findById(s.getId()));
+
+        repo.deleteById(s.getId());
+        assertNull(repo.findById(s.getId()));
+    }
+
+    @Test
+    void findById_expiredSession_returnsNullAndDeletes() {
+        MapSession s = repo.createSession();
+        s.setMaxInactiveInterval(Duration.ofSeconds(1));
+        s.setLastAccessedTime(Instant.now().minusSeconds(60));
+        s.setAttribute("k", "v");
+        repo.save(s);
+
+        assertNull(repo.findById(s.getId()), "expired session must return null");
+        // Confirm it was also removed from the collection (not just filtered in-memory).
+        // A second lookup would otherwise still find the raw document.
+        assertNull(repo.findById(s.getId()));
+    }
+
+    @Test
+    void save_updatesExistingSession() {
+        MapSession s = repo.createSession();
+        s.setAttribute("v", 1);
+        repo.save(s);
+
+        s.setAttribute("v", 2);
+        repo.save(s);
+
+        MapSession loaded = repo.findById(s.getId());
+        assertNotNull(loaded);
+        assertEquals(Integer.valueOf(2), loaded.getAttribute("v"));
+    }
+}

--- a/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/JettyConfigurationBuilder.java
+++ b/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/JettyConfigurationBuilder.java
@@ -782,6 +782,16 @@ public class JettyConfigurationBuilder {
         return requireJdbcDataSource();
     }
 
+    /**
+     * Returns the shared {@link MongoStoreFactory} if {@code database.type=mongo}, else {@code null}. Callers that need
+     * a {@link com.mongodb.client.MongoClient} (e.g. the dashboard's session store wiring) should go through this
+     * accessor so the underlying connection pool is reused across stores.
+     */
+    public MongoStoreFactory getMongoStoreFactoryOrNull() {
+        if (!"mongo".equals(config.getDatabase().getType())) return null;
+        return requireMongoStoreFactory();
+    }
+
     private DataSource requireJdbcDataSource() {
         if (cachedDataSource == null) {
             DatabaseConfig db = config.getDatabase();


### PR DESCRIPTION
## Summary

- Add `MongoSessionRepository` — a Spring Session `SessionRepository` backed directly by the raw mongo-java-driver (no `spring-data-mongodb` dep). Attributes are JDK-serialized into a BSON `Binary`; a TTL index on `expireAt` delegates idle-session cleanup to MongoDB. Wired via `SessionStoreConfig` under `server.session-store=mongo`, reusing the shared `MongoClient` from `MongoStoreFactory` so the connection pool is not duplicated.
- Rename the two MongoDB collections that collided with upstream finos/git-proxy: `users` → `proxy_users`, `pushes` → `proxy_pushes`. The other three collections (`repo_permissions`, `access_rules`, `fetch_records`) already had distinct names. From 1.0.0 onward these names are part of the stability contract.
- Update docs: `CONFIGURATION.md` gains a Mongo session-store example and a new "coexisting with upstream" subsection that recommends a dedicated database while explaining the rename makes shared-database deployments no longer a correctness hazard.
- Fix compose overlays: add `GITPROXY_SERVER_SESSION_STORE` to `docker-compose.mongo.yml` and `docker-compose.postgres.yml` so the session store actually engages (the previous `GITPROXY_SESSION_STORE` was missing the `SERVER_` segment and was a no-op).

Closes #138
Closes #139

## Test plan

- [x] `./gradlew :git-proxy-java-core:test :git-proxy-java-dashboard:test` — full suites pass, including the new `MongoSessionRepositoryIntegrationTest` (6 cases: createSession, save/load round-trip, unknown id, delete, expired-session cleanup, save-updates-existing) running against a real Mongo 7.0 Testcontainer
- [x] Manual end-to-end via `./compose.sh ... --profile mongo` with `session-store: mongo`: logged in, stopped and restarted the `git-proxy-java` container, re-opened the dashboard and remained authenticated
- [x] Verified via Mongo Express that session documents land in `proxy_sessions` with the expected shape (JDK-serialized attribute blob, 86400s default timeout, `expireAt` index with `expireAfterSeconds: 0`)