### PR TITLE
fix: ForwardedHeaderFilter for OIDC behind TLS ingress, gitleaks URL override, graceful SIGTERM shutdown

### DIFF
--- a/git-proxy-java-core/build.gradle
+++ b/git-proxy-java-core/build.gradle
@@ -249,7 +249,11 @@ tasks.register('downloadGitleaks') {
         out.parentFile.mkdirs()
 
         def tarName = "gitleaks_${gitleaksVersion}_${gitleaksTarSuffix}.tar.gz"
-        def tarUrl  = "https://github.com/gitleaks/gitleaks/releases/download/v${gitleaksVersion}/${tarName}"
+        def gitleaksDownloadUrl = 'https://github.com/gitleaks/gitleaks/releases/download'
+        if (System.getenv('GITLEAKS_DOWNLOAD_URL')) {
+            gitleaksDownloadUrl = System.getenv('GITLEAKS_DOWNLOAD_URL')
+        }
+        def tarUrl  = "${gitleaksDownloadUrl}/v${gitleaksVersion}/${tarName}"
         def tmpDir  = layout.buildDirectory.dir("tmp/gitleaks").get().asFile
         tmpDir.mkdirs()
         def tarFile = new File(tmpDir, tarName)

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/validation/BlockedContentDiffCheck.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/validation/BlockedContentDiffCheck.java
@@ -52,7 +52,7 @@ public class BlockedContentDiffCheck implements DiffCheck {
             for (Pattern pattern : block.getPatterns()) {
                 if (pattern.matcher(content).find()) {
                     String location = currentFile != null ? " in " + currentFile : "";
-                    violations.add("blocked pattern: " + pattern.pattern() + location);
+                    violations.add("blocked pattern match" + location);
                 }
             }
         }

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/validation/BlockedContentDiffCheck.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/validation/BlockedContentDiffCheck.java
@@ -52,7 +52,7 @@ public class BlockedContentDiffCheck implements DiffCheck {
             for (Pattern pattern : block.getPatterns()) {
                 if (pattern.matcher(content).find()) {
                     String location = currentFile != null ? " in " + currentFile : "";
-                    violations.add("blocked pattern match" + location);
+                    violations.add("blocked pattern: " + pattern.pattern() + location);
                 }
             }
         }

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/GitProxyWithDashboardApplication.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/GitProxyWithDashboardApplication.java
@@ -29,6 +29,7 @@ import org.finos.gitproxy.provider.ProviderRegistry;
 import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 import org.springframework.web.filter.DelegatingFilterProxy;
+import org.springframework.web.filter.ForwardedHeaderFilter;
 import org.springframework.web.servlet.DispatcherServlet;
 
 /**
@@ -185,6 +186,15 @@ public class GitProxyWithDashboardApplication {
         var holder = new ServletHolder("spring-dispatcher", dispatcher);
         holder.setInitOrder(1);
         context.addServlet(holder, "/*");
+
+        // ForwardedHeaderFilter — must be registered first so that X-Forwarded-Proto/Host/Port
+        // headers from TLS-terminating ingress (OCP Route, nginx, etc.) are resolved before any
+        // downstream filter builds absolute URLs (e.g. OAuth2 redirect URIs in Spring Security).
+        var forwardedHeaderFilter = new FilterHolder(new ForwardedHeaderFilter());
+        forwardedHeaderFilter.setAsyncSupported(true);
+        for (String path : new String[] {"/api/*", "/login", "/logout", "/", "/oauth2/*", "/login/oauth2/*"}) {
+            context.addFilter(forwardedHeaderFilter, path, EnumSet.of(DispatcherType.REQUEST, DispatcherType.ERROR));
+        }
 
         // Spring Session filter — must be registered before Spring Security so that the distributed
         // session store is in place before Security reads authentication state from the session.

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/GitProxyWithDashboardApplication.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/GitProxyWithDashboardApplication.java
@@ -62,6 +62,11 @@ public class GitProxyWithDashboardApplication {
         connector.setPort(configBuilder.getServerPort());
         server.addConnector(connector);
 
+        // Graceful shutdown: drain in-flight requests for up to 30s on SIGTERM before the JVM exits.
+        // Without this, rolling deploys on Kubernetes/OCP hard-kill active git push/proxy streams.
+        server.setStopTimeout(30_000);
+        server.setStopAtShutdown(true);
+
         var tls = configBuilder.getTlsConfig();
         if (tls.isServerTlsConfigured()) {
             server.addConnector(GitProxyJettyApplication.buildHttpsConnector(server, tls));

--- a/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/GitProxyJettyApplication.java
+++ b/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/GitProxyJettyApplication.java
@@ -53,6 +53,11 @@ public class GitProxyJettyApplication {
         connector.setPort(configBuilder.getServerPort());
         server.addConnector(connector);
 
+        // Graceful shutdown: drain in-flight requests for up to 30s on SIGTERM before the JVM exits.
+        // Without this, rolling deploys on Kubernetes/OCP hard-kill active git push/proxy streams.
+        server.setStopTimeout(30_000);
+        server.setStopAtShutdown(true);
+
         TlsConfig tls = configBuilder.getTlsConfig();
         if (tls.isServerTlsConfigured()) {
             server.addConnector(buildHttpsConnector(server, tls));


### PR DESCRIPTION
## Summary

- **ForwardedHeaderFilter** — register Spring's `ForwardedHeaderFilter` as the first filter in `GitProxyWithDashboardApplication`, ahead of Spring Session and Security. Fixes OAuth2 redirect URIs being built with `http://` when running behind a TLS-terminating ingress (OCP Route, nginx), causing Entra ID to reject the authorization request for non-localhost origins.
- **Gitleaks download URL override** — `build.gradle` now reads `GITLEAKS_DOWNLOAD_URL` env var, allowing air-gapped/restricted CI environments to redirect the binary download to a corporate artifact mirror (e.g. Artifactory) without modifying the build script.
- **Graceful SIGTERM shutdown** — both `GitProxyJettyApplication` and `GitProxyWithDashboardApplication` now configure `setStopAtShutdown(true)` and `setStopTimeout(30_000)`. Prevents in-flight git pushes from being torn down mid-transfer during Kubernetes rolling deploys or pod eviction.

## Test plan

- [ ] Deploy behind TLS-terminating ingress and confirm OIDC login redirects use `https://`
- [ ] Set `GITLEAKS_DOWNLOAD_URL` to a mirror URL and confirm `./gradlew build` fetches from it
- [ ] Send SIGTERM mid-push and confirm the connection drains gracefully rather than being forcibly closed