### PR TITLE
fix: compile test sources in CodeQL build to increase Java scan coverage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Build Java
         if: matrix.language == 'java-kotlin'
-        run: ./gradlew build -x test -x e2eTest --no-build-cache
+        run: ./gradlew classes testClasses --no-build-cache
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # ratchet:github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

CodeQL was only scanning 213/316 Java files (67%) because `-x test` in the Gradle build command also skips `compileTestJava`, leaving all test sources untraced.

Switching to `classes testClasses` compiles all main and test sources across every module without running tests, targeting 100% file coverage.

## Before / After

| | Files scanned |
|---|---|
| Before | 213/316 (67%) |
| After | 316/316 (expected) |