### PR TITLE
refactor: use provider name as canonical DB foreign key

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -17,12 +17,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
+      - name: Install grype
+        run: |
+          cd /tmp
+          curl -sSfL -o "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz"
+          curl -sSfL -o "grype_${GRYPE_VERSION}_checksums.txt" \
+            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_checksums.txt"
+          grep "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" "grype_${GRYPE_VERSION}_checksums.txt" | sha256sum --check
+          tar -xzf "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -C /usr/local/bin grype
+
       - name: Scan image
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # ratchet:anchore/scan-action@v7
         id: scan
         with:
           image: ghcr.io/coopernetes/git-proxy-java:latest
-          grype-version: ${{ env.GRYPE_VERSION }}
           fail-build: true
           severity-cutoff: high
           only-fixed: true
@@ -32,17 +41,6 @@ jobs:
       # by internal scanning with application context. Uploading here creates misleading noise
       # in the GitHub Security tab (high CVSS score ≠ high actual risk for this workload).
       # The build still fails on high/critical with a fix available via fail-build: true above.
-
-      - name: Install grype
-        if: always()
-        run: |
-          cd /tmp
-          curl -sSfL -o "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" \
-            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz"
-          curl -sSfL -o "grype_${GRYPE_VERSION}_checksums.txt" \
-            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_checksums.txt"
-          grep "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" "grype_${GRYPE_VERSION}_checksums.txt" | sha256sum --check
-          tar -xzf "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -C /usr/local/bin grype
 
       - name: Generate human-readable report
         if: always()

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -12,7 +12,7 @@ jobs:
     name: Container Scan
     runs-on: ubuntu-latest
     env:
-      GRYPE_VERSION: "0.111.1"
+      GRYPE_VERSION: "0.112.0"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -82,17 +82,26 @@ jobs:
       contents: read
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     env:
-      GRYPE_VERSION: "0.111.1"
+      GRYPE_VERSION: "0.112.0"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+      - name: Install grype
+        run: |
+          cd /tmp
+          curl -sSfL -o "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz"
+          curl -sSfL -o "grype_${GRYPE_VERSION}_checksums.txt" \
+            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_checksums.txt"
+          grep "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" "grype_${GRYPE_VERSION}_checksums.txt" | sha256sum --check
+          tar -xzf "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -C /usr/local/bin grype
 
       - name: Scan image
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # ratchet:anchore/scan-action@v7
         id: scan
         with:
           image: ghcr.io/${{ github.repository }}@${{ needs.build-and-push.outputs.digest }}
-          grype-version: ${{ env.GRYPE_VERSION }}
           fail-build: true
           severity-cutoff: high
           only-fixed: true
@@ -102,10 +111,6 @@ jobs:
       # by internal scanning with application context. Uploading here creates misleading noise
       # in the GitHub Security tab (high CVSS score ≠ high actual risk for this workload).
       # The build still fails on high/critical with a fix available via fail-build: true above.
