### PR TITLE
fix(oidc): unified discovery + optional endpoint overrides

### DIFF
--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SecurityConfig.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SecurityConfig.java
@@ -69,7 +69,6 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.registration.ClientRegistrations;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizedClientRepository;
-import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -372,45 +371,23 @@ public class SecurityConfig {
                 ? ClientAuthenticationMethod.PRIVATE_KEY_JWT
                 : ClientAuthenticationMethod.CLIENT_SECRET_BASIC;
 
-        ClientRegistration registration;
-        if (!oidcCfg.getJwkSetUri().isBlank()) {
-            // Manual registration: skip OIDC discovery and issuer validation. Used when the provider's
-            // reported issuer URL does not match the URL used to reach it (e.g. Entra ID, whose tokens
-            // carry iss=https://sts.windows.net/{tenant}/ rather than the discovery base URL).
-            // Endpoint paths follow the standard OIDC convention relative to issuerUri.
-            var builder = ClientRegistration.withRegistrationId("gitproxy")
-                    .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                    .clientId(oidcCfg.getClientId())
-                    .authorizationUri(oidcCfg.getIssuerUri() + "/authorize")
-                    .tokenUri(
-                            oidcCfg.getTokenUri().isBlank() ? oidcCfg.getIssuerUri() + "/token" : oidcCfg.getTokenUri())
-                    .jwkSetUri(oidcCfg.getJwkSetUri())
-                    .userInfoUri(
-                            oidcCfg.getUserInfoUri().isBlank()
-                                    ? oidcCfg.getIssuerUri() + "/userinfo"
-                                    : oidcCfg.getUserInfoUri())
-                    .userNameAttributeName(oidcCfg.getUserNameAttribute())
-                    .scope("openid", "profile", "email")
-                    .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
-                    .clientAuthenticationMethod(authMethod);
-            if (!usePrivateKeyJwt) {
-                builder.clientSecret(oidcCfg.getClientSecret());
-            }
-            registration = builder.build();
-        } else {
-            // Standard path: fetch OIDC discovery document at startup. The OIDC server must be reachable
-            // when the Spring context initializes (in Docker Compose this is guaranteed via depends_on).
-            var builder = ClientRegistrations.fromIssuerLocation(oidcCfg.getIssuerUri())
-                    .registrationId("gitproxy")
-                    .clientId(oidcCfg.getClientId())
-                    .scope("openid", "profile", "email")
-                    .userNameAttributeName(oidcCfg.getUserNameAttribute())
-                    .clientAuthenticationMethod(authMethod);
-            if (!usePrivateKeyJwt) {
-                builder.clientSecret(oidcCfg.getClientSecret());
-            }
-            registration = builder.build();
-        }
+        // Fetch OIDC discovery document at startup, then apply any explicit overrides on top.
+        // The OIDC server must be reachable when the Spring context initializes.
+        // Override properties (authorization-uri, token-uri, user-info-uri, jwk-set-uri) are optional:
+        // leave them blank to accept whatever the discovery document advertises.
+        var builder = ClientRegistrations.fromIssuerLocation(oidcCfg.getIssuerUri())
+                .registrationId("gitproxy")
+                .clientId(oidcCfg.getClientId())
+                .scope("openid", "profile", "email")
+                .userNameAttributeName(oidcCfg.getUserNameAttribute())
+                .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                .clientAuthenticationMethod(authMethod);
+        if (!oidcCfg.getAuthorizationUri().isBlank()) builder.authorizationUri(oidcCfg.getAuthorizationUri());
+        if (!oidcCfg.getTokenUri().isBlank()) builder.tokenUri(oidcCfg.getTokenUri());
+        if (!oidcCfg.getUserInfoUri().isBlank()) builder.userInfoUri(oidcCfg.getUserInfoUri());
+        if (!oidcCfg.getJwkSetUri().isBlank()) builder.jwkSetUri(oidcCfg.getJwkSetUri());
+        if (!usePrivateKeyJwt) builder.clientSecret(oidcCfg.getClientSecret());
+        ClientRegistration registration = builder.build();
 
         http.oauth2Login(oauth2 -> {
                     oauth2.clientRegistrationRepository(new InMemoryClientRegistrationRepository(registration))

--- a/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/OidcAuthConfig.java
+++ b/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/OidcAuthConfig.java
@@ -39,7 +39,14 @@ public class OidcAuthConfig {
     private String jwkSetUri = "";
 
     /**
-     * Override for the token endpoint URL. When blank, defaults to {@code {issuerUri}/token}. Useful in local
+     * Override for the authorization endpoint URL. When blank, the value from OIDC discovery is used. Rarely needed —
+     * only set this when the provider's discovery document points to an endpoint that is unreachable from the client's
+     * browser (e.g. an internal hostname that is only routable inside the cluster).
+     */
+    private String authorizationUri = "";
+
+    /**
+     * Override for the token endpoint URL. When blank, the value from OIDC discovery is used. Useful in local
      * development when the server-side token exchange must reach the OIDC provider via a different hostname than the
      * browser-facing authorization URL (e.g. Podman injects the host {@code /etc/hosts} into containers, so
      * {@code host.containers.internal} can be used to reach a port-mapped provider from inside a container).
@@ -47,8 +54,13 @@ public class OidcAuthConfig {
     private String tokenUri = "";
 
     /**
-     * Override for the UserInfo endpoint URL. When blank, defaults to {@code {issuerUri}/userinfo}. See
-     * {@code token-uri} for when this override is needed.
+     * Override for the UserInfo endpoint URL. When blank, the value from OIDC discovery is used.
+     *
+     * <p><b>Required for Entra ID</b> — OIDC discovery for Entra points to {@code graph.microsoft.com/oidc/userinfo},
+     * which does not return {@code preferred_username}. Set this to
+     * {@code https://login.microsoftonline.com/{tenant}/v2.0/userinfo} to get the full claim set.
+     *
+     * <p>Example: {@code https://login.microsoftonline.com/{tenant}/v2.0/userinfo}
      */
     private String userInfoUri = "";
 


### PR DESCRIPTION
## Summary

- Replaces the `if jwk-set-uri / else` dual-path `ClientRegistration` logic in `SecurityConfig` with a single path: always run OIDC discovery via `ClientRegistrations.fromIssuerLocation()`, then apply any non-blank override properties (`authorization-uri`, `token-uri`, `user-info-uri`, `jwk-set-uri`) on top
- Adds `authorizationUri` to `OidcAuthConfig` to complete the set of overridable endpoint properties
- Updates `userInfoUri` javadoc to document the Entra ID Graph endpoint problem: OIDC discovery for Entra points to `graph.microsoft.com/oidc/userinfo` which omits `preferred_username`; fix is to set `user-info-uri` to `https://login.microsoftonline.com/{tenant}/v2.0/userinfo`

## Motivation

The manual path was originally added to work around Entra ID v1.0 issuer mismatches (`iss=https://sts.windows.net/{tenant}/`), but it hardcoded endpoint URLs as `{issuerUri}/authorize`, `{issuerUri}/token`, `{issuerUri}/userinfo` — which are wrong for Entra and any provider with non-standard paths. With Entra ID v2.0 (`/{tenant}/v2.0` issuer), the discovery document's issuer field matches the configured `issuer-uri`, so `ClientRegistrations.fromIssuerLocation()` works directly and the manual bypass is no longer needed.

## Test plan

- [ ] Local OIDC provider (mock or Keycloak) login flow succeeds with no overrides set
- [ ] Entra ID login succeeds with `user-info-uri` override set to `https://login.microsoftonline.com/{tenant}/v2.0/userinfo` and `user-name-attribute: preferred_username`
- [ ] `preferred_username` is populated in the authenticated principal
- [ ] Group-based role mapping works with `groups-claim: groups`

🤖 Generated with [Claude Code](https://claude.com/claude-code)