### PR TITLE
fix: bump base images, overhaul container scan and release workflow

### DIFF
--- a/.claude/commands/fetch-grype-report.md
+++ b/.claude/commands/fetch-grype-report.md
@@ -1,0 +1,58 @@
+# Fetch Latest Grype Container Scan Report
+
+Fetch the latest grype container scan report from GitHub Actions and update the Dockerfile base image SHAs to address any CVEs.
+
+## Steps
+
+1. Find the latest completed container scan run and download the report into a temp directory:
+   ```
+   gh run list --workflow=container-scan.yml --status=completed --limit=5 --json databaseId,displayTitle,createdAt,conclusion
+   GRYPE_TMP=$(mktemp -d)
+   gh run download <RUN_ID> -n grype-container-scan -D "$GRYPE_TMP"
+   cat "$GRYPE_TMP/grype-report.txt"
+   ```
+
+2. Analyze the report:
+   - All current CVEs are in `openjdk` or Ubuntu base packages — both are fixed by updating the base image
+   - Check the "FIXED IN" column: if `*21.0.X` is listed, a new temurin release is available
+   - If no fix is listed, the CVE cannot be addressed by a base image bump
+   - **If CVEs remain after a digest bump:** the temurin Docker image may not yet include the upstream JDK fix.
+     OpenJDK releases and the corresponding `eclipse-temurin` Docker image publish are independent — there is
+     typically a lag of days to weeks. Check https://github.com/adoptium/containers for open issues or pending
+     PRs tracking the update.
+
+3. Pull the latest temurin images and extract the multi-arch index digests:
+   ```bash
+   CONTAINER_TOOL=$(command -v docker || command -v podman)
+   
+   for IMG in eclipse-temurin:21-jre eclipse-temurin:21-jdk; do
+     $CONTAINER_TOOL pull docker.io/$IMG --quiet
+     PLATFORM_DIGESTS=$($CONTAINER_TOOL manifest inspect docker.io/$IMG | python3 -c "import json,sys; [print(m['digest']) for m in json.load(sys.stdin)['manifests']]")
+     $CONTAINER_TOOL image inspect docker.io/$IMG --format '{{.RepoDigests}}' \
+       | tr ' ' '\n' | sed 's/.*@//' | tr -d '[]' \
+       | while read d; do
+           [ -n "$d" ] && ! echo "$PLATFORM_DIGESTS" | grep -qF "$d" && echo "$IMG  sha256: $d"
+         done
+   done
+   ```
+
+4. Update `Dockerfile` — replace both `@sha256:` pins:
+   - Build stage: `FROM docker.io/eclipse-temurin:21-jdk@sha256:<new>`
+   - Runtime stage: `FROM docker.io/eclipse-temurin:21-jre@sha256:<new>`
+
+5. Optionally verify locally that the Dockerfile changes resolve the findings. Build the image first, then scan it (`fail-on-severity`, `sort-by`, and `output-template-file` come from `.grype.yaml`):
+   ```
+   CONTAINER_TOOL=$(command -v docker || command -v podman)
+   $CONTAINER_TOOL build -t git-proxy-java:local-verify .
+   SCAN_TMP=$(mktemp -d)
+   grype git-proxy-java:local-verify --config .grype.yaml -o "template=$SCAN_TMP/report.txt" -o "json=$SCAN_TMP/report.json"
+   cat "$SCAN_TMP/report.txt"
+   ```
+
+6. Commit on a new branch:
+   ```
+   fix: bump temurin base images to resolve CVEs
+   
+   Addresses: <list CVE IDs from report>
+   closes #<issue number if one exists>
+   ```

--- a/.claude/commands/release-tag.md
+++ b/.claude/commands/release-tag.md
@@ -12,6 +12,10 @@ allowed-tools:
 This is phase 2 of the release process. Phase 1 (`/release`) bumped the version and pushed to main.
 This command creates the git tag and pushes it, which triggers the Docker publish workflow.
 
+When the tag is pushed, the publish workflow promotes the already-built `:edge` image to the release
+tags (`:v<version>`, `:latest`, etc.) — it does **not** rebuild the image. The image being released is
+byte-for-byte identical to what was scanned when the version bump merged to main.
+
 Arguments passed: `$ARGUMENTS`
 
 `$ARGUMENTS` is the version string (without `v` prefix), e.g. `1.0.0-alpha.9`.
