### PR TITLE
fix(oidc): skip UserInfo endpoint call for Entra ID compatibility

### DIFF
--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SecurityConfig.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SecurityConfig.java
@@ -394,8 +394,8 @@ public class SecurityConfig {
                             .authorizedClientRepository(new HttpSessionOAuth2AuthorizedClientRepository())
                             .successHandler(successHandler)
                             .failureUrl("/login.html?error")
-                            .userInfoEndpoint(userInfo ->
-                                    userInfo.oidcUserService(buildOidcUserService(roleMappings, groupsClaim, oidcCfg.isSkipUserInfo())));
+                            .userInfoEndpoint(userInfo -> userInfo.oidcUserService(
+                                    buildOidcUserService(roleMappings, groupsClaim, oidcCfg.isSkipUserInfo())));
 
                     if (usePrivateKeyJwt) {
                         RSAKey rsaKey =

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SecurityConfig.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SecurityConfig.java
@@ -395,7 +395,7 @@ public class SecurityConfig {
                             .successHandler(successHandler)
                             .failureUrl("/login.html?error")
                             .userInfoEndpoint(userInfo ->
-                                    userInfo.oidcUserService(buildOidcUserService(roleMappings, groupsClaim)));
+                                    userInfo.oidcUserService(buildOidcUserService(roleMappings, groupsClaim, oidcCfg.isSkipUserInfo())));
 
                     if (usePrivateKeyJwt) {
                         RSAKey rsaKey =
@@ -501,7 +501,8 @@ public class SecurityConfig {
      * {@code roleMappings} is non-empty, access is <em>deny-by-default</em>: the user must belong to at least one
      * mapped group, otherwise authentication is rejected.
      */
-    private OidcUserService buildOidcUserService(Map<String, List<String>> roleMappings, String groupsClaim) {
+    private OidcUserService buildOidcUserService(
+            Map<String, List<String>> roleMappings, String groupsClaim, boolean skipUserInfo) {
         OidcUserService service = new OidcUserService() {
             @Override
             public OidcUser loadUser(OidcUserRequest userRequest) {
@@ -539,10 +540,13 @@ public class SecurityConfig {
                         authorities, oidcUser.getIdToken(), oidcUser.getUserInfo(), nameAttributeKey);
             }
         };
-        // graph.microsoft.com/oidc/userinfo (Entra's discovered UserInfo endpoint) returns 200 but
-        // omits preferred_username, causing DefaultOAuth2UserService to throw before the ID token
-        // merge. All required claims are present in the Entra v2.0 ID token with the profile scope.
-        service.setRetrieveUserInfo(req -> false);
+        if (skipUserInfo) {
+            // skip-user-info=true: all claims are read from the ID token; the UserInfo endpoint is
+            // never contacted. Required for Entra ID — graph.microsoft.com/oidc/userinfo returns 200
+            // but omits preferred_username, causing DefaultOAuth2UserService to throw before the ID
+            // token merge. All required claims are present in the Entra v2.0 ID token with profile scope.
+            service.setRetrieveUserInfo(req -> false);
+        }
         return service;
     }
 

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SecurityConfig.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SecurityConfig.java
@@ -502,7 +502,7 @@ public class SecurityConfig {
      * mapped group, otherwise authentication is rejected.
      */
     private OidcUserService buildOidcUserService(Map<String, List<String>> roleMappings, String groupsClaim) {
-        return new OidcUserService() {
+        OidcUserService service = new OidcUserService() {
             @Override
             public OidcUser loadUser(OidcUserRequest userRequest) {
                 OidcUser oidcUser = super.loadUser(userRequest);
@@ -539,6 +539,11 @@ public class SecurityConfig {
                         authorities, oidcUser.getIdToken(), oidcUser.getUserInfo(), nameAttributeKey);
             }
         };
+        // graph.microsoft.com/oidc/userinfo (Entra's discovered UserInfo endpoint) returns 200 but
+        // omits preferred_username, causing DefaultOAuth2UserService to throw before the ID token
+        // merge. All required claims are present in the Entra v2.0 ID token with the profile scope.
+        service.setRetrieveUserInfo(req -> false);
+        return service;
     }
 
     /**

--- a/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/OidcAuthConfig.java
+++ b/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/OidcAuthConfig.java
@@ -54,8 +54,8 @@ public class OidcAuthConfig {
     private String tokenUri = "";
 
     /**
-     * Override for the UserInfo endpoint URL. When blank, the value from OIDC discovery is used. Rarely needed —
-     * only set this when the provider's discovered UserInfo endpoint is unreachable or must be substituted.
+     * Override for the UserInfo endpoint URL. When blank, the value from OIDC discovery is used. Rarely needed — only
+     * set this when the provider's discovered UserInfo endpoint is unreachable or must be substituted.
      *
      * <p>For Entra ID, prefer setting {@code skip-user-info: true} instead of overriding this URL.
      */
@@ -109,10 +109,11 @@ public class OidcAuthConfig {
      * Skip the UserInfo endpoint call entirely. When {@code true}, all claims are read from the ID token and the
      * UserInfo endpoint is never contacted.
      *
-     * <p><b>Required for Entra ID</b> — Entra's discovered UserInfo endpoint ({@code graph.microsoft.com/oidc/userinfo})
-     * returns HTTP 200 but omits {@code preferred_username}. This is a Microsoft design constraint present on all Entra
-     * tenants; it is not a tenant configuration issue. With the {@code profile} scope, the Entra v2.0 ID token contains
-     * all required claims ({@code preferred_username}, {@code groups}, {@code email}).
+     * <p><b>Required for Entra ID</b> — Entra's discovered UserInfo endpoint
+     * ({@code graph.microsoft.com/oidc/userinfo}) returns HTTP 200 but omits {@code preferred_username}. This is a
+     * Microsoft design constraint present on all Entra tenants; it is not a tenant configuration issue. With the
+     * {@code profile} scope, the Entra v2.0 ID token contains all required claims ({@code preferred_username},
+     * {@code groups}, {@code email}).
      *
      * <p>Set to {@code false} (the default) for standard OIDC providers (Keycloak, Okta, Dex) that return all required
      * claims from their UserInfo endpoints.

--- a/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/OidcAuthConfig.java
+++ b/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/OidcAuthConfig.java
@@ -54,13 +54,10 @@ public class OidcAuthConfig {
     private String tokenUri = "";
 
     /**
-     * Override for the UserInfo endpoint URL. When blank, the value from OIDC discovery is used.
+     * Override for the UserInfo endpoint URL. When blank, the value from OIDC discovery is used. Rarely needed —
+     * only set this when the provider's discovered UserInfo endpoint is unreachable or must be substituted.
      *
-     * <p><b>Required for Entra ID</b> — OIDC discovery for Entra points to {@code graph.microsoft.com/oidc/userinfo},
-     * which does not return {@code preferred_username}. Set this to
-     * {@code https://login.microsoftonline.com/{tenant}/v2.0/userinfo} to get the full claim set.
-     *
-     * <p>Example: {@code https://login.microsoftonline.com/{tenant}/v2.0/userinfo}
+     * <p>For Entra ID, prefer setting {@code skip-user-info: true} instead of overriding this URL.
      */
     private String userInfoUri = "";
 
@@ -107,6 +104,20 @@ public class OidcAuthConfig {
      * <p>Example: {@code /run/secrets/gitproxy-oidc-cert.pem}
      */
     private String certPath = "";
+
+    /**
+     * Skip the UserInfo endpoint call entirely. When {@code true}, all claims are read from the ID token and the
+     * UserInfo endpoint is never contacted.
+     *
+     * <p><b>Required for Entra ID</b> — Entra's discovered UserInfo endpoint ({@code graph.microsoft.com/oidc/userinfo})
+     * returns HTTP 200 but omits {@code preferred_username}. This is a Microsoft design constraint present on all Entra
+     * tenants; it is not a tenant configuration issue. With the {@code profile} scope, the Entra v2.0 ID token contains
+     * all required claims ({@code preferred_username}, {@code groups}, {@code email}).
+     *
+     * <p>Set to {@code false} (the default) for standard OIDC providers (Keycloak, Okta, Dex) that return all required
+     * claims from their UserInfo endpoints.
+     */
+    private boolean skipUserInfo = false;
 
     /**
      * Explicit {@code kid} (key ID) to include in the {@code private_key_jwt} assertion header. Use this when the IdP


### PR DESCRIPTION
## Summary

- Entra's discovered UserInfo endpoint (`graph.microsoft.com/oidc/userinfo`) returns HTTP 200 but omits `preferred_username`, causing `DefaultOAuth2UserService` to throw before ID token claims are merged
- Fixes the `preferred_username cannot be null` 500 error on OIDC callback
- All required claims (`preferred_username`, `groups`) are present in the Entra v2.0 ID token with the `profile` scope — skip the UserInfo call entirely via `setRetrieveUserInfo(req -> false)`

## Test plan

- [x] Confirmed working end-to-end locally against Entra tenant with `private_key_jwt` client auth
- [x] Verify `preferred_username` and `groups` claims are populated from ID token
- [x] Verify role mapping via `groups` claim still works (ROLE_ADMIN granted via group membership)

🤖 Generated with [Claude Code](https://claude.com/claude-code)