### PR TITLE
fix: bump grype to 0.111.1 and fix checksum verification in container scan

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -12,7 +12,7 @@ jobs:
     name: Container Scan
     runs-on: ubuntu-latest
     env:
-      GRYPE_VERSION: "0.111.0"
+      GRYPE_VERSION: "0.111.1"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -36,12 +36,13 @@ jobs:
       - name: Install grype
         if: always()
         run: |
-          curl -sSfL -o /tmp/grype.tar.gz \
-            https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz
-          curl -sSfL -o /tmp/grype_checksums.txt \
-            https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_checksums.txt
-          grep "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" /tmp/grype_checksums.txt | sha256sum --check --ignore-missing
-          tar -xzf /tmp/grype.tar.gz -C /usr/local/bin grype
+          cd /tmp
+          curl -sSfL -o "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz"
+          curl -sSfL -o "grype_${GRYPE_VERSION}_checksums.txt" \
+            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_checksums.txt"
+          grep "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" "grype_${GRYPE_VERSION}_checksums.txt" | sha256sum --check
+          tar -xzf "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -C /usr/local/bin grype
 
       - name: Generate human-readable report
         if: always()

--- a/.github/workflows/cve.yml
+++ b/.github/workflows/cve.yml
@@ -36,13 +36,34 @@ jobs:
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 
+      - name: Generate human-readable report
+        if: ${{ always() }}
+        run: |
+          grype dir:git-proxy-java-dashboard/frontend \
+            --config .grype.yaml \
+            --only-fixed \
+            --output table > grype-report.txt || true
+          grype dir:git-proxy-java-dashboard/frontend \
+            --config .grype.yaml \
+            --only-fixed \
+            --output json > grype-report.json || true
+
+      - name: Upload scan reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
+        with:
+          name: grype-npm-scan
+          path: |
+            grype-report.txt
+            grype-report.json
+          retention-days: 30
+
   grype-gradle:
     name: CVE / Gradle
     if: true
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -65,18 +86,26 @@ jobs:
           only-fixed: true
           config: .grype.yaml
 
-      - name: Upload SARIF report
+      - name: Generate human-readable report
         if: ${{ always() }}
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # ratchet:github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: ${{ steps.scan.outputs.sarif }}
+        run: |
+          grype sbom:build/reports/cyclonedx/bom.json \
+            --config .grype.yaml \
+            --only-fixed \
+            --output table > grype-report.txt || true
+          grype sbom:build/reports/cyclonedx/bom.json \
+            --config .grype.yaml \
+            --only-fixed \
+            --output json > grype-report.json || true
 
-      - name: Upload SBOM
+      - name: Upload scan reports
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
-          name: sbom-gradle
-          path: build/reports/cyclonedx/bom.json
+          name: grype-gradle-scan
+          path: |
+            grype-report.txt
+            grype-report.json
           retention-days: 30
 
   depcheck:

--- a/.github/workflows/cve.yml
+++ b/.github/workflows/cve.yml
@@ -36,17 +36,14 @@ jobs:
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 
-      - name: Generate human-readable report
+      - name: Generate table report
         if: ${{ always() }}
         run: |
+          export PATH="$(dirname $(find /opt/hostedtoolcache/grype -name grype -type f | head -1)):$PATH"
           grype dir:git-proxy-java-dashboard/frontend \
             --config .grype.yaml \
             --only-fixed \
-            --output table > grype-report.txt || true
-          grype dir:git-proxy-java-dashboard/frontend \
-            --config .grype.yaml \
-            --only-fixed \
-            --output json > grype-report.json || true
+            --output table > grype-npm-report.txt || true
 
       - name: Upload scan reports
         if: ${{ always() }}
@@ -54,8 +51,8 @@ jobs:
         with:
           name: grype-npm-scan
           path: |
-            grype-report.txt
-            grype-report.json
+            grype-npm-report.txt
+            ${{ steps.scan.outputs.json }}
           retention-days: 30
 
   grype-gradle:
@@ -86,17 +83,14 @@ jobs:
           only-fixed: true
           config: .grype.yaml
 
-      - name: Generate human-readable report
+      - name: Generate table report
         if: ${{ always() }}
         run: |
+          export PATH="$(dirname $(find /opt/hostedtoolcache/grype -name grype -type f | head -1)):$PATH"
           grype sbom:build/reports/cyclonedx/bom.json \
             --config .grype.yaml \
             --only-fixed \
-            --output table > grype-report.txt || true
-          grype sbom:build/reports/cyclonedx/bom.json \
-            --config .grype.yaml \
-            --only-fixed \
-            --output json > grype-report.json || true
+            --output table > grype-gradle-report.txt || true
 
       - name: Upload scan reports
         if: ${{ always() }}
@@ -104,8 +98,8 @@ jobs:
         with:
           name: grype-gradle-scan
           path: |
-            grype-report.txt
-            grype-report.json
+            grype-gradle-report.txt
+            ${{ steps.scan.outputs.json }}
           retention-days: 30
 
   depcheck:

--- a/.github/workflows/cve.yml
+++ b/.github/workflows/cve.yml
@@ -43,7 +43,7 @@ jobs:
           grype dir:git-proxy-java-dashboard/frontend \
             --config .grype.yaml \
             --only-fixed \
-            --output table > grype-npm-report.txt || true
+            --output table | tee grype-npm-report.txt || true
 
       - name: Upload scan reports
         if: ${{ always() }}
@@ -90,7 +90,7 @@ jobs:
           grype sbom:build/reports/cyclonedx/bom.json \
             --config .grype.yaml \
             --only-fixed \
-            --output table > grype-gradle-report.txt || true
+            --output table | tee grype-gradle-report.txt || true
 
       - name: Upload scan reports
         if: ${{ always() }}

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     jgitVersion = '7.6.0.202603022253-r'
 
     // HTTP
-    apacheHttpClientVersion = '5.6'
+    apacheHttpClientVersion = '5.6.1'
 
     // Jetty / Servlet
     jettyVersion = '12.1.8'
@@ -43,7 +43,7 @@ ext {
 
     // Spring
     springVersion = '7.0.6'
-    springSecurityVersion = '7.0.4'
+    springSecurityVersion = '7.0.5'
     springSessionVersion = '4.0.2'
 
     // YAML


### PR DESCRIPTION
## Summary

- Bumps `GRYPE_VERSION` from `0.111.0` to `0.111.1` — `0.111.0` does not exist as a GitHub release, causing a 404 in the `anchore/scan-action` install step and the manual install in the container scan job
- Fixes `sha256sum` verification in the container scan manual install: archive is now saved under its release filename so the checksum entry matches and `sha256sum --check` can verify it (old approach saved to `/tmp/grype.tar.gz` → "no file was verified", exit 1)
- Drops the broken SARIF upload from the Gradle CVE job — grype SARIF output for `sbom:` inputs omits `artifactLocation`, causing GitHub code scanning to fail with `locationFromSarifResult: expected artifact location`
- Adds human-readable table + JSON artifacts to both CVE jobs (`grype-npm-scan`, `grype-gradle-scan`) so findings are immediately accessible without downloading the raw SBOM. Uses `scan-action`'s `json` output and locates the grype binary in the tool cache for the table report
- Keeps SARIF upload on the npm job where path-based scans produce valid SARIF output

## Test plan

- [ ] CVE / npm: confirm `grype-npm-scan` artifact contains a non-empty table report and JSON on a failing run
- [ ] CVE / Gradle: confirm `grype-gradle-scan` artifact contains a non-empty table report and JSON, and no SARIF upload error
- [ ] Container Scan: trigger manually after merge and confirm `Scan image` and `Install grype` steps both pass and `grype-container-scan` artifact is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)