### PR TITLE
fix: install grype with checksum verification for container scan reports

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -11,6 +11,8 @@ jobs:
   grype:
     name: Container Scan
     runs-on: ubuntu-latest
+    env:
+      GRYPE_VERSION: "0.111.0"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -20,6 +22,7 @@ jobs:
         id: scan
         with:
           image: ghcr.io/coopernetes/git-proxy-java:latest
+          grype-version: ${{ env.GRYPE_VERSION }}
           fail-build: true
           severity-cutoff: high
           only-fixed: true
@@ -29,6 +32,16 @@ jobs:
       # by internal scanning with application context. Uploading here creates misleading noise
       # in the GitHub Security tab (high CVSS score ≠ high actual risk for this workload).
       # The build still fails on high/critical with a fix available via fail-build: true above.
+
+      - name: Install grype
+        if: always()
+        run: |
+          curl -sSfL -o /tmp/grype.tar.gz \
+            https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz
+          curl -sSfL -o /tmp/grype_checksums.txt \
+            https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_checksums.txt
+          grep "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" /tmp/grype_checksums.txt | sha256sum --check --ignore-missing
+          tar -xzf /tmp/grype.tar.gz -C /usr/local/bin grype
 
       - name: Generate human-readable report
         if: always()

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -86,6 +86,8 @@ jobs:
       contents: read
       security-events: write
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    env:
+      GRYPE_VERSION: "0.111.0"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -95,6 +97,7 @@ jobs:
         id: scan
         with:
           image: ghcr.io/${{ github.repository }}@${{ needs.build-and-push.outputs.digest }}
+          grype-version: ${{ env.GRYPE_VERSION }}
           fail-build: true
           severity-cutoff: high
           only-fixed: true
@@ -107,8 +110,6 @@ jobs:
 
       - name: Install grype
         if: always()
-        env:
-          GRYPE_VERSION: "0.111.0"
         run: |
           curl -sSfL -o /tmp/grype.tar.gz \
             https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -105,6 +105,18 @@ jobs:
       # in the GitHub Security tab (high CVSS score ≠ high actual risk for this workload).
       # The build still fails on high/critical with a fix available via fail-build: true above.
 
+      - name: Install grype
+        if: always()
+        env:
+          GRYPE_VERSION: "0.111.0"
+        run: |
+          curl -sSfL -o /tmp/grype.tar.gz \
+            https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz
+          curl -sSfL -o /tmp/grype_checksums.txt \
+            https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_checksums.txt
+          grep "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" /tmp/grype_checksums.txt | sha256sum --check --ignore-missing
+          tar -xzf /tmp/grype.tar.gz -C /usr/local/bin grype
+
       - name: Generate human-readable report
         if: always()
         run: |


### PR DESCRIPTION
## Summary

- The \"Generate human-readable report\" step was failing because `anchore/scan-action` installs grype to a temp dir that is not on `$PATH`
- Adds an \"Install grype\" step that downloads v0.111.0, verifies the tarball against the release-provided checksums.txt (with `--ignore-missing` since the file covers all platforms), then extracts to `/usr/local/bin`
- Fixes empty artifacts in the `grype-container-scan` upload

## Test plan

- [ ] Docker Build & Publish workflow runs on merge to main
- [ ] Container Scan job completes without `grype: command not found`
- [ ] `grype-container-scan` artifact is non-empty (contains grype-report.txt and grype-report.json)