@@ -24,15 +28,16 @@ Arguments passed: `$ARGUMENTS`
 
 2. **Verify checks passed.** Run:
    ```
-   gh run list --branch main --limit 4 --json name,status,conclusion
+   gh run list --branch main --limit 6 --json name,status,conclusion
    ```
    Confirm that these checks all show `conclusion: "success"`:
    - `CI / Build & Test`
    - `CI / E2E Test`
    - `CodeQL / java-kotlin`
    - `CodeQL / actions`
-   - `CVE / Dependency Check (Gradle)`
-   - `CVE / Grype (npm)`
+   - `CVE / Gradle`
+   - `CVE / npm`
+   - `Container Scan`
 
    If any are still in progress or failed, tell the user and stop.
 

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -27,30 +27,16 @@ jobs:
           grep "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" "grype_${GRYPE_VERSION}_checksums.txt" | sha256sum --check
           tar -xzf "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -C /usr/local/bin grype
 
+      # Single scan — fail on high+, emit template report and JSON in one pass.
+      # SARIF upload intentionally omitted — OS-layer CVEs are triaged with application
+      # context; uploading creates misleading noise in the GitHub Security tab.
       - name: Scan image
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # ratchet:anchore/scan-action@v7
-        id: scan
-        with:
-          image: ghcr.io/coopernetes/git-proxy-java:latest
-          fail-build: true
-          severity-cutoff: high
-          only-fixed: true
-          config: .grype.yaml
-
-      # SARIF upload intentionally omitted — OS-layer CVEs from the base image are triaged
-      # by internal scanning with application context. Uploading here creates misleading noise
-      # in the GitHub Security tab (high CVSS score ≠ high actual risk for this workload).
-      # The build still fails on high/critical with a fix available via fail-build: true above.
-
-      - name: Generate human-readable report
         if: always()
         run: |
           grype ghcr.io/coopernetes/git-proxy-java:latest \
             --config .grype.yaml \
-            --output table > grype-report.txt || true
-          grype ghcr.io/coopernetes/git-proxy-java:latest \
-            --config .grype.yaml \
-            --output json > grype-report.json || true
+            -o "template=grype-report.txt" \
+            -o "json=grype-report.json"
 
       - name: Upload scan reports
         if: always()

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,14 +18,16 @@ permissions:
 
 jobs:
   build-and-push:
+    # Tags are released by promoting the already-built edge image — no rebuild needed.
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.push.outputs.digest }}
     permissions:
       contents: read
       packages: write
-      id-token: write # required for SLSA provenance signing
-      attestations: write # required for GitHub artifact attestations
+      id-token: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -49,7 +51,6 @@ jobs:
           tags: |
             type=ref,event=pr
             type=raw,value=edge,enable={{is_default_branch}}
-            type=raw,value=${{ github.ref_name }}-pending,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
@@ -98,39 +99,24 @@ jobs:
           tar -xzf "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -C /usr/local/bin grype
 
       - name: Scan image
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # ratchet:anchore/scan-action@v7
-        id: scan
-        with:
-          image: ghcr.io/${{ github.repository }}@${{ needs.build-and-push.outputs.digest }}
-          fail-build: true
-          severity-cutoff: high
-          only-fixed: true
-          config: .grype.yaml
-
-      # SARIF upload intentionally omitted — OS-layer CVEs from the base image are triaged
-      # by internal scanning with application context. Uploading here creates misleading noise
-      # in the GitHub Security tab (high CVSS score ≠ high actual risk for this workload).
-      # The build still fails on high/critical with a fix available via fail-build: true above.
-
-      - name: Generate scan report
-        if: always()
         run: |
           grype ghcr.io/${{ github.repository }}@${{ needs.build-and-push.outputs.digest }} \
             --config .grype.yaml \
-            --only-fixed \
-            --output table | tee grype-report.txt || true
+            -o "template=grype-report.txt" \
+            -o "json=grype-report.json"
 
-      - name: Upload scan report
+      - name: Upload scan reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
           name: grype-container-scan
-          path: grype-report.txt
+          path: |
+            grype-report.txt
+            grype-report.json
           retention-days: 30
 
   publish-release:
-    name: Publish Release Tags
-    needs: [build-and-push, scan]
+    name: Publish Release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
@@ -138,6 +124,12 @@ jobs:
       packages: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
+
       - name: Log in to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
         with:
@@ -145,35 +137,56 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
+      - name: Install grype
+        env:
+          GRYPE_VERSION: "0.112.0"
+        run: |
+          cd /tmp
+          curl -sSfL -o "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz"
+          curl -sSfL -o "grype_${GRYPE_VERSION}_checksums.txt" \
+            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_checksums.txt"
+          grep "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" "grype_${GRYPE_VERSION}_checksums.txt" | sha256sum --check
+          tar -xzf "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -C /usr/local/bin grype
 
-      # Retag the scanned ephemeral image to final release tags without rebuilding.
-      # Only runs after scan passes — latest always points to a clean image.
-      - name: Retag to release version and latest
+      # Resolve the digest of the already-built, already-scanned edge image.
+      # The tag ruleset enforces Container Scan passed on this commit before the tag
+      # could be pushed, so edge is guaranteed clean at this point.
+      - name: Resolve edge digest
+        id: edge
+        run: |
+          DIGEST=$(docker buildx imagetools inspect \
+            ghcr.io/${{ github.repository }}:edge \
+            --format '{{.Manifest.Digest}}')
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Promoting edge digest: ${DIGEST}"
+
+      - name: Scan edge image
+        run: |
+          grype ghcr.io/${{ github.repository }}@${{ steps.edge.outputs.digest }} \
+            --config .grype.yaml \
+            -o "template=grype-report.txt" \
+            -o "json=grype-report.json"
+
+      - name: Upload scan reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
+        with:
+          name: grype-release-scan
+          path: |
+            grype-report.txt
+            grype-report.json
+          retention-days: 90
+
+      - name: Promote edge to release tags
         run: |
           VERSION=${GITHUB_REF_NAME}
           MAJOR=$(echo ${VERSION} | cut -d. -f1)
           MINOR=$(echo ${VERSION} | cut -d. -f1-2)
-          SOURCE="ghcr.io/${{ github.repository }}@${{ needs.build-and-push.outputs.digest }}"
+          SOURCE="ghcr.io/${{ github.repository }}@${{ steps.edge.outputs.digest }}"
           docker buildx imagetools create \
             --tag "ghcr.io/${{ github.repository }}:${VERSION}" \
             --tag "ghcr.io/${{ github.repository }}:${MINOR}" \
             --tag "ghcr.io/${{ github.repository }}:${MAJOR}" \
             --tag "ghcr.io/${{ github.repository }}:latest" \
             ${SOURCE}
-
-      - name: Delete ephemeral pending tag
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PACKAGE_NAME=$(basename ${{ github.repository }})
-          TAG="${GITHUB_REF_NAME}-pending"
-          VERSION_ID=$(gh api "/user/packages/container/${PACKAGE_NAME}/versions" \
-            --paginate --jq ".[] | select(.metadata.container.tags[] == \"${TAG}\") | .id")
-          if [ -n "${VERSION_ID}" ]; then
-            gh api --method DELETE "/user/packages/container/${PACKAGE_NAME}/versions/${VERSION_ID}"
-            echo "Deleted ephemeral tag ${TAG}"
-          else
-            echo "No ephemeral tag ${TAG} found — nothing to clean up"
-          fi

--- a/.grype-report.tmpl
+++ b/.grype-report.tmpl
@@ -1,0 +1,6 @@
+{{- range .Matches -}}
+{{.Vulnerability.ID}}  {{.Vulnerability.Severity}}  {{.Artifact.Name}} {{.Artifact.Version}} ({{.Artifact.Type}})
+  Fix state: {{.Vulnerability.Fix.State}}
+  Fixed in:  {{range $i, $v := .Vulnerability.Fix.Versions}}{{if $i}}, {{end}}{{$v}}{{end}}
+
+{{ end -}}

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,4 +1,6 @@
 fail-on-severity: high
