### PR TITLE
fix: move per-request credentials from shared Repository config to PushContext

### DIFF
--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/ApprovalPreReceiveHook.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/ApprovalPreReceiveHook.java
@@ -45,13 +45,14 @@ public class ApprovalPreReceiveHook implements PreReceiveHook {
     private final Duration timeout;
     private final String serviceUrl;
     private final RepoPermissionService repoPermissionService;
+    private final PushContext pushContext;
 
     public ApprovalPreReceiveHook(PushStore pushStore, ApprovalGateway approvalGateway) {
-        this(pushStore, approvalGateway, DEFAULT_TIMEOUT, null, null);
+        this(pushStore, approvalGateway, DEFAULT_TIMEOUT, null, null, null);
     }
 
     public ApprovalPreReceiveHook(PushStore pushStore, ApprovalGateway approvalGateway, String serviceUrl) {
-        this(pushStore, approvalGateway, DEFAULT_TIMEOUT, serviceUrl, null);
+        this(pushStore, approvalGateway, DEFAULT_TIMEOUT, serviceUrl, null, null);
     }
 
     public ApprovalPreReceiveHook(
@@ -59,16 +60,25 @@ public class ApprovalPreReceiveHook implements PreReceiveHook {
             ApprovalGateway approvalGateway,
             String serviceUrl,
             RepoPermissionService repoPermissionService) {
-        this(pushStore, approvalGateway, DEFAULT_TIMEOUT, serviceUrl, repoPermissionService);
+        this(pushStore, approvalGateway, DEFAULT_TIMEOUT, serviceUrl, repoPermissionService, null);
+    }
+
+    public ApprovalPreReceiveHook(
+            PushStore pushStore,
+            ApprovalGateway approvalGateway,
+            String serviceUrl,
+            RepoPermissionService repoPermissionService,
+            PushContext pushContext) {
+        this(pushStore, approvalGateway, DEFAULT_TIMEOUT, serviceUrl, repoPermissionService, pushContext);
     }
 
     public ApprovalPreReceiveHook(PushStore pushStore, ApprovalGateway approvalGateway, Duration timeout) {
-        this(pushStore, approvalGateway, timeout, null, null);
+        this(pushStore, approvalGateway, timeout, null, null, null);
     }
 
     public ApprovalPreReceiveHook(
             PushStore pushStore, ApprovalGateway approvalGateway, Duration timeout, String serviceUrl) {
-        this(pushStore, approvalGateway, timeout, serviceUrl, null);
+        this(pushStore, approvalGateway, timeout, serviceUrl, null, null);
     }
 
     public ApprovalPreReceiveHook(
@@ -77,21 +87,31 @@ public class ApprovalPreReceiveHook implements PreReceiveHook {
             Duration timeout,
             String serviceUrl,
             RepoPermissionService repoPermissionService) {
+        this(pushStore, approvalGateway, timeout, serviceUrl, repoPermissionService, null);
+    }
+
+    public ApprovalPreReceiveHook(
+            PushStore pushStore,
+            ApprovalGateway approvalGateway,
+            Duration timeout,
+            String serviceUrl,
+            RepoPermissionService repoPermissionService,
+            PushContext pushContext) {
         this.pushStore = pushStore;
         this.approvalGateway = approvalGateway;
         this.timeout = timeout;
         this.serviceUrl = serviceUrl;
         this.repoPermissionService = repoPermissionService;
+        this.pushContext = pushContext;
     }
 
     @Override
     public void onPreReceive(ReceivePack rp, Collection<ReceiveCommand> commands) {
         OutputStream msgOut = rp.getMessageOutputStream();
 
-        // Read the validation record ID stored by PushStorePersistenceHook.validationResultHook
-        String validationRecordId = rp.getRepository().getConfig().getString("gitproxy", null, "validationRecordId");
+        String validationRecordId = pushContext != null ? pushContext.getValidationRecordId() : null;
         if (validationRecordId == null) {
-            log.warn("No validationRecordId in repo config - skipping approval gate");
+            log.warn("No validationRecordId in push context - skipping approval gate");
             return;
         }
 

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/BitbucketCredentialRewriteHook.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/BitbucketCredentialRewriteHook.java
@@ -30,6 +30,7 @@ public class BitbucketCredentialRewriteHook implements GitProxyHook {
     private static final int ORDER = 148;
 
     private final BitbucketProvider provider;
+    private final PushContext pushContext;
 
     @Override
     public int getOrder() {
@@ -43,12 +44,11 @@ public class BitbucketCredentialRewriteHook implements GitProxyHook {
 
     @Override
     public void onPreReceive(ReceivePack rp, Collection<ReceiveCommand> commands) {
-        var repo = rp.getRepository();
-        String pushEmail = repo.getConfig().getString("gitproxy", null, "pushUser");
-        String pushToken = repo.getConfig().getString("gitproxy", null, "pushToken");
+        String pushEmail = pushContext.getPushUser();
+        String pushToken = pushContext.getPushToken();
 
         if (pushEmail == null || pushToken == null) {
-            log.debug("No push credentials in repo config — skipping Bitbucket upstream username resolution");
+            log.debug("No push credentials in context — skipping Bitbucket upstream username resolution");
             return;
         }
 
@@ -61,7 +61,7 @@ public class BitbucketCredentialRewriteHook implements GitProxyHook {
         }
 
         String upstreamUser = identity.get().login();
-        repo.getConfig().setString("gitproxy", null, "upstreamUser", upstreamUser);
+        pushContext.setUpstreamUser(upstreamUser);
         log.debug("Stored Bitbucket upstream username '{}' for push email '{}'", upstreamUser, pushEmail);
     }
 }

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/CheckUserPushPermissionHook.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/CheckUserPushPermissionHook.java
@@ -64,10 +64,9 @@ public class CheckUserPushPermissionHook implements GitProxyHook {
 
     @Override
     public void onPreReceive(ReceivePack rp, Collection<ReceiveCommand> commands) {
-        var config = rp.getRepository().getConfig();
-        String pushUser = config.getString("gitproxy", null, "pushUser");
-        String pushToken = config.getString("gitproxy", null, "pushToken");
-        String repoSlug = config.getString("gitproxy", null, "repoSlug");
+        String pushUser = pushContext.getPushUser();
+        String pushToken = pushContext.getPushToken();
+        String repoSlug = pushContext.getRepoSlug();
 
         if (identityResolver == null) {
             log.debug("No identity resolver configured (open mode), skipping permission check");
@@ -140,13 +139,13 @@ public class CheckUserPushPermissionHook implements GitProxyHook {
                 user.getUsername(),
                 providerId,
                 repoSlug);
-        config.setString("gitproxy", null, "resolvedUser", user.getUsername());
+        pushContext.setResolvedUser(user.getUsername());
         if (provider != null && user.getScmIdentities() != null) {
             user.getScmIdentities().stream()
                     .filter(id -> provider.getProviderId().equalsIgnoreCase(id.getProvider()))
                     .map(org.finos.gitproxy.user.ScmIdentity::getUsername)
                     .findFirst()
-                    .ifPresent(scmUser -> config.setString("gitproxy", null, "scmUsername", scmUser));
+                    .ifPresent(pushContext::setScmUsername);
         }
         pushContext.addStep(PushStep.builder()
                 .stepName("checkUserPermission")

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/ForwardingPostReceiveHook.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/ForwardingPostReceiveHook.java
@@ -68,10 +68,10 @@ public class ForwardingPostReceiveHook implements PostReceiveHook {
         Repository repo = rp.getRepository();
 
         // If BitbucketCredentialRewriteHook resolved an upstream username, use it instead of the push email.
-        String upstreamUser = repo.getConfig().getString("gitproxy", null, "upstreamUser");
+        String upstreamUser = pushContext.getUpstreamUser();
         CredentialsProvider effectiveCreds = credentials;
         if (upstreamUser != null) {
-            String pushToken = repo.getConfig().getString("gitproxy", null, "pushToken");
+            String pushToken = pushContext.getPushToken();
             effectiveCreds = new UsernamePasswordCredentialsProvider(upstreamUser, pushToken != null ? pushToken : "");
             log.debug("Using Bitbucket upstream username '{}' for forwarding credentials", upstreamUser);
         }

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/IdentityVerificationHook.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/IdentityVerificationHook.java
@@ -74,9 +74,8 @@ public class IdentityVerificationHook implements GitProxyHook {
             return;
         }
 
-        var config = rp.getRepository().getConfig();
-        String pushUser = config.getString("gitproxy", null, "pushUser");
-        String pushToken = config.getString("gitproxy", null, "pushToken");
+        String pushUser = pushContext.getPushUser();
+        String pushToken = pushContext.getPushToken();
 
         if (pushUser == null || pushUser.isEmpty()) {
             log.debug("No push user in repo config — skipping identity verification");

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/PushContext.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/PushContext.java
@@ -4,15 +4,40 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import lombok.Data;
 import org.finos.gitproxy.db.model.PushStep;
 
 /**
- * Shared context for accumulating {@link PushStep} records across pre-receive hooks within a single push. Hooks write
- * steps (diffs, scan results, etc.) to this context, and the persistence hook reads them when saving the final record.
+ * Per-request context shared across all pre/post-receive hooks within a single push. Carries both accumulated
+ * {@link PushStep} records (diffs, scan results, etc.) and transient per-request values that must not be stored on the
+ * shared cached {@link org.eclipse.jgit.lib.Repository} config.
+ *
+ * <p>All fields are written once (by {@link StoreAndForwardReceivePackFactory} or early hooks) and read by later hooks.
+ * No synchronisation is needed because hooks in a single push execute sequentially on the same thread.
  */
+@Data
 public class PushContext {
 
     private final List<PushStep> steps = new ArrayList<>();
+
+    // Per-request credentials — written by StoreAndForwardReceivePackFactory before any hook runs.
+    private String pushUser;
+    private String pushToken;
+    private String repoSlug;
+
+    // Resolved upstream username for Bitbucket pushes — written by BitbucketCredentialRewriteHook.
+    private String upstreamUser;
+
+    // Push record ID — written by PushStorePersistenceHook.preReceiveHook().
+    private String pushId;
+
+    // Identity resolved by CheckUserPushPermissionHook — written after permission check passes.
+    private String resolvedUser;
+    private String scmUsername;
+
+    // Validation record ID — written by PushStorePersistenceHook.validationResultHook().
+    private String validationRecordId;
 
     /** Add a step to the context. */
     public void addStep(PushStep step) {

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/PushContext.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/PushContext.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
 import lombok.Data;
 import org.finos.gitproxy.db.model.PushStep;
 

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/PushStorePersistenceHook.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/PushStorePersistenceHook.java
@@ -80,8 +80,7 @@ public class PushStorePersistenceHook {
     public PreReceiveHook preReceiveHook() {
         return (ReceivePack rp, Collection<ReceiveCommand> commands) -> {
             String pushId = UUID.randomUUID().toString();
-            // Store push ID in repo config so post-receive can find it
-            rp.getRepository().getConfig().setString("gitproxy", null, "pushId", pushId);
+            pushContext.setPushId(pushId);
 
             try {
                 PushRecord record = buildInitialRecord(pushId, rp, commands);
@@ -102,14 +101,14 @@ public class PushStorePersistenceHook {
      */
     public PreReceiveHook validationResultHook(ValidationContext validationContext) {
         return (ReceivePack rp, Collection<ReceiveCommand> commands) -> {
-            String pushId = rp.getRepository().getConfig().getString("gitproxy", null, "pushId");
+            String pushId = pushContext != null ? pushContext.getPushId() : null;
             if (pushId == null) return;
 
-            // Re-read resolvedUser and scmUsername here — both are set by CheckUserPushPermissionHook
-            // (order 150), which runs after preReceiveHook(), so they were not available when the
-            // RECEIVED record was written. validationResultHook fires after all validation hooks complete.
-            String resolvedUserLate = rp.getRepository().getConfig().getString("gitproxy", null, "resolvedUser");
-            String scmUsernameLate = rp.getRepository().getConfig().getString("gitproxy", null, "scmUsername");
+            // Read resolvedUser and scmUsername from pushContext — both are set by CheckUserPushPermissionHook
+            // (order 150) after preReceiveHook() ran, so they were not available when the RECEIVED record
+            // was written. validationResultHook fires after all validation hooks complete.
+            String resolvedUserLate = pushContext.getResolvedUser();
+            String scmUsernameLate = pushContext.getScmUsername();
 
             try {
                 pushStore.findById(pushId).ifPresent(initial -> {
@@ -156,9 +155,7 @@ public class PushStorePersistenceHook {
                         record.setBlockedMessage(validationContext.getIssues().size() + " validation issue(s) found");
                         record.setSteps(allSteps);
                         pushStore.save(record);
-                        rp.getRepository()
-                                .getConfig()
-                                .setString("gitproxy", null, "validationRecordId", record.getId());
+                        if (pushContext != null) pushContext.setValidationRecordId(record.getId());
                         log.debug(
                                 "Saved validation result record: id={}, status=REJECTED (auto-rejected)",
                                 record.getId());
@@ -221,7 +218,7 @@ public class PushStorePersistenceHook {
                     }
 
                     pushStore.save(record);
-                    rp.getRepository().getConfig().setString("gitproxy", null, "validationRecordId", record.getId());
+                    if (pushContext != null) pushContext.setValidationRecordId(record.getId());
                     log.debug(
                             "Saved validation result record: id={}, status=PENDING (awaiting review)", record.getId());
                 });
@@ -239,7 +236,7 @@ public class PushStorePersistenceHook {
      */
     public PostReceiveHook postReceiveHook() {
         return (ReceivePack rp, Collection<ReceiveCommand> commands) -> {
-            String pushId = rp.getRepository().getConfig().getString("gitproxy", null, "pushId");
+            String pushId = pushContext != null ? pushContext.getPushId() : null;
             if (pushId == null) return;
 
             try {

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/RepositoryUrlRuleHook.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/RepositoryUrlRuleHook.java
@@ -41,9 +41,9 @@ public class RepositoryUrlRuleHook implements GitProxyHook {
 
     @Override
     public void onPreReceive(ReceivePack rp, Collection<ReceiveCommand> commands) {
-        String repoSlug = rp.getRepository().getConfig().getString("gitproxy", null, "repoSlug");
+        String repoSlug = pushContext.getRepoSlug();
         if (repoSlug == null || repoSlug.isBlank()) {
-            log.warn("No repoSlug in repo config — cannot evaluate URL rules, blocking push (fail-closed)");
+            log.warn("No repoSlug in push context — cannot evaluate URL rules, blocking push (fail-closed)");
             blockPush(rp, commands, "Repository path unavailable");
             return;
         }

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/StoreAndForwardReceivePackFactory.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/StoreAndForwardReceivePackFactory.java
@@ -157,34 +157,26 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
             creds = extractBasicAuth(req);
         }
 
-        // Store push credentials in repo config so hooks can read them for identity resolution.
-        // pushToken is the PAT/password — stored only in-process repo config, never persisted to disk.
-        String[] userPass = extractUserPass(req);
-        String pushUser = userPass != null ? userPass[0] : null;
-        String pushToken = userPass != null ? userPass[1] : null;
-        if (pushUser != null) {
-            db.getConfig().setString("gitproxy", null, "pushUser", pushUser);
-        }
-        if (pushToken != null) {
-            db.getConfig().setString("gitproxy", null, "pushToken", pushToken);
-        }
+        // Per-request shared contexts — created before credentials are extracted so they can be
+        // stored on pushContext rather than the shared cached Repository config.
+        var validationContext = new ValidationContext();
+        var pushContext = new PushContext();
 
-        // Store the repo slug (/owner/repo) so permission hooks can read it without re-parsing the URL.
+        // Store per-request credentials on pushContext, not the shared Repository config.
+        // Writing to db.getConfig() would race with concurrent pushes to the same cached repo.
+        String[] userPass = extractUserPass(req);
+        pushContext.setPushUser(userPass != null ? userPass[0] : null);
+        pushContext.setPushToken(userPass != null ? userPass[1] : null);
+
         String pathInfo = req.getPathInfo();
         if (pathInfo != null) {
-            // pathInfo is e.g. /owner/repo.git — strip .git suffix
             String slug = pathInfo.replaceAll("\\.git$", "");
-            // Normalise to /owner/repo (at most two path segments after leading /)
             String[] segments = slug.split("/", 4);
             if (segments.length >= 3) {
                 slug = "/" + segments[1] + "/" + segments[2];
             }
-            db.getConfig().setString("gitproxy", null, "repoSlug", slug);
+            pushContext.setRepoSlug(slug);
         }
-
-        // Per-request shared contexts
-        var validationContext = new ValidationContext();
-        var pushContext = new PushContext();
 
         // Persistence hook (records push to database)
         var persistenceHook = pushStore != null ? new PushStorePersistenceHook(pushStore, provider) : null;
@@ -247,7 +239,7 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
                 new GpgSignatureHook(gpgConfig, validationContext, pushContext),
                 new SecretScanningHook(secretScanConfig, validationContext, pushContext)));
         if (provider instanceof BitbucketProvider bitbucketProvider) {
-            validationHooks.add(new BitbucketCredentialRewriteHook(bitbucketProvider));
+            validationHooks.add(new BitbucketCredentialRewriteHook(bitbucketProvider, pushContext));
         }
         validationHooks.sort(Comparator.comparingInt(GitProxyHook::getOrder));
 
@@ -257,7 +249,8 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
             hooks.add(persistenceHook.preReceiveHook());
             hooks.addAll(validationHooks);
             hooks.add(persistenceHook.validationResultHook(validationContext));
-            hooks.add(new ApprovalPreReceiveHook(pushStore, approvalGateway, serviceUrl, repoPermissionService));
+            hooks.add(new ApprovalPreReceiveHook(
+                    pushStore, approvalGateway, serviceUrl, repoPermissionService, pushContext));
             preHooks = hooks.toArray(PreReceiveHook[]::new);
         } else {
             preHooks = validationHooks.toArray(PreReceiveHook[]::new);

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/ApprovalPreReceiveHookTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/ApprovalPreReceiveHookTest.java
@@ -24,7 +24,6 @@ import org.finos.gitproxy.db.model.Attestation;
 import org.finos.gitproxy.db.model.PushRecord;
 import org.finos.gitproxy.db.model.PushStatus;
 import org.finos.gitproxy.permission.RepoPermissionService;
-import org.finos.gitproxy.git.PushContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -86,7 +85,8 @@ class ApprovalPreReceiveHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofMinutes(30), null, null, pushContext).onPreReceive(rp, List.of(cmd));
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofMinutes(30), null, null, pushContext)
+                .onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.NOT_ATTEMPTED, cmd.getResult());
         verifyNoInteractions(approvalGateway);
@@ -106,7 +106,8 @@ class ApprovalPreReceiveHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofMinutes(30), null, null, pushContext).onPreReceive(rp, List.of(cmd));
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofMinutes(30), null, null, pushContext)
+                .onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.NOT_ATTEMPTED, cmd.getResult());
         verifyNoInteractions(approvalGateway);
@@ -128,7 +129,8 @@ class ApprovalPreReceiveHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, null, pushContext).onPreReceive(rp, List.of(cmd));
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, null, pushContext)
+                .onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.NOT_ATTEMPTED, cmd.getResult());
     }
@@ -151,7 +153,8 @@ class ApprovalPreReceiveHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, null, pushContext).onPreReceive(rp, List.of(cmd));
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, null, pushContext)
+                .onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.REJECTED_OTHER_REASON, cmd.getResult());
     }
@@ -323,7 +326,8 @@ class ApprovalPreReceiveHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, null, pushContext).onPreReceive(rp, List.of(cmd));
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, null, pushContext)
+                .onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.REJECTED_OTHER_REASON, cmd.getResult());
     }

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/ApprovalPreReceiveHookTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/ApprovalPreReceiveHookTest.java
@@ -24,6 +24,7 @@ import org.finos.gitproxy.db.model.Attestation;
 import org.finos.gitproxy.db.model.PushRecord;
 import org.finos.gitproxy.db.model.PushStatus;
 import org.finos.gitproxy.permission.RepoPermissionService;
+import org.finos.gitproxy.git.PushContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -76,8 +77,8 @@ class ApprovalPreReceiveHookTest {
     @Test
     void validationRecordNotInStore_skipsApprovalGate() throws Exception {
         String recordId = UUID.randomUUID().toString();
-        repo.getConfig().setString("gitproxy", null, "validationRecordId", recordId);
-        repo.getConfig().save();
+        PushContext pushContext = new PushContext();
+        pushContext.setValidationRecordId(recordId);
         when(pushStore.findById(recordId)).thenReturn(Optional.empty());
 
         RevCommit c1 = createCommit("init");
@@ -85,7 +86,7 @@ class ApprovalPreReceiveHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new ApprovalPreReceiveHook(pushStore, approvalGateway).onPreReceive(rp, List.of(cmd));
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofMinutes(30), null, null, pushContext).onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.NOT_ATTEMPTED, cmd.getResult());
         verifyNoInteractions(approvalGateway);
@@ -94,8 +95,8 @@ class ApprovalPreReceiveHookTest {
     @Test
     void alreadyApproved_passesImmediately() throws Exception {
         String recordId = UUID.randomUUID().toString();
-        repo.getConfig().setString("gitproxy", null, "validationRecordId", recordId);
-        repo.getConfig().save();
+        PushContext pushContext = new PushContext();
+        pushContext.setValidationRecordId(recordId);
         PushRecord record =
                 PushRecord.builder().id(recordId).status(PushStatus.APPROVED).build();
         when(pushStore.findById(recordId)).thenReturn(Optional.of(record));
@@ -105,7 +106,7 @@ class ApprovalPreReceiveHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new ApprovalPreReceiveHook(pushStore, approvalGateway).onPreReceive(rp, List.of(cmd));
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofMinutes(30), null, null, pushContext).onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.NOT_ATTEMPTED, cmd.getResult());
         verifyNoInteractions(approvalGateway);
@@ -114,8 +115,8 @@ class ApprovalPreReceiveHookTest {
     @Test
     void blockedPush_gatewayApproves_commandNotRejected() throws Exception {
         String recordId = UUID.randomUUID().toString();
-        repo.getConfig().setString("gitproxy", null, "validationRecordId", recordId);
-        repo.getConfig().save();
+        PushContext pushContext = new PushContext();
+        pushContext.setValidationRecordId(recordId);
         PushRecord record =
                 PushRecord.builder().id(recordId).status(PushStatus.PENDING).build();
         when(pushStore.findById(recordId)).thenReturn(Optional.of(record));
@@ -127,7 +128,7 @@ class ApprovalPreReceiveHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5)).onPreReceive(rp, List.of(cmd));
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, null, pushContext).onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.NOT_ATTEMPTED, cmd.getResult());
     }
@@ -135,8 +136,8 @@ class ApprovalPreReceiveHookTest {
     @Test
     void blockedPush_gatewayRejects_commandRejected() throws Exception {
         String recordId = UUID.randomUUID().toString();
-        repo.getConfig().setString("gitproxy", null, "validationRecordId", recordId);
-        repo.getConfig().save();
+        PushContext pushContext = new PushContext();
+        pushContext.setValidationRecordId(recordId);
         PushRecord record =
                 PushRecord.builder().id(recordId).status(PushStatus.PENDING).build();
         PushRecord updatedRecord =
@@ -150,7 +151,7 @@ class ApprovalPreReceiveHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5)).onPreReceive(rp, List.of(cmd));
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, null, pushContext).onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.REJECTED_OTHER_REASON, cmd.getResult());
     }
@@ -160,8 +161,8 @@ class ApprovalPreReceiveHookTest {
     @Test
     void selfApproved_alreadyApprovedAtHookStart_noPerm_rejected() throws Exception {
         String recordId = UUID.randomUUID().toString();
-        repo.getConfig().setString("gitproxy", null, "validationRecordId", recordId);
-        repo.getConfig().save();
+        PushContext pushContext = new PushContext();
+        pushContext.setValidationRecordId(recordId);
         Attestation att = Attestation.builder()
                 .pushId(recordId)
                 .type(Attestation.Type.APPROVAL)
@@ -185,7 +186,7 @@ class ApprovalPreReceiveHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, perms)
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, perms, pushContext)
                 .onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.REJECTED_OTHER_REASON, cmd.getResult());
@@ -195,8 +196,8 @@ class ApprovalPreReceiveHookTest {
     @Test
     void selfApproved_alreadyApprovedAtHookStart_withPerm_passes() throws Exception {
         String recordId = UUID.randomUUID().toString();
-        repo.getConfig().setString("gitproxy", null, "validationRecordId", recordId);
-        repo.getConfig().save();
+        PushContext pushContext = new PushContext();
+        pushContext.setValidationRecordId(recordId);
         Attestation att = Attestation.builder()
                 .pushId(recordId)
                 .type(Attestation.Type.APPROVAL)
@@ -220,7 +221,7 @@ class ApprovalPreReceiveHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, perms)
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, perms, pushContext)
                 .onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.NOT_ATTEMPTED, cmd.getResult());
