### PR TITLE
chore: bump version to 1.0.0-rc.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,14 @@ Gradle itself is included via the wrapper — no separate installation needed.
 
 Formatting is enforced in CI. Always run `spotlessApply` before pushing.
 
+When working on Java-only changes in the dashboard module, pass `-PskipFrontend` to skip the
+Node/npm frontend build steps (requires Node to be available otherwise):
+
+```shell
+./gradlew :git-proxy-java-dashboard:compileJava -PskipFrontend
+./gradlew :git-proxy-java-dashboard:build -PskipFrontend
+```
+
 ## Running the server locally
 
 ### Proxy only (no dashboard)

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ ext {
 
 allprojects {
     group = 'org.finos.gitproxy'
-    version = '1.0.0-beta.4'
+    version = '1.0.0-rc.1'
     
     repositories {
         mavenCentral()


### PR DESCRIPTION
## Summary

- Bumps version from `1.0.0-beta.4` to `1.0.0-rc.1`
- Documents `-PskipFrontend` flag in CONTRIBUTING.md for Java-only dashboard development

## Test plan

- [ ] CI passes
- [ ] `version.properties` in the dashboard JAR reflects `1.0.0-rc.1`