### PR TITLE
refactor: provider registry name cleanup + Optional return types

### DIFF
--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/provider/InMemoryProviderRegistry.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/provider/InMemoryProviderRegistry.java
@@ -4,15 +4,16 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.ToString;
 
-/** In-memory {@link ProviderRegistry} backed by a {@link LinkedHashMap} keyed by friendly provider name. */
+/** In-memory {@link ProviderRegistry} backed by a {@link LinkedHashMap} keyed by provider name. */
 @ToString
 public class InMemoryProviderRegistry implements ProviderRegistry {
 
     private final Map<String, GitProxyProvider> providers;
 
-    /** Construct from a map of friendly name → provider. Insertion order is preserved. */
+    /** Construct from a name → provider map. Insertion order is preserved. */
     public InMemoryProviderRegistry(Map<String, GitProxyProvider> providers) {
         this.providers = new LinkedHashMap<>(providers);
     }
@@ -26,8 +27,8 @@ public class InMemoryProviderRegistry implements ProviderRegistry {
     }
 
     @Override
-    public GitProxyProvider getProvider(String name) {
-        return providers.get(name);
+    public Optional<GitProxyProvider> getProvider(String name) {
+        return Optional.ofNullable(providers.get(name));
     }
 
     @Override

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/provider/ProviderRegistry.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/provider/ProviderRegistry.java
@@ -1,6 +1,7 @@
 package org.finos.gitproxy.provider;
 
 import java.util.List;
+import java.util.Optional;
 import org.finos.gitproxy.db.UrlRuleRegistry;
 
 /**
@@ -12,23 +13,21 @@ import org.finos.gitproxy.db.UrlRuleRegistry;
 public interface ProviderRegistry {
 
     /**
-     * Look up a provider by its friendly name (the YAML map key, e.g. {@code "github"}).
+     * Look up a provider by name (the YAML map key, e.g. {@code "github"}).
      *
-     * @return the provider, or {@code null} if not found
+     * @return the provider, or {@link Optional#empty()} if not found
      */
-    GitProxyProvider getProvider(String name);
+    Optional<GitProxyProvider> getProvider(String name);
 
     /** Returns all registered providers. */
     List<GitProxyProvider> getProviders();
 
     /**
-     * Resolves a provider by its name (the YAML config map key, e.g. {@code "github"}). Null/blank input returns null
-     * (meaning "applies to all providers").
+     * Resolves a provider by name (the YAML config map key, e.g. {@code "github"}).
      *
-     * @return the provider, or {@code null} if not found
+     * @return the provider, or {@link Optional#empty()} if not found
      */
-    default GitProxyProvider resolveProvider(String nameOrId) {
-        if (nameOrId == null || nameOrId.isBlank()) return null;
-        return getProvider(nameOrId);
+    default Optional<GitProxyProvider> resolveProvider(String name) {
+        return getProvider(name);
     }
 }

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/provider/ProviderTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/provider/ProviderTest.java
@@ -124,13 +124,13 @@ class ProviderTest {
     void registry_fromMap_getByFriendlyName() {
         var github = new GitHubProvider("/proxy");
         var registry = new InMemoryProviderRegistry(Map.of("github", github));
-        assertSame(github, registry.getProvider("github"));
+        assertSame(github, registry.getProvider("github").orElseThrow());
     }
 
     @Test
-    void registry_fromMap_unknownName_returnsNull() {
+    void registry_fromMap_unknownName_returnsEmpty() {
         var registry = new InMemoryProviderRegistry(Map.of());
-        assertNull(registry.getProvider("unknown"));
+        assertTrue(registry.getProvider("unknown").isEmpty());
     }
 
     @Test
@@ -138,8 +138,8 @@ class ProviderTest {
         var github = new GitHubProvider("/proxy");
         var gitlab = new GitLabProvider("/proxy");
         var registry = new InMemoryProviderRegistry(List.of(github, gitlab));
-        assertSame(github, registry.getProvider("github"));
-        assertSame(gitlab, registry.getProvider("gitlab"));
+        assertSame(github, registry.getProvider("github").orElseThrow());
+        assertSame(gitlab, registry.getProvider("gitlab").orElseThrow());
     }
 
     @Test
@@ -158,21 +158,21 @@ class ProviderTest {
     }
 
     @Test
-    void registry_resolveProvider_byFriendlyName() {
+    void registry_resolveProvider_byName() {
         var github = new GitHubProvider("/proxy");
         var registry = new InMemoryProviderRegistry(Map.of("github", github));
-        assertSame(github, registry.resolveProvider("github"));
+        assertSame(github, registry.resolveProvider("github").orElseThrow());
     }
 
     @Test
-    void registry_resolveProvider_unknown_returnsNull() {
+    void registry_resolveProvider_unknown_returnsEmpty() {
         var registry = new InMemoryProviderRegistry(Map.of());
-        assertNull(registry.resolveProvider("nonexistent"));
+        assertTrue(registry.resolveProvider("nonexistent").isEmpty());
     }
 
     @Test
-    void registry_resolveProvider_null_returnsNull() {
+    void registry_resolveProvider_null_returnsEmpty() {
         var registry = new InMemoryProviderRegistry(Map.of());
-        assertNull(registry.resolveProvider(null));
+        assertTrue(registry.resolveProvider(null).isEmpty());
     }
 }

--- a/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/JettyConfigurationBuilder.java
+++ b/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/JettyConfigurationBuilder.java
@@ -161,10 +161,7 @@ public class JettyConfigurationBuilder {
         return cachedProviders;
     }
 
-    /**
-     * Builds and caches a {@link ProviderRegistry} keyed by each provider's name (the YAML config map key, e.g.
-     * {@code "github"}), which is also the canonical provider ID stored in the database.
-     */
+    /** Builds and caches a {@link ProviderRegistry} keyed by provider name. */
     public ProviderRegistry buildProviderRegistry() {
         if (cachedProviderRegistry != null) return cachedProviderRegistry;
         Map<String, GitProxyProvider> byName = new LinkedHashMap<>();
@@ -190,22 +187,22 @@ public class JettyConfigurationBuilder {
         config.getUsers()
                 .forEach(uc -> uc.getScmIdentities().forEach(s -> {
                     if (!"proxy".equals(s.getProvider())) {
-                        resolveToProviderId("User '" + uc.getUsername() + "' scm-identity", s.getProvider());
+                        resolveProviderName("User '" + uc.getUsername() + "' scm-identity", s.getProvider());
                     }
                 }));
 
         config.getPermissions()
-                .forEach(p -> resolveToProviderId("Permission for user '" + p.getUsername() + "'", p.getProvider()));
+                .forEach(p -> resolveProviderName("Permission for user '" + p.getUsername() + "'", p.getProvider()));
 
         config.getRules()
                 .getAllow()
                 .forEach(rule -> rule.getProviders()
-                        .forEach(pid -> resolveToProviderId("ALLOW rule (order=" + rule.getOrder() + ")", pid)));
+                        .forEach(pid -> resolveProviderName("ALLOW rule (order=" + rule.getOrder() + ")", pid)));
 
         config.getRules()
                 .getDeny()
                 .forEach(rule -> rule.getProviders()
-                        .forEach(pid -> resolveToProviderId("DENY rule (order=" + rule.getOrder() + ")", pid)));
+                        .forEach(pid -> resolveProviderName("DENY rule (order=" + rule.getOrder() + ")", pid)));
 
         log.debug(
                 "Provider reference validation passed ({} users, {} permissions, {} allow rules, {} deny rules)",
@@ -216,24 +213,25 @@ public class JettyConfigurationBuilder {
     }
 
     /**
-     * Resolves a provider name to the canonical provider ID. Returns {@code null} for null/blank input (meaning
-     * "applies to all providers"). Throws {@link IllegalStateException} on startup if the name is unknown —
+     * Validates that {@code name} refers to a configured provider and returns it. Returns {@code null} for null/blank
+     * input (meaning "applies to all providers"). Throws {@link IllegalStateException} on startup if unknown —
      * misconfiguration must be caught early.
      */
-    private String resolveToProviderId(String context, String nameOrId) {
-        if (nameOrId == null || nameOrId.isBlank()) return null;
-        GitProxyProvider resolved = buildProviderRegistry().resolveProvider(nameOrId);
-        if (resolved == null) {
-            String known = buildProviderRegistry().getProviders().stream()
-                    .map(p -> "'" + p.getName() + "'")
-                    .collect(Collectors.joining(", "));
-            throw new IllegalStateException(String.format(
-                    "%s references unknown provider '%s'. "
-                            + "Use the provider name from providers: config (e.g. 'github'). "
-                            + "Configured providers: %s",
-                    context, nameOrId, known));
-        }
-        return resolved.getProviderId();
+    private String resolveProviderName(String context, String name) {
+        if (name == null || name.isBlank()) return null;
+        return buildProviderRegistry()
+                .resolveProvider(name)
+                .orElseThrow(() -> {
+                    String known = buildProviderRegistry().getProviders().stream()
+                            .map(p -> "'" + p.getName() + "'")
+                            .collect(Collectors.joining(", "));
+                    return new IllegalStateException(String.format(
+                            "%s references unknown provider '%s'. "
+                                    + "Use the provider name from providers: config (e.g. 'github'). "
+                                    + "Configured providers: %s",
+                            context, name, known));
+                })
+                .getName();
     }
 
     /**
@@ -253,9 +251,9 @@ public class JettyConfigurationBuilder {
         for (RuleConfig rule : ruleConfigs) {
             if (!rule.isEnabled()) continue;
 
-            // Resolve provider names to canonical IDs — validates at startup
+            // Validate provider names and resolve to stored IDs — validates at startup
             List<String> resolvedProviderIds = rule.getProviders().stream()
-                    .map(n -> resolveToProviderId(access.name() + " rule (order=" + rule.getOrder() + ")", n))
+                    .map(n -> resolveProviderName(access.name() + " rule (order=" + rule.getOrder() + ")", n))
                     .toList();
             // null provider = applies to all providers; specific IDs = scoped
             List<String> providerScopes =
@@ -553,7 +551,7 @@ public class JettyConfigurationBuilder {
         return cfg.getPermissions().stream()
                 .map(p -> {
                     String resolvedId =
-                            resolveToProviderId("Permission for user '" + p.getUsername() + "'", p.getProvider());
+                            resolveProviderName("Permission for user '" + p.getUsername() + "'", p.getProvider());
                     return RepoPermission.builder()
                             .username(p.getUsername())
                             .provider(resolvedId)
@@ -615,7 +613,7 @@ public class JettyConfigurationBuilder {
             for (String rawProvider : rawProviders) {
                 // null → applies to all providers (no resolution needed)
                 String resolvedId =
-                        resolveToProviderId(access.name() + " rule (order=" + rule.getOrder() + ")", rawProvider);
+                        resolveProviderName(access.name() + " rule (order=" + rule.getOrder() + ")", rawProvider);
                 for (String rawSlug : rule.getSlugs()) {
                     String slug = rawSlug.startsWith("/") ? rawSlug : "/" + rawSlug;
                     result.add(AccessRule.builder()
@@ -671,7 +669,7 @@ public class JettyConfigurationBuilder {
                                 // "proxy" is a synthetic provider for push-username lookup — no resolution needed
                                 String resolvedProvider = "proxy".equals(s.getProvider())
                                         ? "proxy"
-                                        : resolveToProviderId(
+                                        : resolveProviderName(
                                                 "User '" + uc.getUsername() + "' scm-identity", s.getProvider());
                                 return ScmIdentity.builder()
                                         .provider(resolvedProvider)

--- a/git-proxy-java-server/src/test/java/org/finos/gitproxy/e2e/JettyProxyFixture.java
+++ b/git-proxy-java-server/src/test/java/org/finos/gitproxy/e2e/JettyProxyFixture.java
@@ -228,7 +228,7 @@ class JettyProxyFixture implements AutoCloseable {
         return pushStore;
     }
 
-    /** The provider ID (type/host) used by this fixture — use this when seeding permission grants. */
+    /** The provider ID used by this fixture — use this when seeding permission grants. */
     String getProviderId() {
         return providerId;
     }

--- a/git-proxy-java-server/src/test/java/org/finos/gitproxy/jetty/config/JettyConfigurationBuilderTest.java
+++ b/git-proxy-java-server/src/test/java/org/finos/gitproxy/jetty/config/JettyConfigurationBuilderTest.java
@@ -93,33 +93,35 @@ class JettyConfigurationBuilderTest {
         var builder = new JettyConfigurationBuilder(configWithGithub());
         var registry = builder.buildProviderRegistry();
 
-        // Lookup by friendly name
-        assertNotNull(registry.getProvider("github"));
-        assertInstanceOf(GitHubProvider.class, registry.getProvider("github"));
+        // Lookup by name
+        assertTrue(registry.getProvider("github").isPresent());
+        assertInstanceOf(GitHubProvider.class, registry.getProvider("github").orElseThrow());
         // Lookup by name via resolveProvider
-        assertNotNull(registry.resolveProvider("github"));
-        assertSame(registry.getProvider("github"), registry.resolveProvider("github"));
-        // Friendly name and ID resolve to same provider
+        assertTrue(registry.resolveProvider("github").isPresent());
+        assertSame(
+                registry.getProvider("github").orElseThrow(),
+                registry.resolveProvider("github").orElseThrow());
+        // Name resolves to a stable provider ID
         assertEquals(
-                registry.resolveProvider("github").getProviderId(),
-                registry.resolveProvider("github").getProviderId());
+                registry.resolveProvider("github").orElseThrow().getProviderId(),
+                registry.resolveProvider("github").orElseThrow().getProviderId());
     }
 
-    // ---- buildConfigPermissions — friendly name resolution (#127) ----
+    // ---- buildConfigPermissions — provider name resolution ----
 
     @Test
-    void buildConfigPermissions_friendlyName_resolvesToCanonicalId() {
+    void buildConfigPermissions_name_stored_on_permission() {
         var config = configWithGithub();
         var permission = new PermissionConfig();
         permission.setUsername("alice");
-        permission.setProvider("github"); // friendly name
+        permission.setProvider("github");
         permission.setPath("/org/repo");
         config.setPermissions(List.of(permission));
 
         List<RepoPermission> perms = new JettyConfigurationBuilder(config).buildConfigPermissions(config);
 
         assertEquals(1, perms.size());
-        // Name is both the friendly form and the canonical ID
+
         assertEquals("github", perms.get(0).getProvider());
         assertEquals("alice", perms.get(0).getUsername());
     }
@@ -139,20 +141,20 @@ class JettyConfigurationBuilderTest {
         assertTrue(ex.getMessage().contains("github"), "error should list configured providers");
     }
 
-    // ---- buildConfigRules — friendly name resolution (#127) ----
+    // ---- buildConfigRules — provider name resolution ----
 
     @Test
-    void buildConfigRules_friendlyName_resolvesToCanonicalId() {
+    void buildConfigRules_name_stored_on_rule() {
         var config = configWithGithub();
         var ruleConfig = new RuleConfig();
-        ruleConfig.setProviders(List.of("github")); // friendly name
+        ruleConfig.setProviders(List.of("github"));
         ruleConfig.setSlugs(List.of("/org/repo"));
         config.getRules().setAllow(List.of(ruleConfig));
 
         List<AccessRule> rules = new JettyConfigurationBuilder(config).buildConfigRules(config);
 
         assertFalse(rules.isEmpty());
-        // Provider field in AccessRule must be the canonical type/host ID for evaluator to work
+
         assertEquals("github", rules.get(0).getProvider());
     }
 
@@ -170,20 +172,22 @@ class JettyConfigurationBuilderTest {
         assertNull(rules.get(0).getProvider()); // null = all providers
     }
 
-    // ---- buildConfigRules — friendly name scoping (#127) ----
+    // ---- buildConfigRules — provider name scoping ----
 
     @Test
-    void buildConfigRules_friendlyName_producesRuleWithGithubProviderId() {
+    void buildConfigRules_name_scopes_rule_to_provider() {
         var config = configWithGithub();
         var ruleConfig = new RuleConfig();
         ruleConfig.setOrder(110);
-        ruleConfig.setProviders(List.of("github")); // friendly name
+        ruleConfig.setProviders(List.of("github"));
         ruleConfig.setSlugs(List.of("/org/repo"));
         config.getRules().setAllow(List.of(ruleConfig));
 
         var builder = new JettyConfigurationBuilder(config);
-        var githubProviderId =
-                builder.buildProviderRegistry().getProvider("github").getProviderId();
+        var githubProviderId = builder.buildProviderRegistry()
+                .getProvider("github")
+                .orElseThrow()
+                .getProviderId();
         var rules = builder.buildConfigRules();
 
         assertFalse(rules.isEmpty(), "rule scoped to 'github' should produce at least one AccessRule");
@@ -193,7 +197,7 @@ class JettyConfigurationBuilderTest {
     }
 
     @Test
-    void buildConfigRules_friendlyName_doesNotProduceRuleForOtherProvider() {
+    void buildConfigRules_name_excludes_other_provider() {
         var config = configWithGithubAndGitlab();
         var ruleConfig = new RuleConfig();
         ruleConfig.setOrder(110);
@@ -202,8 +206,10 @@ class JettyConfigurationBuilderTest {
         config.getRules().setAllow(List.of(ruleConfig));
 
         var builder = new JettyConfigurationBuilder(config);
-        var gitlabProviderId =
-                builder.buildProviderRegistry().getProvider("gitlab").getProviderId();
+        var gitlabProviderId = builder.buildProviderRegistry()
+                .getProvider("gitlab")
+                .orElseThrow()
+                .getProviderId();
         var rules = builder.buildConfigRules();
 
         assertTrue(


### PR DESCRIPTION
## Summary

- `ProviderRegistry.getProvider()` and `resolveProvider()` now return `Optional<GitProxyProvider>` instead of nullable `GitProxyProvider`
- `InMemoryProviderRegistry` wraps map lookup in `Optional.ofNullable()`
- `JettyConfigurationBuilder.resolveProviderName()` uses `.orElseThrow()` — misconfigured provider names still fail fast at startup
- All callers and tests updated; no behavioural changes

## Also included (from earlier commits on this branch)

- `ProviderRegistry.resolveProvider()` Javadoc corrected — null/blank "applies to all" semantic belongs in `resolveProviderName` (the caller), not the registry interface
- `resolveToProviderId` renamed to `resolveProviderName`; `nameOrId` parameter renamed to `name` throughout `JettyConfigurationBuilder`
- Removed stale "friendly name" / "type/host" language from comments and test names
- `InMemoryProviderRegistry` class comment updated
- `JettyProxyFixture` comment fix (was "(type/host)")
- `scripts/migrate-provider-ids.sql` — one-off data fixup for renaming stored `type/host` FK values to provider `name` in all 6 tables
- Added `twoProvidersOfSameType_differentNames_haveDistinctProviderIds` and `twoProvidersOfSameType_permissionsAreKeptSeparate` tests

## Test plan

- [ ] `./gradlew :git-proxy-java-core:test :git-proxy-java-server:test` — all pass