@@ -229,8 +230,8 @@ class ApprovalPreReceiveHookTest {
     @Test
     void selfApproved_viaWaitForApproval_noPerm_rejected() throws Exception {
         String recordId = UUID.randomUUID().toString();
-        repo.getConfig().setString("gitproxy", null, "validationRecordId", recordId);
-        repo.getConfig().save();
+        PushContext pushContext = new PushContext();
+        pushContext.setValidationRecordId(recordId);
         // Initial fetch returns PENDING (no attestation yet); after approval, returns APPROVED with attestation
         // showing the pusher self-approved.
         PushRecord pending = PushRecord.builder()
@@ -265,7 +266,7 @@ class ApprovalPreReceiveHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, perms)
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, perms, pushContext)
                 .onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.REJECTED_OTHER_REASON, cmd.getResult());
@@ -276,8 +277,8 @@ class ApprovalPreReceiveHookTest {
     void differentApproverThanPusher_noReVerifyNeeded() throws Exception {
         // Approver != pusher → defense-in-depth check skipped; push is forwarded.
         String recordId = UUID.randomUUID().toString();
-        repo.getConfig().setString("gitproxy", null, "validationRecordId", recordId);
-        repo.getConfig().save();
+        PushContext pushContext = new PushContext();
+        pushContext.setValidationRecordId(recordId);
         Attestation att = Attestation.builder()
                 .pushId(recordId)
                 .type(Attestation.Type.APPROVAL)
@@ -299,7 +300,7 @@ class ApprovalPreReceiveHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, perms)
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, perms, pushContext)
                 .onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.NOT_ATTEMPTED, cmd.getResult());
