### PR TITLE
fix: committer email policy and malformed permission deny URL (#181, #182)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -580,18 +580,31 @@ accepts the internal username, not an email address.
 
 ## Commit validation
 
-Per-commit checks (identity, author email, message content) apply to both store-and-forward and transparent proxy modes.
+Per-commit checks (identity, email policy, message content) apply to both store-and-forward and transparent proxy modes.
 
 ```yaml
 commit:
-  author:
+  # Committer email policy — the committer is the employee who ran git commit or git rebase.
+  # This is the primary corporate control: enforce that your staff use their work identity.
+  # Rebased commits from external contributors still pass as long as the committer email is valid.
+  committer:
     email:
       domain:
-        # Regex the email domain must match. Omit to allow all domains.
-        allow: "(corp\\.example\\.com|contractors\\.example\\.com)$"
+        # Regex the committer email domain must match. Omit to allow all domains.
+        allow: "corp\\.example\\.com$"
       local:
         # Regex blocking specific local-parts (before @). Omit to allow all.
         block: "^(noreply|no-reply|bot|nobody)$"
+
+  # Author email policy — the author is whoever originally wrote the commit.
+  # Configure this only if you want to disallow rebasing external contributors' commits.
+  # When set, any commit whose author email is outside the allowed domain is blocked —
+  # developers must open PRs from the original fork rather than rebasing upstream changes.
+  # Omit this block entirely to allow external author emails (the most common setup).
+  author:
+    email:
+      domain:
+        allow: "corp\\.example\\.com$"
 
   message:
     block:

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/config/CommitConfig.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/config/CommitConfig.java
@@ -50,6 +50,10 @@ public class CommitConfig {
     @Builder.Default
     private AuthorConfig author = AuthorConfig.builder().build();
 
+    /** Configuration for committer email validation. */
+    @Builder.Default
+    private CommitterConfig committer = CommitterConfig.builder().build();
+
     /** Configuration for commit message validation. */
     @Builder.Default
     private MessageConfig message = MessageConfig.builder().build();
@@ -58,6 +62,16 @@ public class CommitConfig {
     @Data
     @Builder
     public static class AuthorConfig {
+
+        /** Configuration for email validation. */
+        @Builder.Default
+        private EmailConfig email = EmailConfig.builder().build();
+    }
+
+    /** Configuration for committer validation. */
+    @Data
+    @Builder
+    public static class CommitterConfig {
 
         /** Configuration for email validation. */
         @Builder.Default

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/CheckUserPushPermissionHook.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/CheckUserPushPermissionHook.java
@@ -119,8 +119,8 @@ public class CheckUserPushPermissionHook implements GitProxyHook {
                     user.getUsername(),
                     providerId,
                     repoSlug);
-            String repoRef = providerId != null && repoSlug != null
-                    ? String.format("https://%s%s", providerId, repoSlug)
+            String repoRef = provider != null && repoSlug != null
+                    ? provider.getUri().toString().replaceAll("/$", "") + repoSlug
                     : repoSlug;
             String detail = GitClientUtils.format(
                     sym(NO_ENTRY) + "  Push Blocked - Unauthorized",

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/CheckUserPushPermissionFilter.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/CheckUserPushPermissionFilter.java
@@ -107,8 +107,9 @@ public class CheckUserPushPermissionFilter extends AbstractGitProxyFilter {
                     user.getUsername(),
                     providerId,
                     slug);
-            String repoUrl =
-                    providerId != null && slug != null ? String.format("https://%s%s", providerId, slug) : slug;
+            String repoUrl = requestDetails.getProvider() != null && slug != null
+                    ? requestDetails.getProvider().getUri().toString().replaceAll("/$", "") + slug
+                    : slug;
             String title = sym(NO_ENTRY) + "  Push Blocked - Unauthorized";
             String message = sym(CROSS_MARK) + "  " + user.getUsername() + " is not allowed to push to:\n" + "   "
                     + sym(LINK) + "  " + repoUrl;

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/validation/AuthorEmailCheck.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/validation/AuthorEmailCheck.java
@@ -14,8 +14,15 @@ import org.finos.gitproxy.config.CommitConfig;
 import org.finos.gitproxy.git.Commit;
 
 /**
- * Validates that every author email in the pushed commits passes format checks and matches the configured domain/local
- * rules.
+ * Validates committer and author emails in the pushed commits against configured domain/local rules.
+ *
+ * <p>Committer validation ({@code commit.committer.email.*}) is the primary corporate control: the committer is the
+ * employee who authored or rebased the change, and must use their work identity. Author validation
+ * ({@code commit.author.email.*}) is an optional stricter policy: when configured, it also checks the original author
+ * email, which effectively disallows rebasing commits from contributors outside the allowed domain.
+ *
+ * <p>Each policy is independent — configure one, both, or neither. Violations from each are reported separately with
+ * explicit labels so developers know exactly which identity triggered the block and what to do about it.
  */
 @RequiredArgsConstructor
 public class AuthorEmailCheck implements CommitCheck {
@@ -24,22 +31,38 @@ public class AuthorEmailCheck implements CommitCheck {
 
     @Override
     public List<Violation> check(List<Commit> commits) {
-        Set<String> emails = commits.stream().map(c -> c.getAuthor().getEmail()).collect(Collectors.toSet());
-
         List<Violation> violations = new ArrayList<>();
-        for (String email : emails) {
-            String reason = violationReason(email);
+
+        Set<String> committerEmails =
+                commits.stream().map(c -> c.getCommitter().getEmail()).collect(Collectors.toSet());
+        for (String email : committerEmails) {
+            String reason = violationReason(email, config.getCommitter().getEmail());
             if (reason != null) {
-                String detail = sym(CROSS_MARK) + "  " + email + ": " + reason + "\n"
-                        + "  \u2192 git config user.email \"you@example.com\"";
-                violations.add(new Violation(email, reason, detail));
+                String detail = sym(CROSS_MARK) + "  committer email (" + email + "): " + reason + "\n"
+                        + "  \u2192 The committer is you — the person who ran git commit or git rebase.\n"
+                        + "  \u2192 Fix: git config user.email \"you@corp.com\"";
+                violations.add(new Violation("committer:" + email, reason, detail));
             }
         }
+
+        Set<String> authorEmails =
+                commits.stream().map(c -> c.getAuthor().getEmail()).collect(Collectors.toSet());
+        for (String email : authorEmails) {
+            String reason = violationReason(email, config.getAuthor().getEmail());
+            if (reason != null) {
+                String detail = sym(CROSS_MARK) + "  author email (" + email + "): " + reason + "\n"
+                        + "  \u2192 This commit was originally authored by someone outside the allowed domain.\n"
+                        + "  \u2192 Rebasing external commits onto this branch is not permitted by policy.\n"
+                        + "  \u2192 Alternative: open a PR from the original author's fork instead of rebasing.";
+                violations.add(new Violation("author:" + email, reason, detail));
+            }
+        }
+
         return violations;
     }
 
-    /** Returns the reason the email is rejected, or {@code null} if it is allowed. */
-    private String violationReason(String email) {
+    /** Returns the reason the email is rejected under the given email config, or {@code null} if it is allowed. */
+    private String violationReason(String email, CommitConfig.EmailConfig emailConfig) {
         if (email == null || email.isEmpty()) {
             return "empty email";
         }
@@ -54,12 +77,12 @@ public class AuthorEmailCheck implements CommitCheck {
         String local = parts[0];
         String domain = parts[1];
 
-        Pattern localBlock = config.getAuthor().getEmail().getLocal().getBlock();
+        Pattern localBlock = emailConfig.getLocal().getBlock();
         if (localBlock != null && localBlock.matcher(local).find()) {
             return "blocked local part (" + local + ")";
         }
 
-        Pattern domainAllow = config.getAuthor().getEmail().getDomain().getAllow();
+        Pattern domainAllow = emailConfig.getDomain().getAllow();
         if (domainAllow != null && !domainAllow.matcher(domain).find()) {
             return "domain not allowed (" + domain + ")";
         }

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/AuthorEmailValidationHookTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/AuthorEmailValidationHookTest.java
@@ -58,7 +58,7 @@ class AuthorEmailValidationHookTest {
 
     private CommitConfig allowExampleCom() {
         return CommitConfig.builder()
-                .author(CommitConfig.AuthorConfig.builder()
+                .committer(CommitConfig.CommitterConfig.builder()
                         .email(CommitConfig.EmailConfig.builder()
                                 .domain(CommitConfig.DomainConfig.builder()
                                         .allow(Pattern.compile("example\\.com$"))

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/servlet/filter/CheckAuthorEmailsFilterTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/servlet/filter/CheckAuthorEmailsFilterTest.java
@@ -95,7 +95,7 @@ class CheckAuthorEmailsFilterTest {
 
     private CommitConfig testConfig() {
         return CommitConfig.builder()
-                .author(CommitConfig.AuthorConfig.builder()
+                .committer(CommitConfig.CommitterConfig.builder()
                         .email(CommitConfig.EmailConfig.builder()
                                 .domain(CommitConfig.DomainConfig.builder()
                                         .allow(Pattern.compile("(example\\.com|company\\.org)$"))

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/servlet/filter/FilterChainIntegrationTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/servlet/filter/FilterChainIntegrationTest.java
@@ -100,7 +100,7 @@ class FilterChainIntegrationTest {
 
     private CommitConfig emailAndMessageConfig() {
         return CommitConfig.builder()
-                .author(CommitConfig.AuthorConfig.builder()
+                .committer(CommitConfig.CommitterConfig.builder()
                         .email(CommitConfig.EmailConfig.builder()
                                 .domain(CommitConfig.DomainConfig.builder()
                                         .allow(Pattern.compile("(example\\.com|company\\.org)$"))

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/validation/AuthorEmailCheckTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/validation/AuthorEmailCheckTest.java
@@ -13,7 +13,33 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class AuthorEmailCheckTest {
 
-    private static CommitConfig configWithDomainAllow(String pattern) {
+    // --- config helpers ---
+
+    private static CommitConfig committerDomainAllow(String pattern) {
+        return CommitConfig.builder()
+                .committer(CommitConfig.CommitterConfig.builder()
+                        .email(CommitConfig.EmailConfig.builder()
+                                .domain(CommitConfig.DomainConfig.builder()
+                                        .allow(Pattern.compile(pattern))
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+    }
+
+    private static CommitConfig committerLocalBlock(String pattern) {
+        return CommitConfig.builder()
+                .committer(CommitConfig.CommitterConfig.builder()
+                        .email(CommitConfig.EmailConfig.builder()
+                                .local(CommitConfig.LocalConfig.builder()
+                                        .block(Pattern.compile(pattern))
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+    }
+
+    private static CommitConfig authorDomainAllow(String pattern) {
         return CommitConfig.builder()
                 .author(CommitConfig.AuthorConfig.builder()
                         .email(CommitConfig.EmailConfig.builder()
@@ -25,91 +51,141 @@ class AuthorEmailCheckTest {
                 .build();
     }
 
-    private static CommitConfig configWithLocalBlock(String pattern) {
+    private static CommitConfig bothDomainAllow(String pattern) {
+        CommitConfig.EmailConfig emailConfig = CommitConfig.EmailConfig.builder()
+                .domain(CommitConfig.DomainConfig.builder()
+                        .allow(Pattern.compile(pattern))
+                        .build())
+                .build();
         return CommitConfig.builder()
-                .author(CommitConfig.AuthorConfig.builder()
-                        .email(CommitConfig.EmailConfig.builder()
-                                .local(CommitConfig.LocalConfig.builder()
-                                        .block(Pattern.compile(pattern))
-                                        .build())
-                                .build())
+                .author(CommitConfig.AuthorConfig.builder().email(emailConfig).build())
+                .committer(CommitConfig.CommitterConfig.builder()
+                        .email(emailConfig)
                         .build())
                 .build();
     }
 
-    private static Commit commitWithEmail(String email) {
+    // --- commit builders ---
+
+    private static Commit commit(String authorEmail, String committerEmail) {
         return Commit.builder()
                 .sha("abc123")
-                .author(Contributor.builder().name("Test User").email(email).build())
-                .committer(Contributor.builder().name("Test User").email(email).build())
+                .author(Contributor.builder().name("Author").email(authorEmail).build())
+                .committer(Contributor.builder()
+                        .name("Committer")
+                        .email(committerEmail)
+                        .build())
                 .message("Test commit")
                 .build();
     }
 
+    private static Commit plainCommit(String email) {
+        return commit(email, email);
+    }
+
+    private static Commit rebasedExternalCommit(String committerEmail) {
+        return commit("external@opensource.io", committerEmail);
+    }
+
+    // --- committer-only policy ---
+
     @Test
     void defaultConfig_anyValidEmail_noViolations() {
         AuthorEmailCheck check = new AuthorEmailCheck(CommitConfig.defaultConfig());
-        assertTrue(check.check(List.of(commitWithEmail("anyone@anywhere.io"))).isEmpty());
+        assertTrue(check.check(List.of(plainCommit("anyone@anywhere.io"))).isEmpty());
     }
 
     @Test
-    void validEmail_matchingAllowDomain_noViolations() {
-        AuthorEmailCheck check = new AuthorEmailCheck(configWithDomainAllow("example\\.com$"));
-        assertTrue(check.check(List.of(commitWithEmail("dev@example.com"))).isEmpty());
+    void committerOnly_matchingDomain_noViolations() {
+        AuthorEmailCheck check = new AuthorEmailCheck(committerDomainAllow("corp\\.com$"));
+        assertTrue(check.check(List.of(plainCommit("dev@corp.com"))).isEmpty());
     }
 
     @Test
-    void domainNotInAllowList_returnsViolation() {
-        AuthorEmailCheck check = new AuthorEmailCheck(configWithDomainAllow("company\\.com$"));
-        List<Violation> violations = check.check(List.of(commitWithEmail("dev@gmail.com")));
-        assertFalse(violations.isEmpty());
-        assertTrue(violations.get(0).reason().contains("domain not allowed"));
+    void committerOnly_wrongDomain_violation_labelledAsCommitter() {
+        AuthorEmailCheck check = new AuthorEmailCheck(committerDomainAllow("corp\\.com$"));
+        List<Violation> violations = check.check(List.of(plainCommit("dev@gmail.com")));
+        assertEquals(1, violations.size());
+        assertTrue(violations.get(0).formattedDetail().contains("committer email (dev@gmail.com)"));
+        assertTrue(violations.get(0).formattedDetail().contains("git config user.email"));
     }
 
     @Test
-    void blockedLocalPart_returnsViolation() {
-        AuthorEmailCheck check = new AuthorEmailCheck(configWithLocalBlock("^(noreply|bot)$"));
-        List<Violation> violations = check.check(List.of(commitWithEmail("noreply@example.com")));
-        assertFalse(violations.isEmpty());
-        assertTrue(violations.get(0).reason().contains("blocked local part"));
+    void committerOnly_blockedLocalPart_violation_labelledAsCommitter() {
+        AuthorEmailCheck check = new AuthorEmailCheck(committerLocalBlock("^(noreply|bot)$"));
+        List<Violation> violations = check.check(List.of(plainCommit("noreply@corp.com")));
+        assertEquals(1, violations.size());
+        assertTrue(violations.get(0).formattedDetail().contains("committer email (noreply@corp.com)"));
+    }
+
+    // --- rebase scenario: committer policy only allows rebased external commits ---
+
+    @Test
+    void committerOnly_rebasedExternalCommit_authorEmailNotChecked() {
+        // external@opensource.io author passes because author policy is not configured
+        AuthorEmailCheck check = new AuthorEmailCheck(committerDomainAllow("corp\\.com$"));
+        Commit rebased = rebasedExternalCommit("employee@corp.com");
+        assertTrue(check.check(List.of(rebased)).isEmpty());
     }
 
     @Test
-    void blockedLocalPart_otherEmailsStillPass() {
-        AuthorEmailCheck check = new AuthorEmailCheck(configWithLocalBlock("^(noreply|bot)$"));
-        assertTrue(check.check(List.of(commitWithEmail("dev@example.com"))).isEmpty());
+    void committerOnly_rebasedExternalCommit_committerViolates_blocked() {
+        AuthorEmailCheck check = new AuthorEmailCheck(committerDomainAllow("corp\\.com$"));
+        Commit rebased = rebasedExternalCommit("employee@gmail.com");
+        List<Violation> violations = check.check(List.of(rebased));
+        assertEquals(1, violations.size());
+        assertTrue(violations.get(0).formattedDetail().contains("committer email"));
+    }
+
+    // --- author-only policy (strict rebase prevention) ---
+
+    @Test
+    void authorOnly_rebasedExternalCommit_authorViolates_committerPasses() {
+        // no committer domain rule, so employee@corp.com passes as committer
+        // but external@opensource.io fails the author rule
+        AuthorEmailCheck check = new AuthorEmailCheck(authorDomainAllow("corp\\.com$"));
+        Commit rebased = rebasedExternalCommit("employee@corp.com");
+        List<Violation> violations = check.check(List.of(rebased));
+        assertEquals(1, violations.size());
+        assertTrue(violations.get(0).formattedDetail().contains("author email (external@opensource.io)"));
+        assertTrue(violations.get(0).formattedDetail().contains("Rebasing external commits"));
     }
 
     @Test
-    void invalidEmailFormat_returnsViolation() {
-        AuthorEmailCheck check = new AuthorEmailCheck(CommitConfig.defaultConfig());
-        assertFalse(check.check(List.of(commitWithEmail("notanemail"))).isEmpty());
+    void authorOnly_internalAuthor_noViolations() {
+        AuthorEmailCheck check = new AuthorEmailCheck(authorDomainAllow("corp\\.com$"));
+        assertTrue(check.check(List.of(plainCommit("dev@corp.com"))).isEmpty());
+    }
+
+    // --- both policies configured (strictest mode) ---
+
+    @Test
+    void bothPolicies_cleanInternalCommit_noViolations() {
+        AuthorEmailCheck check = new AuthorEmailCheck(bothDomainAllow("corp\\.com$"));
+        assertTrue(check.check(List.of(plainCommit("dev@corp.com"))).isEmpty());
     }
 
     @Test
-    void emptyEmail_returnsViolation() {
-        AuthorEmailCheck check = new AuthorEmailCheck(CommitConfig.defaultConfig());
-        List<Violation> violations = check.check(List.of(commitWithEmail("")));
-        assertFalse(violations.isEmpty());
-        assertTrue(violations.get(0).reason().contains("empty email"));
+    void bothPolicies_rebasedExternalCommit_twoViolations_bothLabelled() {
+        AuthorEmailCheck check = new AuthorEmailCheck(bothDomainAllow("corp\\.com$"));
+        Commit rebased = rebasedExternalCommit("employee@corp.com");
+        // committer passes corp domain; author (external@opensource.io) fails
+        List<Violation> violations = check.check(List.of(rebased));
+        assertEquals(1, violations.size());
+        assertTrue(violations.get(0).formattedDetail().contains("author email"));
     }
 
     @Test
-    void multipleCommits_deduplicatesEmails() {
-        // Two commits with the same bad email should produce only one violation
-        AuthorEmailCheck check = new AuthorEmailCheck(configWithDomainAllow("example\\.com$"));
-        Commit c1 = commitWithEmail("bad@gmail.com");
-        Commit c2 = commitWithEmail("bad@gmail.com");
-        assertEquals(1, check.check(List.of(c1, c2)).size());
+    void bothPolicies_wrongCommitterAndExternalAuthor_twoDistinctViolations() {
+        AuthorEmailCheck check = new AuthorEmailCheck(bothDomainAllow("corp\\.com$"));
+        Commit rebased = commit("external@opensource.io", "employee@gmail.com");
+        List<Violation> violations = check.check(List.of(rebased));
+        assertEquals(2, violations.size());
+        assertTrue(violations.stream().anyMatch(v -> v.formattedDetail().contains("committer email")));
+        assertTrue(violations.stream().anyMatch(v -> v.formattedDetail().contains("author email")));
     }
 
-    @Test
-    void multipleCommits_differentBadEmails_eachViolationReported() {
-        AuthorEmailCheck check = new AuthorEmailCheck(configWithDomainAllow("example\\.com$"));
-        Commit c1 = commitWithEmail("a@gmail.com");
-        Commit c2 = commitWithEmail("b@yahoo.com");
-        assertEquals(2, check.check(List.of(c1, c2)).size());
-    }
+    // --- shared edge cases ---
 
     @Test
     void emptyCommitList_noViolations() {
@@ -117,17 +193,24 @@ class AuthorEmailCheckTest {
         assertTrue(check.check(List.of()).isEmpty());
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"user@example.com", "dev+alias@example.com", "a.b.c@sub.example.com"})
-    void variousValidEmails_allowDomainSet_noViolations(String email) {
-        AuthorEmailCheck check = new AuthorEmailCheck(configWithDomainAllow("example\\.com$"));
-        assertTrue(check.check(List.of(commitWithEmail(email))).isEmpty());
+    @Test
+    void invalidEmailFormat_committerViolation() {
+        AuthorEmailCheck check = new AuthorEmailCheck(committerDomainAllow("corp\\.com$"));
+        assertFalse(check.check(List.of(plainCommit("notanemail"))).isEmpty());
+    }
+
+    @Test
+    void multipleCommits_deduplicatesCommitterEmails() {
+        AuthorEmailCheck check = new AuthorEmailCheck(committerDomainAllow("corp\\.com$"));
+        Commit c1 = plainCommit("bad@gmail.com");
+        Commit c2 = plainCommit("bad@gmail.com");
+        assertEquals(1, check.check(List.of(c1, c2)).size());
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"noreply@example.com", "bot@example.com"})
-    void blockedLocalParts_allRejected(String email) {
-        AuthorEmailCheck check = new AuthorEmailCheck(configWithLocalBlock("^(noreply|bot)$"));
-        assertFalse(check.check(List.of(commitWithEmail(email))).isEmpty());
+    @ValueSource(strings = {"user@corp.com", "dev+alias@corp.com", "a.b.c@sub.corp.com"})
+    void variousValidCommitterEmails_noViolations(String email) {
+        AuthorEmailCheck check = new AuthorEmailCheck(committerDomainAllow("corp\\.com$"));
+        assertTrue(check.check(List.of(plainCommit(email))).isEmpty());
     }
 }

--- a/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/CommitSettings.java
+++ b/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/CommitSettings.java
@@ -20,10 +20,16 @@ public class CommitSettings {
     private String identityVerification = "warn";
 
     private AuthorSettings author = new AuthorSettings();
+    private CommitterSettings committer = new CommitterSettings();
     private MessageSettings message = new MessageSettings();
 
     @Data
     public static class AuthorSettings {
+        private EmailSettings email = new EmailSettings();
+    }
+
+    @Data
+    public static class CommitterSettings {
         private EmailSettings email = new EmailSettings();
     }
 

--- a/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/JettyConfigurationBuilder.java
+++ b/git-proxy-java-server/src/main/java/org/finos/gitproxy/jetty/config/JettyConfigurationBuilder.java
@@ -309,8 +309,49 @@ public class JettyConfigurationBuilder {
      */
     public CommitConfig buildCommitConfig() {
         CommitSettings cs = config.getCommit();
-        CommitSettings.EmailSettings email = cs.getAuthor().getEmail();
 
+        CommitConfig.AuthorConfig authorConfig =
+                buildAuthorConfig(cs.getAuthor().getEmail());
+        CommitConfig.CommitterConfig committerConfig =
+                buildCommitterConfig(cs.getCommitter().getEmail());
+
+        CommitConfig.MessageConfig messageConfig = CommitConfig.MessageConfig.builder()
+                .block(buildBlockConfig(cs.getMessage().getBlock()))
+                .build();
+
+        CommitConfig.IdentityVerificationMode identityVerificationMode =
+                CommitConfig.IdentityVerificationMode.fromString(cs.getIdentityVerification());
+
+        CommitConfig commitConfig = CommitConfig.builder()
+                .identityVerification(identityVerificationMode)
+                .author(authorConfig)
+                .committer(committerConfig)
+                .message(messageConfig)
+                .build();
+
+        log.info(
+                "Loaded commit config: committer.domain.allow={}, committer.local.block={}, message.literals={}, message.patterns={}",
+                cs.getCommitter().getEmail().getDomain().getAllow(),
+                cs.getCommitter().getEmail().getLocal().getBlock(),
+                commitConfig.getMessage().getBlock().getLiterals().size(),
+                commitConfig.getMessage().getBlock().getPatterns().size());
+
+        return commitConfig;
+    }
+
+    private CommitConfig.AuthorConfig buildAuthorConfig(CommitSettings.EmailSettings email) {
+        return CommitConfig.AuthorConfig.builder()
+                .email(buildEmailConfig(email))
+                .build();
+    }
+
+    private CommitConfig.CommitterConfig buildCommitterConfig(CommitSettings.EmailSettings email) {
+        return CommitConfig.CommitterConfig.builder()
+                .email(buildEmailConfig(email))
+                .build();
+    }
+
+    private CommitConfig.EmailConfig buildEmailConfig(CommitSettings.EmailSettings email) {
         String domainAllow = email.getDomain().getAllow();
         CommitConfig.DomainConfig domainConfig = (domainAllow != null && !domainAllow.isBlank())
                 ? CommitConfig.DomainConfig.builder()
@@ -325,32 +366,10 @@ public class JettyConfigurationBuilder {
                         .build()
                 : CommitConfig.LocalConfig.builder().build();
 
-        CommitConfig.MessageConfig messageConfig = CommitConfig.MessageConfig.builder()
-                .block(buildBlockConfig(cs.getMessage().getBlock()))
+        return CommitConfig.EmailConfig.builder()
+                .domain(domainConfig)
+                .local(localConfig)
                 .build();
-
-        CommitConfig.IdentityVerificationMode identityVerificationMode =
-                CommitConfig.IdentityVerificationMode.fromString(cs.getIdentityVerification());
-
-        CommitConfig commitConfig = CommitConfig.builder()
-                .identityVerification(identityVerificationMode)
-                .author(CommitConfig.AuthorConfig.builder()
-                        .email(CommitConfig.EmailConfig.builder()
-                                .domain(domainConfig)
-                                .local(localConfig)
-                                .build())
-                        .build())
-                .message(messageConfig)
-                .build();
-
-        log.info(
-                "Loaded commit config: domain.allow={}, local.block={}, message.literals={}, message.patterns={}",
-                domainAllow != null ? domainAllow : "(none)",
-                localBlock != null ? localBlock : "(none)",
-                commitConfig.getMessage().getBlock().getLiterals().size(),
-                commitConfig.getMessage().getBlock().getPatterns().size());
-
-        return commitConfig;
     }
 
     /**


### PR DESCRIPTION
## Summary

- **#182**: Permission deny messages were building the repo URL as `https://{provider.name}{slug}`, producing malformed output like `https://github/github.com/owner/repo`. Fixed to use `provider.getUri()` in both the store-and-forward hook and transparent proxy filter.

- **#181**: The email domain check was validating the commit *author* instead of the *committer*, causing false-positive rejections when a developer rebased external contributor commits. The committer (the corporate employee who ran the rebase) is the identity that matters for compliance.

  Two independent policy knobs are now available:
  - `commit.committer.email.*` — primary control; enforces that your staff use their work identity. Rebased external commits pass as long as the committer email is valid.
  - `commit.author.email.*` — optional strict mode; blocks pushes containing rebased commits from contributors outside the allowed domain. When a violation fires, the message explains the rebase restriction and suggests opening a PR from the original author's fork instead.

  Each violation is labelled explicitly (`committer email (...)` vs `author email (...)`) with a specific fix hint, so developers never need to ask why their push was rejected.

## Test plan

- [ ] `./gradlew :git-proxy-java-core:test` passes (677 tests)
- [ ] Committer-only config: push with rebased external commit — author email ignored, committer email checked
- [ ] Author+committer config: push with rebased external commit — two labelled violations reported
- [ ] Permission deny message shows well-formed URL (`https://github.com/owner/repo`)