+sort-by: severity
+output-template-file: .grype-report.tmpl
 
 ignore:
   # OS packages with no fix available — upstream patch not yet released or won't be released.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,13 @@ Config override file mounted at `/app/conf/git-proxy-local.yml` inside the conta
 Refer to [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for detailed docs on YAML config structure, environment variable
 overrides, and provider-specific settings.
 
+## Commit conventions
+
+- Always squash related commits into one before pushing — use `git reset --soft` to squash, not `git rebase -i` (requires TTY).
+- Always include a `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` trailer in every commit. This is a project transparency requirement.
+- Always include `closes #N` / `resolves #N` in commit messages when addressing a GitHub issue.
+- Never add `[ci skip]` to commits unless explicitly asked.
+
 ## Testing conventions
 
 - Always use JUnit assertions (`org.junit.jupiter.api.Assertions.*`) — not manual `if`/`throw` checks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -429,6 +429,16 @@ This sets `core.hooksPath` to `.githooks/`. The hook runs on every `git commit`:
 See [docs/internals/JGIT_INFRASTRUCTURE.md](docs/internals/JGIT_INFRASTRUCTURE.md) for the store-and-forward
 architecture and [docs/internals/GIT_INTERNALS.md](docs/internals/GIT_INTERNALS.md) for wire-protocol details.
 
+## Releases
+
+Releases follow a two-phase process to ensure every published image is identical to what was already scanned and running as `:edge`.
+
+**Phase 1 — version bump.** Create a `release/<version>` branch, update `version` in `build.gradle`, open a PR, and enable auto-merge. The PR must pass all CI, CodeQL, CVE, and container scan checks before it can merge. Use the `/release` Claude command to automate this.
+
+**Phase 2 — tag.** Once the version bump lands on `main`, push an annotated tag (`v<version>`). The tag ruleset enforces the same checks must have passed on that commit. The publish workflow then promotes the already-built `:edge` image directly to the release tags (`:v1.0.0`, `:latest`, etc.) — no rebuild occurs. Use the `/release-tag` Claude command for this step.
+
+This means every release image is byte-for-byte identical to the `:edge` image that was scanned when the version bump merged.
+
 ## Issues and pull requests
 
 The issue tracker is at [coopernetes/git-proxy-java](https://github.com/coopernetes/git-proxy-java/issues). Reference

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM docker.io/eclipse-temurin:21-jdk@sha256:06a4f4be86d459307036eb97c55a24686bd1312fe88c152723c915b7b2e6a8b4 AS builder
+FROM docker.io/eclipse-temurin:21-jdk@sha256:e58e492628c1428ceb838afc1a1b8762673d5eaa09296f560c363daea0fdcf3b AS builder
 
 # Install Node.js directly from the official distribution with SHA256 verification.
 # To update: download the new tarball, verify against nodejs.org/dist/vX.Y.Z/SHASUMS256.txt,
@@ -47,7 +47,7 @@ RUN sed -i \
     git-proxy-java-dashboard/build/install/git-proxy-java-dashboard/bin/git-proxy-java-dashboard
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM docker.io/eclipse-temurin:21-jre@sha256:137163a1850fd2088d94ecd8420358d83086bd287d3c4f6f14b7d09786490c4d
+FROM docker.io/eclipse-temurin:21-jre@sha256:ff65ff0d43c73d2b675eb4b758665a5cb487e7df127436a9979f8172c144c819
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Bumps `eclipse-temurin:21-jdk` and `:21-jre` to latest multi-arch index digests, resolving all 9 reported CVEs (openjdk 21.0.11 + libcap2)
- Replaces 3 redundant grype invocations with a single scan using multi-output; adds `.grype-report.tmpl` for human-readable reports with no truncated fix versions
- Reworks `docker-publish.yml` so tag pushes promote `:edge` directly instead of rebuilding — released images are byte-for-byte identical to what was scanned on the main push; removes ephemeral `-pending` tag logic
- Updates `/release-tag` command with correct check names and a note about the promotion model
- Adds `/fetch-grype-report` command for future CVE triage workflows
- Adds `## Releases` section to `CONTRIBUTING.md` documenting the two-phase release model

closes #194

## Test plan

- [ ] CI passes on this branch
- [ ] Verify `docker-publish.yml` build-and-push job skips on tag push (`if: !startsWith(github.ref, 'refs/tags/')`)
- [ ] After merge, confirm `:edge` is updated and container scan passes — this unblocks the stalled main pushes (#190, #191)