@@ -309,8 +310,8 @@ class ApprovalPreReceiveHookTest {
     @Test
     void blockedPush_gatewayTimesOut_commandRejected() throws Exception {
         String recordId = UUID.randomUUID().toString();
-        repo.getConfig().setString("gitproxy", null, "validationRecordId", recordId);
-        repo.getConfig().save();
+        PushContext pushContext = new PushContext();
+        pushContext.setValidationRecordId(recordId);
         PushRecord record =
                 PushRecord.builder().id(recordId).status(PushStatus.PENDING).build();
         when(pushStore.findById(recordId)).thenReturn(Optional.of(record));
@@ -322,7 +323,7 @@ class ApprovalPreReceiveHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5)).onPreReceive(rp, List.of(cmd));
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, null, pushContext).onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.REJECTED_OTHER_REASON, cmd.getResult());
     }

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/CheckUserPushPermissionHookTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/CheckUserPushPermissionHookTest.java
@@ -94,8 +94,6 @@ class CheckUserPushPermissionHookTest {
 
     @Test
     void resolverReturnsEmpty_addsNotRegisteredIssue() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "pushUser", "unknown-user");
-        repo.getConfig().save();
         when(resolver.resolve(nullable(GitProxyProvider.class), eq("unknown-user"), any()))
                 .thenReturn(Optional.empty());
 