-
-      - name: Add grype to PATH
-        if: always()
-        run: echo "$(dirname $(find /opt/hostedtoolcache/grype -name grype -type f | head -1))" >> $GITHUB_PATH
 
       - name: Generate scan report
         if: always()

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/provider/GitProxyProvider.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/provider/GitProxyProvider.java
@@ -14,13 +14,12 @@ public interface GitProxyProvider {
     String getType();
 
     /**
-     * Unique provider identity combining type and host (e.g. "github/github.com", "github/github.corp.example.com").
-     * Used for SCM identity resolution, permission matching, token caching, and DB storage. Two providers of the same
-     * type but different hosts (e.g. public GitHub and internal GHES) have distinct provider IDs — tokens, identities,
-     * and permissions are never shared across hosts.
+     * Canonical provider identity — equals the user-configured name (the YAML config map key, e.g. {@code "github"},
+     * {@code "internal"}). Used for SCM identity resolution, permission matching, token caching, and DB storage.
+     * Provider names are unique by YAML map key constraint and stable across hostname changes.
      */
     default String getProviderId() {
-        return getType() + "/" + getUri().getHost();
+        return getName();
     }
 
     URI getUri();

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/provider/ProviderRegistry.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/provider/ProviderRegistry.java
@@ -4,9 +4,8 @@ import java.util.List;
 import org.finos.gitproxy.db.UrlRuleRegistry;
 
 /**
- * Registry of configured git proxy providers. Keyed by the friendly name used as the config map key (e.g.
- * {@code github}, {@code internal-gitlab}), independent of the internal {@code type/host} provider ID used for request
- * routing.
+ * Registry of configured git proxy providers. Keyed by the user-configured name (the YAML config map key, e.g.
+ * {@code github}, {@code internal-gitlab}), which is also the canonical provider ID stored in the database.
  *
  * <p>Consistent with {@link UrlRuleRegistry} — a lookup/discovery mechanism, not a CRUD store.
  */
@@ -23,21 +22,13 @@ public interface ProviderRegistry {
     List<GitProxyProvider> getProviders();
 
     /**
-     * Resolves a provider by either its friendly name (e.g. {@code "github"}) or its canonical {@code type/host} ID
-     * (e.g. {@code "github/github.com"}). Friendly name is tried first.
+     * Resolves a provider by its name (the YAML config map key, e.g. {@code "github"}). Null/blank input returns null
+     * (meaning "applies to all providers").
      *
-     * <p>This is the entry point for validating config references in {@code permissions:}, {@code rules:}, and
-     * {@code scm-identities:} — both forms are accepted so operators can use whichever is more readable.
-     *
-     * @return the provider, or {@code null} if neither a friendly name nor an ID match
+     * @return the provider, or {@code null} if not found
      */
     default GitProxyProvider resolveProvider(String nameOrId) {
         if (nameOrId == null || nameOrId.isBlank()) return null;
-        GitProxyProvider byName = getProvider(nameOrId);
-        if (byName != null) return byName;
-        return getProviders().stream()
-                .filter(p -> p.getProviderId().equals(nameOrId))
-                .findFirst()
-                .orElse(null);
+        return getProvider(nameOrId);
     }
 }

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/db/PushRecordMapperTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/db/PushRecordMapperTest.java
@@ -127,7 +127,7 @@ class PushRecordMapperTest {
         when(provider.getName()).thenReturn("github");
         when(provider.getType()).thenReturn("github");
         when(provider.getUri()).thenReturn(URI.create("https://github.com/"));
-        when(provider.getProviderId()).thenReturn("github/github.com");
+        when(provider.getProviderId()).thenReturn("github");
 
         GitRequestDetails details = new GitRequestDetails();
         details.setRepoRef(

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/ApprovalPreReceiveHookTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/ApprovalPreReceiveHookTest.java
@@ -175,14 +175,13 @@ class ApprovalPreReceiveHookTest {
                 .id(recordId)
                 .status(PushStatus.APPROVED)
                 .resolvedUser("alice")
-                .provider("github/github.com")
+                .provider("github")
                 .url("/owner/repo")
                 .attestation(att)
                 .build();
         when(pushStore.findById(recordId)).thenReturn(Optional.of(record));
         RepoPermissionService perms = mock(RepoPermissionService.class);
-        when(perms.isBypassReviewAllowed("alice", "github/github.com", "/owner/repo"))
-                .thenReturn(false);
+        when(perms.isBypassReviewAllowed("alice", "github", "/owner/repo")).thenReturn(false);
 
         RevCommit c1 = createCommit("init");
         RevCommit c2 = createCommit("second");
@@ -193,7 +192,7 @@ class ApprovalPreReceiveHookTest {
                 .onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.REJECTED_OTHER_REASON, cmd.getResult());
-        verify(perms).isBypassReviewAllowed("alice", "github/github.com", "/owner/repo");
+        verify(perms).isBypassReviewAllowed("alice", "github", "/owner/repo");
     }
 
     @Test
@@ -210,14 +209,13 @@ class ApprovalPreReceiveHookTest {
                 .id(recordId)
                 .status(PushStatus.APPROVED)
                 .resolvedUser("alice")
-                .provider("github/github.com")
+                .provider("github")
                 .url("/owner/repo")
                 .attestation(att)
                 .build();
         when(pushStore.findById(recordId)).thenReturn(Optional.of(record));
         RepoPermissionService perms = mock(RepoPermissionService.class);
-        when(perms.isBypassReviewAllowed("alice", "github/github.com", "/owner/repo"))
-                .thenReturn(true);
+        when(perms.isBypassReviewAllowed("alice", "github", "/owner/repo")).thenReturn(true);
 
         RevCommit c1 = createCommit("init");
         RevCommit c2 = createCommit("second");
@@ -241,7 +239,7 @@ class ApprovalPreReceiveHookTest {
                 .id(recordId)
                 .status(PushStatus.PENDING)
                 .resolvedUser("alice")
-                .provider("github/github.com")
+                .provider("github")
                 .url("/owner/repo")
                 .build();
         Attestation att = Attestation.builder()
@@ -253,7 +251,7 @@ class ApprovalPreReceiveHookTest {
                 .id(recordId)
                 .status(PushStatus.APPROVED)
                 .resolvedUser("alice")
-                .provider("github/github.com")
+                .provider("github")
                 .url("/owner/repo")
                 .attestation(att)
                 .build();
@@ -261,8 +259,7 @@ class ApprovalPreReceiveHookTest {
         when(approvalGateway.waitForApproval(eq(recordId), any(), any(Duration.class)))
                 .thenReturn(ApprovalResult.APPROVED);
         RepoPermissionService perms = mock(RepoPermissionService.class);
-        when(perms.isBypassReviewAllowed("alice", "github/github.com", "/owner/repo"))
-                .thenReturn(false);
+        when(perms.isBypassReviewAllowed("alice", "github", "/owner/repo")).thenReturn(false);
 
         RevCommit c1 = createCommit("init");
         RevCommit c2 = createCommit("second");
@@ -273,7 +270,7 @@ class ApprovalPreReceiveHookTest {
                 .onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.REJECTED_OTHER_REASON, cmd.getResult());
-        verify(perms).isBypassReviewAllowed("alice", "github/github.com", "/owner/repo");
+        verify(perms).isBypassReviewAllowed("alice", "github", "/owner/repo");
     }
 
     @Test
@@ -291,7 +288,7 @@ class ApprovalPreReceiveHookTest {
                 .id(recordId)
                 .status(PushStatus.APPROVED)
                 .resolvedUser("alice")
-                .provider("github/github.com")
+                .provider("github")
                 .url("/owner/repo")
                 .attestation(att)
                 .build();

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/CheckUserPushPermissionHookTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/CheckUserPushPermissionHookTest.java
@@ -123,8 +123,7 @@ class CheckUserPushPermissionHookTest {
     void userNotAuthorized_addsUnauthorizedIssue() throws Exception {
         GitProxyProvider github = new GitHubProvider("/push");
         when(resolver.resolve(eq(github), eq("corp-user"), any())).thenReturn(Optional.of(userEntry("alice")));
-        when(permService.isAllowedToPush("alice", "github/github.com", "/owner/repo"))
-                .thenReturn(false);
+        when(permService.isAllowedToPush("alice", "github", "/owner/repo")).thenReturn(false);
 
         RevCommit c1 = createCommit("init");
         RevCommit c2 = createCommit("second");
@@ -154,8 +153,7 @@ class CheckUserPushPermissionHookTest {
         GitProxyProvider github = new GitHubProvider("/push");
         when(resolver.resolve(eq(github), eq("corp-user"), eq("ghp_secret")))
                 .thenReturn(Optional.of(userEntry("alice")));
-        when(permService.isAllowedToPush("alice", "github/github.com", "/owner/repo"))
-                .thenReturn(true);
+        when(permService.isAllowedToPush("alice", "github", "/owner/repo")).thenReturn(true);
 
         RevCommit c1 = createCommit("init");
         RevCommit c2 = createCommit("second");
@@ -201,8 +199,7 @@ class CheckUserPushPermissionHookTest {
     void provider_isPassedToResolver() throws Exception {
         GitProxyProvider github = new GitHubProvider("/push");
         when(resolver.resolve(eq(github), eq("my-user"), any())).thenReturn(Optional.of(userEntry("my-user")));
-        when(permService.isAllowedToPush("my-user", "github/github.com", "/owner/repo"))
-                .thenReturn(true);
+        when(permService.isAllowedToPush("my-user", "github", "/owner/repo")).thenReturn(true);
 
         RevCommit c1 = createCommit("init");
         RevCommit c2 = createCommit("second");

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/provider/ProviderTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/provider/ProviderTest.java
@@ -165,17 +165,9 @@ class ProviderTest {
     }
 
     @Test
-    void registry_resolveProvider_byTypeHostId() {
-        var github = new GitHubProvider("/proxy");
-        var registry = new InMemoryProviderRegistry(Map.of("github", github));
-        // "github/github.com" is the canonical type/host ID
-        assertSame(github, registry.resolveProvider("github/github.com"));
-    }
-
-    @Test
     void registry_resolveProvider_unknown_returnsNull() {
         var registry = new InMemoryProviderRegistry(Map.of());
-        assertNull(registry.resolveProvider("nonexistent/host.example.com"));
+        assertNull(registry.resolveProvider("nonexistent"));
     }
 
     @Test

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/service/CachingTokenPushIdentityResolverTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/service/CachingTokenPushIdentityResolverTest.java
@@ -31,7 +31,7 @@ class CachingTokenPushIdentityResolverTest {
         when(provider.getName()).thenReturn("github");
         when(provider.getType()).thenReturn("github");
         when(provider.getUri()).thenReturn(URI.create("https://github.com"));
-        when(provider.getProviderId()).thenReturn("github/github.com");
+        when(provider.getProviderId()).thenReturn("github");
         resolver = new CachingTokenPushIdentityResolver(delegate, cache, userStore);
     }
 
@@ -51,7 +51,7 @@ class CachingTokenPushIdentityResolverTest {
     @Test
     void cacheHit_returnsCachedUser_delegateNotCalled() {
         UserEntry alice = entry("alice");
-        when(cache.lookup(eq("github/github.com"), anyString())).thenReturn(Optional.of("alice"));
+        when(cache.lookup(eq("github"), anyString())).thenReturn(Optional.of("alice"));
         when(userStore.findByUsername("alice")).thenReturn(Optional.of(alice));
 
         var result = resolver.resolve(provider, "me", "good-token");
@@ -67,14 +67,14 @@ class CachingTokenPushIdentityResolverTest {
     @Test
     void cacheMiss_delegateResolves_storesAndReturns() {
         UserEntry alice = entry("alice");
-        when(cache.lookup(eq("github/github.com"), anyString())).thenReturn(Optional.empty());
+        when(cache.lookup(eq("github"), anyString())).thenReturn(Optional.empty());
         when(delegate.resolve(provider, "me", "good-token")).thenReturn(Optional.of(alice));
 
         var result = resolver.resolve(provider, "me", "good-token");
 
         assertTrue(result.isPresent());
         assertEquals("alice", result.get().getUsername());
-        verify(cache).store(eq("github/github.com"), anyString(), eq("alice"));
+        verify(cache).store(eq("github"), anyString(), eq("alice"));
         verifyNoMoreInteractions(userStore);
     }
 
@@ -82,7 +82,7 @@ class CachingTokenPushIdentityResolverTest {
 
     @Test
     void cacheMiss_delegateEmpty_nothingStored() {
-        when(cache.lookup(eq("github/github.com"), anyString())).thenReturn(Optional.empty());
+        when(cache.lookup(eq("github"), anyString())).thenReturn(Optional.empty());
         when(delegate.resolve(provider, "me", "bad-token")).thenReturn(Optional.empty());
 
         var result = resolver.resolve(provider, "me", "bad-token");
@@ -95,7 +95,7 @@ class CachingTokenPushIdentityResolverTest {
 
     @Test
     void sameToken_lookupCalledWithSameHash() {
-        when(cache.lookup(eq("github/github.com"), anyString())).thenReturn(Optional.empty());
+        when(cache.lookup(eq("github"), anyString())).thenReturn(Optional.empty());
         when(delegate.resolve(any(), any(), any())).thenReturn(Optional.empty());
 
         resolver.resolve(provider, "me", "my-token");
@@ -103,7 +103,7 @@ class CachingTokenPushIdentityResolverTest {
 
         // Capture both hash arguments and assert they are equal
         var captor = org.mockito.ArgumentCaptor.forClass(String.class);
-        verify(cache, times(2)).lookup(eq("github/github.com"), captor.capture());
+        verify(cache, times(2)).lookup(eq("github"), captor.capture());
         assertEquals(captor.getAllValues().get(0), captor.getAllValues().get(1));
     }
 
@@ -111,14 +111,14 @@ class CachingTokenPushIdentityResolverTest {
 
     @Test
     void differentTokens_differentHashes() {
-        when(cache.lookup(eq("github/github.com"), anyString())).thenReturn(Optional.empty());
+        when(cache.lookup(eq("github"), anyString())).thenReturn(Optional.empty());
         when(delegate.resolve(any(), any(), any())).thenReturn(Optional.empty());
 
         resolver.resolve(provider, "me", "token-a");
         resolver.resolve(provider, "me", "token-b");
 
         var captor = org.mockito.ArgumentCaptor.forClass(String.class);
-        verify(cache, times(2)).lookup(eq("github/github.com"), captor.capture());
+        verify(cache, times(2)).lookup(eq("github"), captor.capture());
         assertNotEquals(captor.getAllValues().get(0), captor.getAllValues().get(1));
     }
 

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/service/TokenPushIdentityResolverTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/service/TokenPushIdentityResolverTest.java
@@ -37,7 +37,7 @@ class TokenPushIdentityResolverTest {
         when(provider.getName()).thenReturn("github");
         when(provider.getType()).thenReturn("github");
         when(provider.getUri()).thenReturn(URI.create("https://github.com"));
-        when(provider.getProviderId()).thenReturn("github/github.com");
+        when(provider.getProviderId()).thenReturn("github");
         resolver = new TokenPushIdentityResolver(store);
     }
 
@@ -92,13 +92,13 @@ class TokenPushIdentityResolverTest {
         UserEntry alice = entry("alice", "alice@example.com");
         when(provider.fetchScmIdentity(anyString(), eq("good-token")))
                 .thenReturn(Optional.of(new ScmUserInfo("alice-gh", Optional.empty())));
-        when(store.findByScmIdentity("github/github.com", "alice-gh")).thenReturn(Optional.of(alice));
+        when(store.findByScmIdentity("github", "alice-gh")).thenReturn(Optional.of(alice));
 
         var result = resolver.resolve(provider, "me", "good-token");
 
         assertTrue(result.isPresent());
         assertEquals("alice", result.get().getUsername());
-        verify(store).findByScmIdentity("github/github.com", "alice-gh");
+        verify(store).findByScmIdentity("github", "alice-gh");
         verify(store, never()).findByEmail(any());
     }
 
@@ -109,14 +109,14 @@ class TokenPushIdentityResolverTest {
         UserEntry alice = entry("alice", "alice@example.com");
         when(provider.fetchScmIdentity(anyString(), anyString()))
                 .thenReturn(Optional.of(new ScmUserInfo("alice-gh", Optional.of("alice@example.com"))));
-        when(store.findByScmIdentity("github/github.com", "alice-gh")).thenReturn(Optional.empty());
+        when(store.findByScmIdentity("github", "alice-gh")).thenReturn(Optional.empty());
         when(store.findByEmail("alice@example.com")).thenReturn(Optional.of(alice));
 
         var result = resolver.resolve(provider, "me", "token");
 
         assertTrue(result.isPresent());
         assertEquals("alice", result.get().getUsername());
-        verify(store).findByScmIdentity("github/github.com", "alice-gh");
+        verify(store).findByScmIdentity("github", "alice-gh");
         verify(store).findByEmail("alice@example.com");
     }
 
@@ -126,7 +126,7 @@ class TokenPushIdentityResolverTest {
     void bothLookupsMiss_returnsEmpty() {
         when(provider.fetchScmIdentity(anyString(), anyString()))
                 .thenReturn(Optional.of(new ScmUserInfo("unknown-gh", Optional.of("unknown@example.com"))));
-        when(store.findByScmIdentity("github/github.com", "unknown-gh")).thenReturn(Optional.empty());
+        when(store.findByScmIdentity("github", "unknown-gh")).thenReturn(Optional.empty());
         when(store.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
 
         var result = resolver.resolve(provider, "me", "token");
@@ -140,7 +140,7 @@ class TokenPushIdentityResolverTest {
     void noEmailInScmInfo_scmIdentityMiss_returnsEmpty() {
         when(provider.fetchScmIdentity(anyString(), anyString()))
                 .thenReturn(Optional.of(new ScmUserInfo("nobody-gh", Optional.empty())));
-        when(store.findByScmIdentity("github/github.com", "nobody-gh")).thenReturn(Optional.empty());
+        when(store.findByScmIdentity("github", "nobody-gh")).thenReturn(Optional.empty());
 
         var result = resolver.resolve(provider, "me", "token");
 

--- a/git-proxy-java-dashboard/frontend/src/api.ts
+++ b/git-proxy-java-dashboard/frontend/src/api.ts
@@ -1,12 +1,3 @@
-/**
- * Provider IDs are internally `{type}/{host}` (e.g. `github/github.com`). The `/` breaks URL path
- * routing — Spring Security's StrictHttpFirewall rejects `%2F` with HTTP 400. Swap `/` for `@` on
- * the wire; the controller swaps it back before touching the store.
- */
-function providerToPathKey(provider: string): string {
-  return provider.replace(/\//g, '@')
-}
-
 /** Reads the XSRF-TOKEN cookie set by Spring Security's CookieCsrfTokenRepository. */
 function getCsrfToken(): string | null {
   const match = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]+)/)
@@ -165,7 +156,7 @@ export async function addScmIdentity(provider: string, username: string) {
 
 export async function removeScmIdentity(provider: string, scmUsername: string) {
   const res = await apiFetch(
-    `/api/me/identities/${encodeURIComponent(providerToPathKey(provider))}/${encodeURIComponent(scmUsername)}`,
+    `/api/me/identities/${encodeURIComponent(provider)}/${encodeURIComponent(scmUsername)}`,
     { method: 'DELETE' },
   )
   if (!res.ok) await parseErrorResponse(res, 'Failed to remove SCM identity')
@@ -231,7 +222,7 @@ export async function removeUserEmail(username: string, email: string) {
 
 export async function removeUserIdentity(username: string, provider: string, scmUsername: string) {
   const res = await apiFetch(
-    `/api/users/${encodeURIComponent(username)}/identities/${encodeURIComponent(providerToPathKey(provider))}/${encodeURIComponent(scmUsername)}`,
+    `/api/users/${encodeURIComponent(username)}/identities/${encodeURIComponent(provider)}/${encodeURIComponent(scmUsername)}`,
     { method: 'DELETE' },
   )
   if (!res.ok) await parseErrorResponse(res, 'Failed to remove SCM identity')

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/controller/ProfileController.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/controller/ProfileController.java
@@ -113,8 +113,7 @@ public class ProfileController {
     public ResponseEntity<?> removeScmIdentity(@PathVariable String provider, @PathVariable String scmUsername) {
         if (!(userStore instanceof UserStore mutable)) return NOT_MUTABLE;
         try {
-            // Provider IDs are `{type}/{host}`; frontend swaps `/` → `@` to survive URL path routing.
-            mutable.removeScmIdentity(currentUsername(), provider.replace('@', '/'), scmUsername);
+            mutable.removeScmIdentity(currentUsername(), provider, scmUsername);
         } catch (LockedByConfigException e) {
             return LOCKED_BY_CONFIG;
         }

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/controller/RepoController.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/controller/RepoController.java
@@ -90,8 +90,7 @@ public class RepoController {
     }
 
     /**
-     * Returns a 400 response if {@code providerId} is not a configured provider ID, or {@code null} if it is valid.
-     * Provider IDs must be in {@code type/host} format (e.g. {@code "gitea/gitea"}).
+     * Returns a 400 response if {@code providerId} is not a configured provider name, or {@code null} if it is valid.
      */
     private ResponseEntity<?> validateProviderId(String providerId) {
         Set<String> known = providerSource.getProviders().stream()
@@ -99,10 +98,7 @@ public class RepoController {
                 .collect(Collectors.toSet());
         if (!known.contains(providerId)) {
             return ResponseEntity.badRequest()
-                    .body(Map.of(
-                            "error",
-                            "Unknown provider ID '" + providerId + "'. Must be one of: " + known
-                                    + ". Provider IDs are in type/host format (e.g. 'gitea/gitea')."));
+                    .body(Map.of("error", "Unknown provider '" + providerId + "'. Must be one of: " + known));
         }
         return null;
     }

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/controller/UserController.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/controller/UserController.java
@@ -199,8 +199,7 @@ public class UserController {
             return ResponseEntity.notFound().build();
         }
         try {
-            // Provider IDs are `{type}/{host}`; frontend swaps `/` → `@` to survive URL path routing.
-            mutable.removeScmIdentity(username, provider.replace('@', '/'), scmUsername);
+            mutable.removeScmIdentity(username, provider, scmUsername);
         } catch (LockedByConfigException e) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("error", e.getMessage()));
         }

--- a/git-proxy-java-dashboard/src/test/java/org/finos/gitproxy/dashboard/controller/RepoControllerTest.java
+++ b/git-proxy-java-dashboard/src/test/java/org/finos/gitproxy/dashboard/controller/RepoControllerTest.java
@@ -89,10 +89,10 @@ class RepoControllerTest {
     @Test
     void createRule_knownProvider_returns201() {
         var p = mock(GitProxyProvider.class);
-        when(p.getProviderId()).thenReturn("github/github.com");
+        when(p.getProviderId()).thenReturn("github");
         when(providerSource.getProviders()).thenReturn(List.of(p));
 
-        var rule = AccessRule.builder().provider("github/github.com").build();
+        var rule = AccessRule.builder().provider("github").build();
         var resp = controller.createRule(rule);
 
         assertEquals(HttpStatus.CREATED, resp.getStatusCode());
@@ -102,10 +102,10 @@ class RepoControllerTest {
     @Test
     void createRule_unknownProvider_returns400() {
         var p = mock(GitProxyProvider.class);
-        when(p.getProviderId()).thenReturn("github/github.com");
+        when(p.getProviderId()).thenReturn("github");
         when(providerSource.getProviders()).thenReturn(List.of(p));
 
-        var rule = AccessRule.builder().provider("github").build(); // bare name — invalid
+        var rule = AccessRule.builder().provider("nonexistent-provider").build();
         var resp = controller.createRule(rule);
 
         assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());

--- a/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/JettyConfigurationBuilder.java
+++ b/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/JettyConfigurationBuilder.java
@@ -141,7 +141,6 @@ public class JettyConfigurationBuilder {
     public List<GitProxyProvider> buildProviders() {
         if (cachedProviders != null) return cachedProviders;
         List<GitProxyProvider> providers = new ArrayList<>();
-        Map<String, String> seenProviderIds = new LinkedHashMap<>();
 
         config.getProviders().forEach((name, providerConfig) -> {
             if (!providerConfig.isEnabled()) {
@@ -150,19 +149,8 @@ public class JettyConfigurationBuilder {
             }
             GitProxyProvider provider = createProvider(name, providerConfig);
             if (provider != null) {
-                String existingName = seenProviderIds.put(provider.getProviderId(), provider.getName());
-                if (existingName != null) {
-                    throw new IllegalStateException(String.format(
-                            "Provider ID conflict: '%s' and '%s' both resolve to '%s'. "
-                                    + "Each provider must have a unique type/host combination.",
-                            existingName, provider.getName(), provider.getProviderId()));
-                }
                 providers.add(provider);
-                log.info(
-                        "Configured provider: {} -> {} (id={})",
-                        provider.getName(),
-                        provider.getUri(),
-                        provider.getProviderId());
+                log.info("Configured provider: {} -> {}", provider.getName(), provider.getUri());
             }
         });
 
@@ -174,9 +162,8 @@ public class JettyConfigurationBuilder {
     }
 
     /**
-     * Builds and caches a {@link ProviderRegistry} keyed by each provider's friendly name (the YAML config map key,
-     * e.g. {@code "github"}). The registry's {@link ProviderRegistry#resolveProvider} default method also accepts
-     * canonical {@code type/host} IDs (e.g. {@code "github/github.com"}) for backwards compatibility.
+     * Builds and caches a {@link ProviderRegistry} keyed by each provider's name (the YAML config map key, e.g.
+     * {@code "github"}), which is also the canonical provider ID stored in the database.
      */
     public ProviderRegistry buildProviderRegistry() {
         if (cachedProviderRegistry != null) return cachedProviderRegistry;
@@ -229,22 +216,20 @@ public class JettyConfigurationBuilder {
     }
 
     /**
-     * Resolves a provider reference (either a friendly name like {@code "github"} or a canonical {@code type/host} ID
-     * like {@code "github/github.com"}) to the canonical provider ID. Returns {@code null} for null/blank input
-     * (meaning "applies to all providers"). Throws {@link IllegalStateException} on startup if the reference is unknown
-     * — misconfiguration must be caught early.
+     * Resolves a provider name to the canonical provider ID. Returns {@code null} for null/blank input (meaning
+     * "applies to all providers"). Throws {@link IllegalStateException} on startup if the name is unknown —
+     * misconfiguration must be caught early.
      */
     private String resolveToProviderId(String context, String nameOrId) {
         if (nameOrId == null || nameOrId.isBlank()) return null;
         GitProxyProvider resolved = buildProviderRegistry().resolveProvider(nameOrId);
         if (resolved == null) {
             String known = buildProviderRegistry().getProviders().stream()
-                    .map(p -> "'" + p.getName() + "' (" + p.getProviderId() + ")")
+                    .map(p -> "'" + p.getName() + "'")
                     .collect(Collectors.joining(", "));
             throw new IllegalStateException(String.format(
                     "%s references unknown provider '%s'. "
-                            + "Use the friendly name from providers: config (e.g. 'github') "
-                            + "or the type/host ID (e.g. 'github/github.com'). "
+                            + "Use the provider name from providers: config (e.g. 'github'). "
                             + "Configured providers: %s",
                     context, nameOrId, known));
         }
@@ -268,7 +253,7 @@ public class JettyConfigurationBuilder {
         for (RuleConfig rule : ruleConfigs) {
             if (!rule.isEnabled()) continue;
 
-            // Resolve friendly names / type/host IDs to canonical IDs — validates at startup
+            // Resolve provider names to canonical IDs — validates at startup
             List<String> resolvedProviderIds = rule.getProviders().stream()
                     .map(n -> resolveToProviderId(access.name() + " rule (order=" + rule.getOrder() + ")", n))
                     .toList();

--- a/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/ScmIdentityConfig.java
+++ b/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/ScmIdentityConfig.java
@@ -6,8 +6,8 @@ import lombok.Data;
 @Data
 public class ScmIdentityConfig {
     /**
-     * Provider ID in {@code type/host} format, e.g. {@code github/github.com} or {@code gitlab/gitlab.com}. Must match
-     * the provider ID derived from the configured provider (type + URI host).
+     * Provider name (the YAML config map key, e.g. {@code github} or {@code internal-gitlab}). Must match a configured
+     * provider name.
      */
     private String provider = "";
 

--- a/git-proxy-java-server/src/test/java/org/finos/gitproxy/jetty/config/JettyConfigurationBuilderTest.java
+++ b/git-proxy-java-server/src/test/java/org/finos/gitproxy/jetty/config/JettyConfigurationBuilderTest.java
@@ -10,6 +10,7 @@ import org.finos.gitproxy.db.PushStoreFactory;
 import org.finos.gitproxy.db.model.AccessRule;
 import org.finos.gitproxy.permission.RepoPermission;
 import org.finos.gitproxy.provider.GitHubProvider;
+import org.finos.gitproxy.provider.GitProxyProvider;
 import org.junit.jupiter.api.Test;
 
 class JettyConfigurationBuilderTest {
@@ -95,13 +96,13 @@ class JettyConfigurationBuilderTest {
         // Lookup by friendly name
         assertNotNull(registry.getProvider("github"));
         assertInstanceOf(GitHubProvider.class, registry.getProvider("github"));
-        // Lookup by type/host ID via resolveProvider
-        assertNotNull(registry.resolveProvider("github/github.com"));
-        assertSame(registry.getProvider("github"), registry.resolveProvider("github/github.com"));
+        // Lookup by name via resolveProvider
+        assertNotNull(registry.resolveProvider("github"));
+        assertSame(registry.getProvider("github"), registry.resolveProvider("github"));
         // Friendly name and ID resolve to same provider
         assertEquals(
                 registry.resolveProvider("github").getProviderId(),
-                registry.resolveProvider("github/github.com").getProviderId());
+                registry.resolveProvider("github").getProviderId());
     }
 
     // ---- buildConfigPermissions — friendly name resolution (#127) ----
@@ -118,24 +119,9 @@ class JettyConfigurationBuilderTest {
         List<RepoPermission> perms = new JettyConfigurationBuilder(config).buildConfigPermissions(config);
 
         assertEquals(1, perms.size());
-        // Friendly name must be resolved to the canonical type/host ID
-        assertEquals("github/github.com", perms.get(0).getProvider());
+        // Name is both the friendly form and the canonical ID
+        assertEquals("github", perms.get(0).getProvider());
         assertEquals("alice", perms.get(0).getUsername());
-    }
-
-    @Test
-    void buildConfigPermissions_typeHostId_backwardsCompat() {
-        var config = configWithGithub();
-        var permission = new PermissionConfig();
-        permission.setUsername("bob");
-        permission.setProvider("github/github.com"); // legacy type/host form
-        permission.setPath("/org/repo");
-        config.setPermissions(List.of(permission));
-
-        List<RepoPermission> perms = new JettyConfigurationBuilder(config).buildConfigPermissions(config);
-
-        assertEquals(1, perms.size());
-        assertEquals("github/github.com", perms.get(0).getProvider());
     }
 
     @Test
@@ -150,9 +136,7 @@ class JettyConfigurationBuilderTest {
         var builder = new JettyConfigurationBuilder(config);
         var ex = assertThrows(IllegalStateException.class, () -> builder.buildConfigPermissions(config));
         assertTrue(ex.getMessage().contains("nonexistent"), "error should name the unknown provider");
-        assertTrue(
-                ex.getMessage().contains("github") || ex.getMessage().contains("github/github.com"),
-                "error should list configured providers");
+        assertTrue(ex.getMessage().contains("github"), "error should list configured providers");
     }
 
     // ---- buildConfigRules — friendly name resolution (#127) ----
@@ -169,7 +153,7 @@ class JettyConfigurationBuilderTest {
 
         assertFalse(rules.isEmpty());
         // Provider field in AccessRule must be the canonical type/host ID for evaluator to work
-        assertEquals("github/github.com", rules.get(0).getProvider());
+        assertEquals("github", rules.get(0).getProvider());
     }
 
     @Test
@@ -227,6 +211,52 @@ class JettyConfigurationBuilderTest {
                 "rule scoped to 'github' should not produce a rule for the GitLab provider");
     }
 
+    // ---- multi-provider: same type, different hostnames ----
+
+    @Test
+    void twoProvidersOfSameType_differentNames_haveDistinctProviderIds() {
+        var config = configWithTwoGitHubProviders();
+        var builder = new JettyConfigurationBuilder(config);
+        var providers = builder.buildProviders();
+
+        assertEquals(2, providers.size());
+        var ids = providers.stream().map(GitProxyProvider::getProviderId).toList();
+        assertTrue(ids.contains("github"), "public GitHub should have id 'github'");
+        assertTrue(ids.contains("internal-github"), "internal GHES should have id 'internal-github'");
+        assertNotEquals(
+                providers.get(0).getProviderId(),
+                providers.get(1).getProviderId(),
+                "two providers of the same type must have distinct IDs");
+    }
+
+    @Test
+    void twoProvidersOfSameType_permissionsAreKeptSeparate() {
+        var config = configWithTwoGitHubProviders();
+        var publicPerm = new PermissionConfig();
+        publicPerm.setUsername("alice");
+        publicPerm.setProvider("github");
+        publicPerm.setPath("/org/public-repo");
+        var internalPerm = new PermissionConfig();
+        internalPerm.setUsername("bob");
+        internalPerm.setProvider("internal-github");
+        internalPerm.setPath("/corp/internal-repo");
+        config.setPermissions(List.of(publicPerm, internalPerm));
+
+        var perms = new JettyConfigurationBuilder(config).buildConfigPermissions(config);
+
+        assertEquals(2, perms.size());
+        var alicePerm = perms.stream()
+                .filter(p -> "alice".equals(p.getUsername()))
+                .findFirst()
+                .orElseThrow();
+        var bobPerm = perms.stream()
+                .filter(p -> "bob".equals(p.getUsername()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("github", alicePerm.getProvider());
+        assertEquals("internal-github", bobPerm.getProvider());
+    }
+
     // ---- helpers ----
 
     private static GitProxyConfig configWithApprovalMode(String mode) {
@@ -250,6 +280,18 @@ class JettyConfigurationBuilderTest {
         var gitlab = new ProviderConfig();
         gitlab.setEnabled(true);
         config.setProviders(Map.of("github", github, "gitlab", gitlab));
+        return config;
+    }
+
+    private static GitProxyConfig configWithTwoGitHubProviders() {
+        var config = new GitProxyConfig();
+        var publicGitHub = new ProviderConfig();
+        publicGitHub.setEnabled(true);
+        var internalGitHub = new ProviderConfig();
+        internalGitHub.setEnabled(true);
+        internalGitHub.setType("github");
+        internalGitHub.setUri("https://github.internal.example.com");
+        config.setProviders(Map.of("github", publicGitHub, "internal-github", internalGitHub));
         return config;
     }
 }

--- a/scripts/migrate-provider-ids.sql
+++ b/scripts/migrate-provider-ids.sql
@@ -1,0 +1,36 @@
+-- One-time data fixup: rename provider column values from `type/host` to `name`.
+--
+-- Run this against your database before deploying the new version.
+-- Replace 'old_value' and 'new_value' with the actual mappings for your deployment.
+--
+-- To find what values are currently stored, run:
+--   SELECT DISTINCT provider FROM user_scm_identities;
+--   SELECT DISTINCT provider FROM repo_permissions;
+--   SELECT DISTINCT provider FROM access_rules WHERE provider IS NOT NULL;
+--   SELECT DISTINCT provider FROM push_records;
+--   SELECT DISTINCT provider FROM fetch_records;
+--   SELECT DISTINCT provider FROM scm_token_cache;
+--
+-- Example: rename 'github/github.com' -> 'github'
+--   Replace 'github/github.com' with 'github' in the statements below.
+
+-- user_scm_identities has a composite PK that includes provider, so rows must be
+-- inserted with the new key and old rows deleted (UPDATE would violate the PK constraint).
+INSERT INTO user_scm_identities (username, provider, scm_username, verified, source)
+    SELECT username, 'new_value', scm_username, verified, source
+    FROM user_scm_identities
+    WHERE provider = 'old_value';
+DELETE FROM user_scm_identities WHERE provider = 'old_value';
+
+-- scm_token_cache also has a composite PK including provider
+INSERT INTO scm_token_cache (token_hash, provider, username, cached_at, expires_at)
+    SELECT token_hash, 'new_value', username, cached_at, expires_at
+    FROM scm_token_cache
+    WHERE provider = 'old_value';
+DELETE FROM scm_token_cache WHERE provider = 'old_value';
+
+-- Simple UPDATE for tables where provider is not part of the PK
+UPDATE repo_permissions  SET provider = 'new_value' WHERE provider = 'old_value';
+UPDATE access_rules      SET provider = 'new_value' WHERE provider = 'old_value';
+UPDATE push_records      SET provider = 'new_value' WHERE provider = 'old_value';
+UPDATE fetch_records     SET provider = 'new_value' WHERE provider = 'old_value';


### PR DESCRIPTION
closes #188

## Summary

**Provider FK refactor:**
- `GitProxyProvider.getProviderId()` now returns `getName()` instead of `type/host`
- `ProviderRegistry.resolveProvider()` simplified — `type/host` fallback removed
- `JettyConfigurationBuilder`: removed redundant duplicate-detection map, updated error messages
- `ProfileController` + `UserController`: removed the `provider.replace('@', '/')` decode hack
- `api.ts`: removed `providerToPathKey` and its call sites — provider names are safe in URL path segments
- New tests: two-provider same-type scenario (`github` + `internal-github` sharing `type=github` with different hostnames)

**Container scan fixes (both workflows):**
- Pre-install our checksum-verified grype binary before `anchore/scan-action` runs — drops `grype-version` so scan-action uses the PATH binary instead of downloading grype's `install.sh` from main (which constructs invalid release tag URLs and 404s)
- Bumped grype to 0.112.0 in both `container-scan.yml` and `docker-publish.yml`
- `docker-publish.yml`: removed the broken `find /opt/hostedtoolcache/grype` step that was silently failing

## Data migration (run before deploying)

The following SQL renames existing `type/host` values to provider names. Adjust pairs to match your `git-proxy.yml`.

**To find what's currently stored:**
```sql
SELECT DISTINCT provider FROM push_records;
SELECT DISTINCT provider FROM user_scm_identities;
```

**For a standard single-GitHub deployment (`github/github.com` → `github`):**

```sql
-- user_scm_identities and scm_token_cache have composite PKs that include provider,
-- so they need insert+delete rather than a plain UPDATE.

INSERT INTO user_scm_identities (username, provider, scm_username, verified, source)
    SELECT username, 'github', scm_username, verified, source
    FROM user_scm_identities WHERE provider = 'github/github.com';
DELETE FROM user_scm_identities WHERE provider = 'github/github.com';

INSERT INTO scm_token_cache (token_hash, provider, username, cached_at, expires_at)
    SELECT token_hash, 'github', username, cached_at, expires_at
    FROM scm_token_cache WHERE provider = 'github/github.com';
DELETE FROM scm_token_cache WHERE provider = 'github/github.com';

UPDATE repo_permissions  SET provider = 'github' WHERE provider = 'github/github.com';
UPDATE access_rules      SET provider = 'github' WHERE provider = 'github/github.com';
UPDATE push_records      SET provider = 'github' WHERE provider = 'github/github.com';
UPDATE fetch_records     SET provider = 'github' WHERE provider = 'github/github.com';
```

For additional providers repeat the block with the appropriate pair (e.g. `gitlab/gitlab.com` → `gitlab`). A parameterised template is in `scripts/migrate-provider-ids.sql`.

## Test plan

- [ ] All unit tests pass (`./gradlew test`)
- [ ] Run data migration SQL against DB before starting new version
- [ ] Push through proxy; confirm `push_records.provider` shows `github` (not `github/github.com`)
- [ ] Add/remove SCM identity on profile page; confirm no `@` encoding in URL
- [ ] Container scan passes on tag push; confirm `latest` is only updated after scan clears