### PR TITLE
chore: supply chain hardening (CODEOWNERS, Dependabot, Renovate, Scorecard fixes)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @coopernetes

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: CI / Build & Test
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -37,10 +37,6 @@ jobs:
       - name: Verify coverage thresholds
         run: ./gradlew jacocoTestCoverageVerification
 
-      - name: Submit dependency graph
-        if: github.event_name == 'push'
-        uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # ratchet:gradle/actions/dependency-submission@v6
-
       - name: Publish test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
@@ -56,6 +52,25 @@ jobs:
           name: jacoco-reports
           path: "**/build/reports/jacoco/"
           retention-days: 14
+
+  dependency-submission:
+    name: CI / Dependency Submission
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+
+      - name: Submit dependency graph
+        uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # ratchet:gradle/actions/dependency-submission@v6
 
   e2e-test:
     name: CI / E2E Test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,7 @@
 name: "CodeQL"
 
+permissions: read-all
+
 on:
   push:
     branches: ["main"]

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -11,7 +11,7 @@ on:
         required: true
         type: string
   schedule:
-    - cron: '0 6 * * 1'  # weekly Monday 06:00 UTC
+    - cron: '0 6 * * 1' # weekly Monday 06:00 UTC
 
 jobs:
   grype:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM docker.io/eclipse-temurin:21-jdk AS builder
+FROM docker.io/eclipse-temurin:21-jdk@sha256:06a4f4be86d459307036eb97c55a24686bd1312fe88c152723c915b7b2e6a8b4 AS builder
 
 # Install Node.js directly from the official distribution with SHA256 verification.
 # To update: download the new tarball, verify against nodejs.org/dist/vX.Y.Z/SHASUMS256.txt,
@@ -47,7 +47,7 @@ RUN sed -i \
     git-proxy-java-dashboard/build/install/git-proxy-java-dashboard/bin/git-proxy-java-dashboard
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM docker.io/eclipse-temurin:21-jre
+FROM docker.io/eclipse-temurin:21-jre@sha256:137163a1850fd2088d94ecd8420358d83086bd287d3c4f6f14b7d09786490c4d
 
 WORKDIR /app
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["dockerfile", "gradle", "gradle-wrapper", "npm"],
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchFileNames": ["git-proxy-java-dashboard/frontend/package.json"],
+      "labels": ["dependencies", "frontend"]
+    },
+    {
+      "matchManagers": ["gradle", "gradle-wrapper"],
+      "labels": ["dependencies", "java"]
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "labels": ["dependencies", "docker"],
+      "pinDigests": true
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["patch", "minor"]
+    }
+  ],
+  "schedule": ["before 6am on monday"]
+}


### PR DESCRIPTION
## Summary

Closes out several actionable OpenSSF Scorecard alerts:

- **CODEOWNERS** — satisfies the Code-Review check
- **dependabot.yml** — scoped to `github-actions` only; satisfies the Dependency-Update-Tool check
- **renovate.json** — covers `gradle`, `gradle-wrapper`, `npm`, and `dockerfile` managers; `pinDigests: true` keeps Dockerfile base image digests updated automatically
- **Pinned-Dependencies** — pin `eclipse-temurin:21-jdk` and `:21-jre` to SHA256 manifest list digests (safe for multi-arch `linux/amd64` + `linux/arm64` builds)
- **Token-Permissions (codeql.yml)** — add `permissions: read-all` at workflow level
- **Token-Permissions (ci.yml)** — split `dependency-submission` into its own job so `build-and-test` drops from `contents: write` to `contents: read`

## Notes

After merging, install the [Renovate GitHub App](https://github.com/apps/renovate) on this repo to activate dependency update PRs.

Remaining Scorecard alerts not addressed here (out of scope for code changes):
- Branch-Protection — repo settings
- Binary-Artifacts (gradle-wrapper.jar) — industry standard, removing breaks builds
- Fuzzing — needs a full fuzz harness
- CII-Best-Practices — manual application at bestpractices.coreinfrastructure.org