@@ -104,6 +102,7 @@ class CheckUserPushPermissionHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
         PushContext pushContext = new PushContext();
+        pushContext.setPushUser("unknown-user");
         ValidationContext validationContext = new ValidationContext();
 
         hook(validationContext, pushContext).onPreReceive(rp, List.of(cmd));
@@ -122,9 +121,6 @@ class CheckUserPushPermissionHookTest {
 
     @Test
     void userNotAuthorized_addsUnauthorizedIssue() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "pushUser", "corp-user");
-        repo.getConfig().setString("gitproxy", null, "repoSlug", "/owner/repo");
-        repo.getConfig().save();
         GitProxyProvider github = new GitHubProvider("/push");
         when(resolver.resolve(eq(github), eq("corp-user"), any())).thenReturn(Optional.of(userEntry("alice")));
         when(permService.isAllowedToPush("alice", "github/github.com", "/owner/repo"))
@@ -135,6 +131,8 @@ class CheckUserPushPermissionHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
         PushContext pushContext = new PushContext();
+        pushContext.setPushUser("corp-user");
+        pushContext.setRepoSlug("/owner/repo");
         ValidationContext validationContext = new ValidationContext();
 
         new CheckUserPushPermissionHook(resolver, permService, validationContext, pushContext, github, null)
