### PR TITLE
feat: bundle gitleaks for all supported architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,17 @@ COPY . .
 # Build the distribution (all deps bundled in lib/).
 # Node.js is installed above; the node-gradle plugin uses it from PATH (download=false).
 # BuildKit cache mounts persist Gradle/npm downloads across builds.
+# gitleaksTargets is derived from TARGETARCH so only the matching binary is bundled,
+# keeping each arch-specific image lean (amd64 image carries only linux_x64, etc.).
 RUN --mount=type=cache,target=/root/.gradle/caches \
     --mount=type=cache,target=/root/.gradle/wrapper \
     --mount=type=cache,target=/root/.npm \
-    ./gradlew clean :git-proxy-java-dashboard:installDist --no-daemon -q
+    case "${TARGETARCH}" in \
+      arm64) GITLEAKS_TARGET=linux_arm64 ;; \
+      *)     GITLEAKS_TARGET=linux_x64   ;; \
+    esac \
+    && ./gradlew clean :git-proxy-java-dashboard:installDist \
+       -PgitleaksTargets=${GITLEAKS_TARGET} --no-daemon -q
 
 # Prepend a conf/ directory to the classpath so that a mounted git-proxy-local.yml
 # is picked up by JettyConfigurationLoader at runtime.

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ ext {
     testContainersVersion = '2.0.4'
 
     // Gitleaks (bundled binary)
-    gitleaksVersion = '8.21.2'
+    gitleaksVersion = '8.30.1'
 
     // OpenAPI spec generation
     swaggerCoreVersion = '2.2.48'

--- a/git-proxy-java-core/build.gradle
+++ b/git-proxy-java-core/build.gradle
@@ -189,95 +189,88 @@ jacocoTestCoverageVerification {
 // ---------------------------------------------------------------------------
 // Hermetic gitleaks bundling
 // ---------------------------------------------------------------------------
-// Detects the current build platform (OS + arch) at Gradle configuration time
-// and downloads the matching gitleaks binary, storing it as the plain name
-// "gitleaks" under build/generated-resources/gitleaks/ so it is packed into
-// the JAR as the classpath resource "gitleaks/gitleaks".
+// Downloads gitleaks binaries at build time and packs them into the JAR as
+// arch-specific classpath resources so GitleaksRunner can extract the right
+// one at runtime without a host installation.
 //
-// At runtime, GitleaksRunner extracts it to a JVM temp directory (cleaned up
-// on JVM shutdown) and invokes it directly — no host installation required.
-//
-// If the build platform is not recognised (e.g. Windows), the download is
-// skipped and a warning is printed.  In that case set
-// commit.secretScanning.scanner-path in git-proxy-local.yml to point at a
-// locally installed gitleaks binary.
+// Default: auto-detects the host OS/arch and downloads only that binary.
+// Override via -PgitleaksTargets to download specific platforms:
+//   -PgitleaksTargets=all                          → all four supported targets
+//   -PgitleaksTargets=linux_x64,linux_arm64        → explicit list
+//   -PgitleaksTargets=linux_x64                    → single target (used by Dockerfile)
 // ---------------------------------------------------------------------------
 
-// Resource root: files here appear at the root of the classpath in the JAR.
-// The gitleaks binary lands at build/generated-resources/gitleaks
-// and is packed into the JAR as the classpath resource "gitleaks".
 def gitleaksResourceDir = layout.buildDirectory.dir("generated-resources")
-
 sourceSets.main.resources.srcDir(gitleaksResourceDir)
 
-// Detect build-time OS and CPU architecture to select the right gitleaks tarball
-def buildOs   = System.properties['os.name'].toLowerCase()
-def buildArch = System.properties['os.arch'].toLowerCase()
+def allGitleaksTargets = ['linux_x64', 'linux_arm64', 'darwin_x64', 'darwin_arm64']
 
-def gitleaksTarSuffix = {
-    String osKey   = buildOs.contains('linux') ? 'linux'
-                   : (buildOs.contains('mac') || buildOs.contains('darwin')) ? 'darwin'
+def gitleaksTargets = {
+    if (project.hasProperty('gitleaksTargets')) {
+        String prop = project.getProperty('gitleaksTargets') as String
+        return prop.trim() == 'all'
+                ? allGitleaksTargets
+                : prop.split(',').collect { it.trim() }.toList()
+    }
+    // Default: detect host platform
+    String os   = System.properties['os.name'].toLowerCase()
+    String arch = System.properties['os.arch'].toLowerCase()
+    String osKey   = os.contains('linux') ? 'linux'
+                   : (os.contains('mac') || os.contains('darwin')) ? 'darwin'
                    : null
-    String archKey = (buildArch.contains('amd64') || buildArch.contains('x86_64')) ? 'x64'
-                   : (buildArch.contains('aarch64') || buildArch.contains('arm64')) ? 'arm64'
+    String archKey = (arch.contains('amd64') || arch.contains('x86_64')) ? 'x64'
+                   : (arch.contains('aarch64') || arch.contains('arm64')) ? 'arm64'
                    : null
-    (osKey && archKey) ? "${osKey}_${archKey}" : null
+    if (osKey && archKey) return ["${osKey}_${archKey}"]
+    logger.warn("gitleaks: unrecognised build platform (os='${os}', arch='${arch}') — " +
+            "skipping download. Use -PgitleaksTargets=<target> or set scanner-path in config.")
+    return []
 }()
 
 tasks.register('downloadGitleaks') {
     group = 'build setup'
-    description = "Downloads the gitleaks ${gitleaksVersion} binary for the current build platform."
+    description = "Downloads gitleaks ${gitleaksVersion} binaries for all supported platforms."
 
-    // Output: build/generated-resources/gitleaks → JAR classpath: gitleaks
-    def outputFile = gitleaksResourceDir.map { it.file("gitleaks") }
-    outputs.file(outputFile)
+    gitleaksTargets.each { suffix ->
+        outputs.file(gitleaksResourceDir.map { it.file("gitleaks/${suffix}") })
+    }
 
     doLast {
-        if (!gitleaksTarSuffix) {
-            logger.warn(
-                "Unsupported build platform (os='${buildOs}', arch='${buildArch}') — " +
-                "skipping bundled gitleaks download. Set commit.secretScanning.scanner-path " +
-                "in git-proxy-local.yml to use a locally installed gitleaks binary.")
-            return
-        }
-
-        def out = outputFile.get().asFile
-        if (out.exists()) {
-            logger.lifecycle("gitleaks ${gitleaksVersion} (${gitleaksTarSuffix}) already bundled, skipping.")
-            return
-        }
-        out.parentFile.mkdirs()
-
-        def tarName = "gitleaks_${gitleaksVersion}_${gitleaksTarSuffix}.tar.gz"
-        def gitleaksDownloadUrl = 'https://github.com/gitleaks/gitleaks/releases/download'
-        if (System.getenv('GITLEAKS_DOWNLOAD_URL')) {
-            gitleaksDownloadUrl = System.getenv('GITLEAKS_DOWNLOAD_URL')
-        }
-        def tarUrl  = "${gitleaksDownloadUrl}/v${gitleaksVersion}/${tarName}"
-        def tmpDir  = layout.buildDirectory.dir("tmp/gitleaks").get().asFile
+        def baseDownloadUrl = System.getenv('GITLEAKS_DOWNLOAD_URL')
+                ?: 'https://github.com/gitleaks/gitleaks/releases/download'
+        def tmpDir = layout.buildDirectory.dir("tmp/gitleaks").get().asFile
         tmpDir.mkdirs()
-        def tarFile = new File(tmpDir, tarName)
 
-        logger.lifecycle("Downloading gitleaks ${gitleaksVersion} (${gitleaksTarSuffix})...")
-        new URL(tarUrl).withInputStream { is -> tarFile.bytes = is.bytes }
+        gitleaksTargets.each { suffix ->
+            def out = gitleaksResourceDir.get().file("gitleaks/${suffix}").asFile
+            if (out.exists()) {
+                logger.lifecycle("gitleaks ${gitleaksVersion} (${suffix}) already bundled, skipping.")
+                return
+            }
+            out.parentFile.mkdirs()
 
-        // Extract just the gitleaks binary; Ant places it as out.parent/gitleaks == out
-        ant.untar(src: tarFile.absolutePath, dest: out.parent, compression: 'gzip') {
-            patternset { include(name: 'gitleaks') }
+            def tarName = "gitleaks_${gitleaksVersion}_${suffix}.tar.gz"
+            def tarUrl  = "${baseDownloadUrl}/v${gitleaksVersion}/${tarName}"
+            def tarFile = new File(tmpDir, tarName)
+
+            logger.lifecycle("Downloading gitleaks ${gitleaksVersion} (${suffix})...")
+            new URL(tarUrl).withInputStream { is -> tarFile.bytes = is.bytes }
+
+            // Extract to a suffix-specific temp dir to avoid name collision between targets
+            def extractDir = new File(tmpDir, suffix)
+            extractDir.mkdirs()
+            ant.untar(src: tarFile.absolutePath, dest: extractDir.absolutePath, compression: 'gzip') {
+                patternset { include(name: 'gitleaks') }
+            }
+            def extracted = new File(extractDir, 'gitleaks')
+            if (!extracted.exists()) {
+                throw new GradleException("gitleaks binary not found in ${tarName} after extraction")
+            }
+            extracted.renameTo(out)
+            out.setExecutable(true)
+            logger.lifecycle("Bundled gitleaks (${suffix}) at ${out} (${out.length()} bytes)")
         }
-
-        if (!out.exists()) {
-            throw new GradleException("gitleaks binary not found in ${tarName} after extraction")
-        }
-        out.setExecutable(true)
-        logger.lifecycle("Bundled gitleaks at ${out} (${out.length()} bytes)")
     }
 }
 
-// The JAR always ships with the bundled gitleaks binary (DEFAULT_VERSION).
-// At runtime, GitleaksRunner uses it unless:
-//   - commit.secretScanning.scanner-path is set (explicit override), or
-//   - commit.secretScanning.version is set to a different version and auto-install is true
-//     (downloads and caches the requested version on first use).
-// The download is a no-op when the binary is already present, so it only costs time once.
 processResources.dependsOn('downloadGitleaks')

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/GitleaksRunner.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/GitleaksRunner.java
@@ -53,10 +53,10 @@ public class GitleaksRunner {
      * Default gitleaks version used for auto-install. Keep in sync with {@code gitleaksVersion} in
      * {@code git-proxy-java-core/build.gradle}.
      */
-    public static final String DEFAULT_VERSION = "8.21.2";
+    public static final String DEFAULT_VERSION = "8.30.1";
 
-    /** Classpath resource name for the pre-bundled gitleaks binary (opt-in, not shipped by default). */
-    private static final String BUNDLED_BINARY_RESOURCE = "gitleaks";
+    /** Classpath resource prefix for bundled gitleaks binaries; full path is {@code gitleaks/<os>_<arch>}. */
+    private static final String BUNDLED_BINARY_RESOURCE_PREFIX = "gitleaks/";
 
     /** Exit code gitleaks returns when findings are present (distinct from error exit codes). */
     private static final int FINDINGS_EXIT_CODE = 2;
@@ -395,8 +395,20 @@ public class GitleaksRunner {
         synchronized (EXTRACT_LOCK) {
             if (extractedBinaryPath != null) return extractedBinaryPath;
 
-            InputStream resource = GitleaksRunner.class.getClassLoader().getResourceAsStream(BUNDLED_BINARY_RESOURCE);
-            if (resource == null) return null;
+            String suffix = detectTarSuffix();
+            if (suffix == null) {
+                log.debug(
+                        "gitleaks: no bundled binary for platform ({} / {})",
+                        System.getProperty("os.name"),
+                        System.getProperty("os.arch"));
+                return null;
+            }
+            String resourceName = BUNDLED_BINARY_RESOURCE_PREFIX + suffix;
+            InputStream resource = GitleaksRunner.class.getClassLoader().getResourceAsStream(resourceName);
+            if (resource == null) {
+                log.debug("gitleaks bundled resource not found: {}", resourceName);
+                return null;
+            }
 
             Path tempDir = Files.createTempDirectory("git-proxy-java-gitleaks-");
             Path binaryPath = tempDir.resolve("gitleaks");
@@ -414,7 +426,7 @@ public class GitleaksRunner {
             }));
 
             extractedBinaryPath = binaryPath;
-            log.info("Extracted bundled gitleaks binary to {}", binaryPath);
+            log.info("Extracted bundled gitleaks binary ({}) to {}", suffix, binaryPath);
             return extractedBinaryPath;
         }
     }


### PR DESCRIPTION
## Summary

- Bumps gitleaks from 8.21.2 → 8.30.1
- Bundles arch-specific gitleaks binaries as classpath resources (`gitleaks/linux_x64`, `gitleaks/linux_arm64`, `gitleaks/darwin_x64`, `gitleaks/darwin_arm64`) so `GitleaksRunner` can extract the right one at runtime
- Fixes silent secret-scan failure on arm64 containers — previously a CI (amd64) build bundled only the amd64 binary, so the arm64 image could never execute it
- Docker builds pass `-PgitleaksTargets=linux_{x64,arm64}` derived from `TARGETARCH` so each arch image carries only its own binary (lean images)
- Default local build auto-detects host arch and downloads one binary; `-PgitleaksTargets=all` opts in to bundling all four (future JAR distribution)

## Test plan

- [ ] `./gradlew :git-proxy-java-core:test` passes with auto-detected single binary
- [ ] `./gradlew :git-proxy-java-core:downloadGitleaks -PgitleaksTargets=all` downloads all four targets
- [ ] `./gradlew :git-proxy-java-core:downloadGitleaks -PgitleaksTargets=linux_arm64` downloads only arm64 (Dockerfile path)
- [ ] CI passes on both amd64 and arm64 build legs

closes #201