@@ -153,10 +151,6 @@ class CheckUserPushPermissionHookTest {
 
     @Test
     void resolvedAndAuthorized_recordsPass() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "pushUser", "corp-user");
-        repo.getConfig().setString("gitproxy", null, "pushToken", "ghp_secret");
-        repo.getConfig().setString("gitproxy", null, "repoSlug", "/owner/repo");
-        repo.getConfig().save();
         GitProxyProvider github = new GitHubProvider("/push");
         when(resolver.resolve(eq(github), eq("corp-user"), eq("ghp_secret")))
                 .thenReturn(Optional.of(userEntry("alice")));
@@ -168,6 +162,9 @@ class CheckUserPushPermissionHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
         PushContext pushContext = new PushContext();
+        pushContext.setPushUser("corp-user");
+        pushContext.setPushToken("ghp_secret");
+        pushContext.setRepoSlug("/owner/repo");
         ValidationContext validationContext = new ValidationContext();
 
         new CheckUserPushPermissionHook(resolver, permService, validationContext, pushContext, github, null)
@@ -182,9 +179,6 @@ class CheckUserPushPermissionHookTest {
 
     @Test
     void nullResolver_withPushUser_passesInOpenMode() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "pushUser", "anyone");
-        repo.getConfig().save();
-
         RevCommit c1 = createCommit("init");
         RevCommit c2 = createCommit("second");
         ReceivePack rp = new ReceivePack(repo);
@@ -205,9 +199,6 @@ class CheckUserPushPermissionHookTest {
 
     @Test
     void provider_isPassedToResolver() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "pushUser", "my-user");
-        repo.getConfig().setString("gitproxy", null, "repoSlug", "/owner/repo");
-        repo.getConfig().save();
         GitProxyProvider github = new GitHubProvider("/push");
         when(resolver.resolve(eq(github), eq("my-user"), any())).thenReturn(Optional.of(userEntry("my-user")));
         when(permService.isAllowedToPush("my-user", "github/github.com", "/owner/repo"))
@@ -218,6 +209,8 @@ class CheckUserPushPermissionHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
         PushContext pushContext = new PushContext();
+        pushContext.setPushUser("my-user");
+        pushContext.setRepoSlug("/owner/repo");
         ValidationContext validationContext = new ValidationContext();
 
         new CheckUserPushPermissionHook(resolver, permService, validationContext, pushContext, github, null)

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/IdentityVerificationHookTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/IdentityVerificationHookTest.java
@@ -130,8 +130,6 @@ class IdentityVerificationHookTest {
 
     @Test
     void emailsMatch_recordsPass() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "pushUser", "alice-git");
-        repo.getConfig().save();
         when(resolver.resolve(any(GitProxyProvider.class), eq("alice-git"), isNull()))
                 .thenReturn(Optional.of(alice()));
 
@@ -140,6 +138,7 @@ class IdentityVerificationHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
         PushContext pc = new PushContext();
+        pc.setPushUser("alice-git");
         ValidationContext vc = new ValidationContext();
 
         hook(CommitConfig.IdentityVerificationMode.STRICT, vc, pc).onPreReceive(rp, List.of(cmd));
@@ -153,8 +152,6 @@ class IdentityVerificationHookTest {
 
     @Test
     void strictMode_emailMismatch_addsIssue() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "pushUser", "alice-git");
-        repo.getConfig().save();
         when(resolver.resolve(any(GitProxyProvider.class), eq("alice-git"), isNull()))
                 .thenReturn(Optional.of(alice()));
 
@@ -163,6 +160,7 @@ class IdentityVerificationHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
         PushContext pc = new PushContext();
+        pc.setPushUser("alice-git");
         ValidationContext vc = new ValidationContext();
 
         hook(CommitConfig.IdentityVerificationMode.STRICT, vc, pc).onPreReceive(rp, List.of(cmd));
@@ -176,8 +174,6 @@ class IdentityVerificationHookTest {
 
     @Test
     void warnMode_emailMismatch_noIssue_recordsPass() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "pushUser", "alice-git");
-        repo.getConfig().save();
         when(resolver.resolve(any(GitProxyProvider.class), eq("alice-git"), isNull()))
                 .thenReturn(Optional.of(alice()));
 
@@ -186,6 +182,7 @@ class IdentityVerificationHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
         PushContext pc = new PushContext();
+        pc.setPushUser("alice-git");
         ValidationContext vc = new ValidationContext();
 
         hook(CommitConfig.IdentityVerificationMode.WARN, vc, pc).onPreReceive(rp, List.of(cmd));
@@ -199,8 +196,6 @@ class IdentityVerificationHookTest {
 
     @Test
     void deleteCommand_skipped() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "pushUser", "alice-git");
-        repo.getConfig().save();
         when(resolver.resolve(any(GitProxyProvider.class), eq("alice-git"), isNull()))
                 .thenReturn(Optional.of(alice()));
 
@@ -210,6 +205,7 @@ class IdentityVerificationHookTest {
         ReceiveCommand cmd = new ReceiveCommand(
                 c1.getId(), org.eclipse.jgit.lib.ObjectId.zeroId(), "refs/heads/main", ReceiveCommand.Type.DELETE);
         PushContext pc = new PushContext();
+        pc.setPushUser("alice-git");
         ValidationContext vc = new ValidationContext();
 
         hook(CommitConfig.IdentityVerificationMode.STRICT, vc, pc).onPreReceive(rp, List.of(cmd));
@@ -221,8 +217,6 @@ class IdentityVerificationHookTest {
 
     @Test
     void strictMode_authorAndCommitterSameEmail_singleViolation() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "pushUser", "alice-git");
-        repo.getConfig().save();
         when(resolver.resolve(any(GitProxyProvider.class), eq("alice-git"), isNull()))
                 .thenReturn(Optional.of(alice())); // alice only has alice@example.com
 
@@ -232,6 +226,7 @@ class IdentityVerificationHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
         PushContext pc = new PushContext();
+        pc.setPushUser("alice-git");
         ValidationContext vc = new ValidationContext();
 
         hook(CommitConfig.IdentityVerificationMode.STRICT, vc, pc).onPreReceive(rp, List.of(cmd));
@@ -246,8 +241,6 @@ class IdentityVerificationHookTest {
 
     @Test
     void warnMode_emailMismatch_stepContentContainsViolations() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "pushUser", "alice-git");
-        repo.getConfig().save();
         when(resolver.resolve(any(GitProxyProvider.class), eq("alice-git"), isNull()))
                 .thenReturn(Optional.of(alice()));
 
@@ -256,6 +249,7 @@ class IdentityVerificationHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
         PushContext pc = new PushContext();
+        pc.setPushUser("alice-git");
         ValidationContext vc = new ValidationContext();
 
         hook(CommitConfig.IdentityVerificationMode.WARN, vc, pc).onPreReceive(rp, List.of(cmd));
@@ -274,8 +268,6 @@ class IdentityVerificationHookTest {
 
     @Test
     void resolverEmpty_skipsCheck_noStep() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "pushUser", "unknown");
-        repo.getConfig().save();
         when(resolver.resolve(any(GitProxyProvider.class), eq("unknown"), any()))
                 .thenReturn(Optional.empty());
 
@@ -284,6 +276,7 @@ class IdentityVerificationHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
         PushContext pc = new PushContext();
+        pc.setPushUser("unknown");
         ValidationContext vc = new ValidationContext();
 
         hook(CommitConfig.IdentityVerificationMode.STRICT, vc, pc).onPreReceive(rp, List.of(cmd));

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/PushStorePersistenceHookTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/PushStorePersistenceHookTest.java
@@ -43,6 +43,7 @@ class PushStorePersistenceHookTest {
     ObjectId commitId;
     PushStore pushStore;
     PushStorePersistenceHook hook;
+    PushContext pushContext;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -64,6 +65,8 @@ class PushStorePersistenceHookTest {
 
         pushStore = new InMemoryPushStore();
         hook = new PushStorePersistenceHook(pushStore, new GitHubProvider("/push"));
+        pushContext = new PushContext();
+        hook.setPushContext(pushContext);
     }
 
     private ReceivePack makeReceivePack() {
@@ -84,7 +87,7 @@ class PushStorePersistenceHookTest {
         hook.preReceiveHook().onPreReceive(rp, List.of(cmd));
 
         // The push ID is stored in the repo config by the pre-receive hook
-        String pushId = repo.getConfig().getString("gitproxy", null, "pushId");
+        String pushId = pushContext.getPushId();
         assertNotNull(pushId, "push ID should be stamped into repo config");
 
         var record = pushStore.findById(pushId);
@@ -99,7 +102,7 @@ class PushStorePersistenceHookTest {
 
         hook.preReceiveHook().onPreReceive(rp, List.of(cmd));
 
-        String pushId = repo.getConfig().getString("gitproxy", null, "pushId");
+        String pushId = pushContext.getPushId();
         var record = pushStore.findById(pushId).orElseThrow();
 
         assertEquals("refs/heads/test", record.getBranch());
@@ -119,7 +122,7 @@ class PushStorePersistenceHookTest {
         ValidationContext ctx = new ValidationContext(); // no issues
         hook.validationResultHook(ctx).onPreReceive(rp, List.of(cmd));
 
-        String pushId = repo.getConfig().getString("gitproxy", null, "pushId");
+        String pushId = pushContext.getPushId();
         // The validation-result hook creates a new record with a fresh UUID (copyBase pattern);
         // we verify by querying for PENDING status rather than by ID.
         var records = pushStore.find(org.finos.gitproxy.db.model.PushQuery.builder()
@@ -155,7 +158,7 @@ class PushStorePersistenceHookTest {
         ctx.addIssue("checkAuthorEmails", "Email blocked", "noreply@ address is not allowed");
         hook.validationResultHook(ctx).onPreReceive(rp, List.of(cmd));
 
-        String pushId = repo.getConfig().getString("gitproxy", null, "pushId");
+        String pushId = pushContext.getPushId();
         var records = pushStore.find(org.finos.gitproxy.db.model.PushQuery.builder()
                 .status(PushStatus.REJECTED)
                 .build());

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/RepositoryUrlRuleHookTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/RepositoryUrlRuleHookTest.java
@@ -60,8 +60,6 @@ class RepositoryUrlRuleHookTest {
 
     @Test
     void withRepoSlug_allowRuleMatches_recordsPass() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "repoSlug", "/myorg/myrepo");
-        repo.getConfig().save();
 
         var allowRule = AccessRule.builder()
                 .ruleOrder(100)
@@ -70,6 +68,7 @@ class RepositoryUrlRuleHookTest {
                 .owner("myorg")
                 .build();
         var pushContext = new PushContext();
+        pushContext.setRepoSlug("/myorg/myrepo");
         var registry = new InMemoryUrlRuleRegistry();
         registry.save(allowRule);
         var hook = new RepositoryUrlRuleHook(registry, GITHUB, null, pushContext);
@@ -83,8 +82,6 @@ class RepositoryUrlRuleHookTest {
 
     @Test
     void withRepoSlug_noMatchingAllowRule_rejectsCommand() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "repoSlug", "/myorg/myrepo");
-        repo.getConfig().save();
 
         var allowRule = AccessRule.builder()
                 .ruleOrder(100)
@@ -93,6 +90,7 @@ class RepositoryUrlRuleHookTest {
                 .owner("other-org")
                 .build();
         var pushContext = new PushContext();
+        pushContext.setRepoSlug("/myorg/myrepo");
         var registry = new InMemoryUrlRuleRegistry();
         registry.save(allowRule);
         var hook = new RepositoryUrlRuleHook(registry, GITHUB, null, pushContext);
@@ -106,8 +104,6 @@ class RepositoryUrlRuleHookTest {
 
     @Test
     void withRepoSlug_denyRuleAtLowerOrder_rejectsEvenWithAllowRule() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "repoSlug", "/myorg/myrepo");
-        repo.getConfig().save();
 
         var denyRule = AccessRule.builder()
                 .ruleOrder(100)
@@ -122,6 +118,7 @@ class RepositoryUrlRuleHookTest {
                 .owner("myorg")
                 .build();
         var pushContext = new PushContext();
+        pushContext.setRepoSlug("/myorg/myrepo");
         var registry = new InMemoryUrlRuleRegistry();
         registry.save(denyRule);
         registry.save(allowRule);
@@ -136,8 +133,6 @@ class RepositoryUrlRuleHookTest {
 
     @Test
     void fetchOnlyAllowRule_doesNotEngageForPush() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "repoSlug", "/myorg/myrepo");
-        repo.getConfig().save();
 
         var fetchOnlyAllow = AccessRule.builder()
                 .ruleOrder(100)
@@ -146,6 +141,7 @@ class RepositoryUrlRuleHookTest {
                 .owner("myorg")
                 .build();
         var pushContext = new PushContext();
+        pushContext.setRepoSlug("/myorg/myrepo");
         var registry = new InMemoryUrlRuleRegistry();
         registry.save(fetchOnlyAllow);
         var hook = new RepositoryUrlRuleHook(registry, GITHUB, null, pushContext);
@@ -159,8 +155,6 @@ class RepositoryUrlRuleHookTest {
 
     @Test
     void fetchOnlyDenyRule_doesNotBlockPush() throws Exception {
-        repo.getConfig().setString("gitproxy", null, "repoSlug", "/myorg/myrepo");
-        repo.getConfig().save();
 
         var fetchDeny = AccessRule.builder()
                 .ruleOrder(100)
@@ -175,6 +169,7 @@ class RepositoryUrlRuleHookTest {
                 .owner("myorg")
                 .build();
         var pushContext = new PushContext();
+        pushContext.setRepoSlug("/myorg/myrepo");
         var registry = new InMemoryUrlRuleRegistry();
         registry.save(fetchDeny);
         registry.save(pushAllow);


### PR DESCRIPTION
## Summary

- `LocalRepositoryCache` returns the same `Repository` object to all concurrent requests for the same upstream URL
- Per-request values (`pushUser`, `pushToken`, `repoSlug`, `pushId`, `resolvedUser`, `scmUsername`, `validationRecordId`, `upstreamUser`) were written to `db.getConfig()` so hooks could read them
- Under concurrent load, request A's token could be overwritten by request B before A's hooks ran — leading to token cross-contamination, wrong identity resolution, and incorrect push attribution

Moves all per-request transient values to `PushContext`, which is created fresh per request. `upstreamUrl` is the only value that remains in repo config as it is legitimately per-repo and intentionally persisted to disk.

Closes #176

## Test plan

- [ ] All existing unit tests pass (`./gradlew test`)
- [ ] `ApprovalPreReceiveHookTest`, `CheckUserPushPermissionHookTest`, `IdentityVerificationHookTest`, `PushStorePersistenceHookTest`, `RepositoryUrlRuleHookTest` all updated to set credentials on `PushContext` directly rather than repo config