### PR TITLE
feat: reject conflicting permission entries at load/save time; document GLOB semantics

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -900,6 +900,103 @@ rules:
         - "*.github.io"
 ```
 
+> **Glob on `owners` and `names`:** Owner and repository names cannot contain `/`, so `*` reliably matches any
+> valid name including hyphens, underscores, and dots. You do not need `**` in these fields — `*` is sufficient
+> and the two are equivalent in this context.
+
+### Real-world URL rule examples
+
+**Gateway for a specific SCM — allow all push and fetch:**
+
+```yaml
+rules:
+  allow:
+    - enabled: true
+      order: 110
+      operations:
+        - FETCH
+        - PUSH
+      providers:
+        - internal-github
+      slugs:
+        - "*/*"
+```
+
+**Allow repos under a set of known owner orgs, identified by a name prefix:**
+
+This is useful when multiple teams or divisions share a SCM and are distinguished by an owner-name convention
+(e.g. `teamA-*`, `teamB-*`).
+
+```yaml
+rules:
+  allow:
+    - enabled: true
+      order: 110
+      operations:
+        - FETCH
+        - PUSH
+      providers:
+        - internal-github
+      owners:
+        - "regex:team-(alpha|beta|gamma)"
+```
+
+**Allow push only for repos whose name starts with a known prefix:**
+
+When application or project repos are identified by a prefix (e.g. a fixed-length code followed by a hyphen),
+match on `names` rather than the full slug so the rule applies regardless of which owner org the repo lives under.
+
+```yaml
+rules:
+  allow:
+    - enabled: true
+      order: 110
+      operations:
+        - PUSH
+      providers:
+        - internal-github
+      names:
+        - "proj0-*"
+        - "proj1-*"
+        - "shared-*"
+```
+
+**Combine owner and name matching (SCM-to-SCM migration scenario):**
+
+When acting as a gateway between two SCMs (e.g. during an M&A integration), you may want to allow only repos
+that belong to a specific org AND follow a naming pattern. Use `slugs` with a glob or regex for this — each
+entry in `owners` and `names` is evaluated independently (OR logic), so combining both in one rule block does
+not produce an AND condition.
+
+```yaml
+rules:
+  allow:
+    # Allow fetch from the source SCM for a specific org + name prefix — use slug for AND logic
+    - enabled: true
+      order: 110
+      operations:
+        - FETCH
+      providers:
+        - source-github
+      slugs:
+        - "acquired-org/migrate-*"
+
+    # Allow push to the destination SCM for the same set, using regex for stricter control
+    - enabled: true
+      order: 120
+      operations:
+        - PUSH
+      providers:
+        - dest-gitlab
+      slugs:
+        - "regex:/migrated-org/migrate-.*"
+```
+
+> **`owners` and `names` are OR conditions.** An entry under `owners: [acme]` allows any repo whose owner is
+> `acme`, regardless of repo name. An entry under `names: [migrate-*]` allows any repo whose name matches,
+> regardless of owner. To restrict both owner AND name together, use `slugs` with a glob (e.g.
+> `acme/migrate-*`) or a `regex:`-prefixed pattern.
+
 ## Permissions
 
 Permissions control which proxy users can push to or review pushes from specific repositories. They are checked
@@ -946,6 +1043,105 @@ permissions:
 | `path`      | string | —         | Repository path pattern (`/owner/repo`); interpretation depends on `path-type`              |
 | `path-type` | enum   | `LITERAL` | `LITERAL` (exact), `GLOB` (`*`/`?` wildcards), `REGEX` (Java regex against the full path)  |
 | `operations`| enum   | `PUSH`    | What the user may do: `PUSH`, `REVIEW`, `PUSH_AND_REVIEW`, `SELF_CERTIFY`                  |
+
+### GLOB path semantics
+
+GLOB matching uses Java NIO `PathMatcher` (`glob:` prefix). Paths follow the `/owner/repo` convention.
+
+| Wildcard | Matches | Does NOT match |
+| -------- | ------- | -------------- |
+| `*` | Any sequence of characters within **one** path segment (no `/` crossing) | Another path segment or the `/` separator itself |
+| `**` | Any sequence of characters **including** path separators (zero or more segments) | — |
+| `?` | Exactly **one** character within a path segment | `/` or a multi-character sequence |
+
+Hyphens, digits, and dots in names are treated as regular characters — no special escaping needed.
+
+**Pattern examples:**
+
+| Pattern | Matches | Does NOT match |
+| ------- | ------- | -------------- |
+| `/acme/repo` _(LITERAL)_ | `/acme/repo` | `/acme/other` |
+| `/acme/*` | `/acme/repo`, `/acme/my-service`, `/acme/repo-v2` | `/acme/sub/repo`, `/other/repo` |
+| `/acme/**` | `/acme/repo`, `/acme/sub/repo`, `/acme/a/b/c` | `/other/repo` |
+| `/**` | Every path | — |
+| `/*/repo` | `/acme/repo`, `/other/repo` | `/acme/other-repo` |
+| `/acme/service-*` | `/acme/service-api`, `/acme/service-worker` | `/acme/repo`, `/acme/my-service-api` |
+| `/acme/repo-?` | `/acme/repo-1`, `/acme/repo-a` | `/acme/repo-12`, `/acme/repo-` |
+
+> **Glob on the repo-name segment:** Repository names cannot contain `/`, so `*` will never cross a path separator
+> when used in the name position (e.g. `/owner/prefix-*`). In this position `*` and `**` are equivalent — use `*`.
+
+> **Conflict detection:** At config load time and when saving via the dashboard API, git-proxy-java rejects any
+> new permission entry whose path overlaps with an existing entry for the same user and provider. Two paths overlap
+> when they are equal, or when one is a GLOB/REGEX pattern that would match the other path string. This prevents
+> silent misconfiguration where the effective permission depends on evaluation order.
+
+### Real-world permission examples
+
+**Gateway use case — allow a user to push any repo on a specific provider:**
+
+```yaml
+permissions:
+  - username: alice
+    provider: internal-github
+    path: "/**"
+    path-type: GLOB
+    operations: PUSH_AND_REVIEW
+```
+
+**Allow push to all repos whose name starts with a known prefix (e.g. a project code):**
+
+Useful when repos are identified by a fixed prefix such as a project or application code. Since repo names cannot
+contain `/`, the `*` in the name segment matches any suffix including hyphens and digits.
+
+```yaml
+permissions:
+  - username: alice
+    provider: internal-github
+    path: "/myorg/proj0-*"
+    path-type: GLOB
+    operations: PUSH
+
+  # Or match the same prefix across any owner using a wildcard in the owner position:
+  - username: alice
+    provider: internal-github
+    path: "/*/proj0-*"
+    path-type: GLOB
+    operations: PUSH
+```
+
+**Regex — match repos under multiple owner orgs:**
+
+```yaml
+permissions:
+  - username: alice
+    provider: internal-github
+    path: "/team-(alpha|beta)/.*"
+    path-type: REGEX
+    operations: PUSH_AND_REVIEW
+```
+
+**Self-certify for a trusted committer scoped to a prefix:**
+
+A trusted committer needs both entries: `PUSH_AND_REVIEW` to be able to push, and `SELF_CERTIFY` to bypass the
+peer review requirement. These cover separate code paths and are not treated as conflicting.
+
+```yaml
+permissions:
+  # Push and review access
+  - username: trusted-dev
+    provider: internal-github
+    path: "/myorg/proj0-*"
+    path-type: GLOB
+    operations: PUSH_AND_REVIEW
+
+  # Self-certify on the same scope (requires SELF_CERTIFY role on the user too)
+  - username: trusted-dev
+    provider: internal-github
+    path: "/myorg/proj0-*"
+    path-type: GLOB
+    operations: SELF_CERTIFY
+```
 
 ### Operations
 

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/permission/RepoPermissionService.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/permission/RepoPermissionService.java
@@ -84,6 +84,25 @@ public class RepoPermissionService {
         return allowed;
     }
 
+    /**
+     * Returns the first existing permission that would conflict with {@code incoming}, or empty if none.
+     *
+     * <p>Two permissions conflict when they share the same username and provider, their paths overlap (exact string
+     * equality, or one pattern matches the other path string), AND their operations affect the same permission check.
+     * {@link RepoPermission.Operations#SELF_CERTIFY} is evaluated by a separate code path from push/review operations,
+     * so a {@code SELF_CERTIFY} entry does not conflict with a {@code PUSH_AND_REVIEW} entry on the same path — both
+     * are needed for a trusted committer configuration.
+     */
+    public Optional<RepoPermission> findConflict(RepoPermission incoming) {
+        return store.findAll().stream()
+                .filter(e -> !e.getId().equals(incoming.getId()))
+                .filter(e -> e.getUsername().equals(incoming.getUsername()))
+                .filter(e -> e.getProvider().equals(incoming.getProvider()))
+                .filter(e -> pathsOverlap(e, incoming))
+                .filter(e -> operationsOverlap(e.getOperations(), incoming.getOperations()))
+                .findFirst();
+    }
+
     // ---- store delegation ----
 
     public void save(RepoPermission permission) {
@@ -120,12 +139,47 @@ public class RepoPermissionService {
                 .filter(p -> p.getSource() == RepoPermission.Source.CONFIG)
                 .forEach(p -> store.delete(p.getId()));
         for (RepoPermission p : permissions) {
+            Optional<RepoPermission> conflict = findConflict(p);
+            if (conflict.isPresent()) {
+                RepoPermission c = conflict.get();
+                throw new IllegalStateException(String.format(
+                        "Conflicting permission for user '%s' provider '%s': path '%s' (%s) overlaps with '%s' (%s) [%s] — fix config and restart",
+                        p.getUsername(),
+                        p.getProvider(),
+                        p.getPath(),
+                        p.getPathType(),
+                        c.getPath(),
+                        c.getPathType(),
+                        c.getSource()));
+            }
             store.save(p);
         }
         log.info("Seeded {} permission grant(s) from config", permissions.size());
     }
 
     // ---- internals ----
+
+    private boolean operationsOverlap(RepoPermission.Operations a, RepoPermission.Operations b) {
+        // SELF_CERTIFY is evaluated by isBypassReviewAllowed(), independent of push/review checks.
+        // A SELF_CERTIFY entry only conflicts with another SELF_CERTIFY entry.
+        if (a == RepoPermission.Operations.SELF_CERTIFY || b == RepoPermission.Operations.SELF_CERTIFY) {
+            return a == b;
+        }
+        // Among PUSH / REVIEW / PUSH_AND_REVIEW: conflict if both entries would affect the same check.
+        // PUSH_AND_REVIEW overlaps with both PUSH and REVIEW; PUSH and REVIEW don't overlap each other.
+        boolean aPush = a == RepoPermission.Operations.PUSH || a == RepoPermission.Operations.PUSH_AND_REVIEW;
+        boolean bPush = b == RepoPermission.Operations.PUSH || b == RepoPermission.Operations.PUSH_AND_REVIEW;
+        boolean aReview = a == RepoPermission.Operations.REVIEW || a == RepoPermission.Operations.PUSH_AND_REVIEW;
+        boolean bReview = b == RepoPermission.Operations.REVIEW || b == RepoPermission.Operations.PUSH_AND_REVIEW;
+        return (aPush && bPush) || (aReview && bReview);
+    }
+
+    private boolean pathsOverlap(RepoPermission a, RepoPermission b) {
+        if (a.getPath().equals(b.getPath())) return true;
+        if (matchesPath(a, b.getPath())) return true;
+        if (matchesPath(b, a.getPath())) return true;
+        return false;
+    }
 
     private boolean isAllowed(String username, String provider, String path, RepoPermission.Operations op) {
         List<RepoPermission> forProvider = store.findByProvider(provider);

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/permission/RepoPermissionServiceTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/permission/RepoPermissionServiceTest.java
@@ -154,6 +154,90 @@ class RepoPermissionServiceTest {
         assertTrue(svc.isAllowedToPush("alice", "github", "/other/thing"));
     }
 
+    // ---- glob matching semantics ----
+    //
+    // Paths use the /owner/repo convention. Glob matching uses java.nio.file.FileSystem#getPathMatcher
+    // ("glob:" prefix). Key rules:
+    //   * = any sequence of characters within ONE path segment (no "/" crossing)
+    //   ** = any sequence including path separators (matches across segments)
+    //   ? = exactly one character (no "/" crossing)
+    //   Hyphens, dots, and digits in names are regular characters — no special treatment.
+
+    @Test
+    void glob_singleStar_matchesRepoName() {
+        svc.save(grant("alice", "github", "/acme/*", RepoPermission.PathType.GLOB, RepoPermission.Operations.PUSH));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/repo"));
+    }
+
+    @Test
+    void glob_singleStar_matchesHyphenatedName() {
+        svc.save(grant("alice", "github", "/acme/*", RepoPermission.PathType.GLOB, RepoPermission.Operations.PUSH));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/my-service"));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/repo-v2"));
+    }
+
+    @Test
+    void glob_singleStar_doesNotCrossPathSeparator() {
+        svc.save(grant("alice", "github", "/acme/*", RepoPermission.PathType.GLOB, RepoPermission.Operations.PUSH));
+        // /acme/sub/repo has two segments after /acme — single * does not match
+        assertFalse(svc.isAllowedToPush("alice", "github", "/acme/sub/repo"));
+    }
+
+    @Test
+    void glob_singleStar_doesNotMatchOtherOwner() {
+        svc.save(grant("alice", "github", "/acme/*", RepoPermission.PathType.GLOB, RepoPermission.Operations.PUSH));
+        assertFalse(svc.isAllowedToPush("alice", "github", "/other/repo"));
+    }
+
+    @Test
+    void glob_doubleStar_matchesAcrossSegments() {
+        svc.save(grant("alice", "github", "/acme/**", RepoPermission.PathType.GLOB, RepoPermission.Operations.PUSH));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/repo"));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/sub/repo"));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/a/b/c"));
+    }
+
+    @Test
+    void glob_doubleStar_doesNotMatchOtherOwner() {
+        svc.save(grant("alice", "github", "/acme/**", RepoPermission.PathType.GLOB, RepoPermission.Operations.PUSH));
+        assertFalse(svc.isAllowedToPush("alice", "github", "/other/repo"));
+    }
+
+    @Test
+    void glob_leadingDoubleStar_matchesAllPaths() {
+        svc.save(grant("alice", "github", "/**", RepoPermission.PathType.GLOB, RepoPermission.Operations.PUSH));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/repo"));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/other/thing"));
+    }
+
+    @Test
+    void glob_wildcardOwner_matchesSpecificRepo() {
+        svc.save(grant("alice", "github", "/*/repo", RepoPermission.PathType.GLOB, RepoPermission.Operations.PUSH));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/repo"));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/other/repo"));
+        assertFalse(svc.isAllowedToPush("alice", "github", "/acme/other-repo"));
+    }
+
+    @Test
+    void glob_prefixSuffix_matchesNames() {
+        svc.save(grant(
+                "alice", "github", "/acme/service-*", RepoPermission.PathType.GLOB, RepoPermission.Operations.PUSH));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/service-api"));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/service-worker"));
+        assertFalse(svc.isAllowedToPush("alice", "github", "/acme/repo"));
+        assertFalse(svc.isAllowedToPush("alice", "github", "/acme/my-service-api"));
+    }
+
+    @Test
+    void glob_questionMark_matchesSingleChar() {
+        svc.save(
+                grant("alice", "github", "/acme/repo-?", RepoPermission.PathType.GLOB, RepoPermission.Operations.PUSH));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/repo-1"));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/repo-a"));
+        assertFalse(svc.isAllowedToPush("alice", "github", "/acme/repo-12"));
+        assertFalse(svc.isAllowedToPush("alice", "github", "/acme/repo-"));
+    }
+
     // ---- regex matching ----
 
     @Test
@@ -229,6 +313,190 @@ class RepoPermissionServiceTest {
         svc.seedFromConfig(List.of());
         assertTrue(svc.isAllowedToPush("bob", "github", "/owner/repo"));
         assertFalse(svc.isAllowedToPush("alice", "github", "/owner/repo"));
+    }
+
+    // ---- conflict detection ----
+
+    @Test
+    void findConflict_exactDuplicatePath_sameOps_detected() {
+        svc.save(grant("alice", "github", "/acme/repo"));
+        RepoPermission incoming =
+                grant("alice", "github", "/acme/repo", RepoPermission.PathType.LITERAL, RepoPermission.Operations.PUSH);
+        assertTrue(svc.findConflict(incoming).isPresent());
+    }
+
+    @Test
+    void findConflict_pushVsPushAndReview_detected() {
+        svc.save(grant(
+                "alice", "github", "/acme/repo", RepoPermission.PathType.LITERAL, RepoPermission.Operations.PUSH));
+        RepoPermission incoming = grant(
+                "alice",
+                "github",
+                "/acme/repo",
+                RepoPermission.PathType.LITERAL,
+                RepoPermission.Operations.PUSH_AND_REVIEW);
+        assertTrue(svc.findConflict(incoming).isPresent());
+    }
+
+    @Test
+    void findConflict_pushAndReviewVsSelfCertify_noConflict() {
+        // Trusted committer pattern: PUSH_AND_REVIEW + SELF_CERTIFY on the same path must coexist.
+        // They are evaluated by separate code paths (isAllowedToPush vs isBypassReviewAllowed).
+        svc.save(grant(
+                "alice",
+                "github",
+                "/acme/repo",
+                RepoPermission.PathType.LITERAL,
+                RepoPermission.Operations.PUSH_AND_REVIEW));
+        RepoPermission incoming = grant(
+                "alice",
+                "github",
+                "/acme/repo",
+                RepoPermission.PathType.LITERAL,
+                RepoPermission.Operations.SELF_CERTIFY);
+        assertTrue(svc.findConflict(incoming).isEmpty());
+    }
+
+    @Test
+    void findConflict_selfCertifyVsSelfCertify_detected() {
+        svc.save(grant(
+                "alice",
+                "github",
+                "/acme/repo",
+                RepoPermission.PathType.LITERAL,
+                RepoPermission.Operations.SELF_CERTIFY));
+        RepoPermission incoming = grant(
+                "alice",
+                "github",
+                "/acme/repo",
+                RepoPermission.PathType.LITERAL,
+                RepoPermission.Operations.SELF_CERTIFY);
+        assertTrue(svc.findConflict(incoming).isPresent());
+    }
+
+    @Test
+    void findConflict_pushVsReview_noConflict() {
+        // PUSH and REVIEW affect different permission checks and can coexist.
+        svc.save(grant(
+                "alice", "github", "/acme/repo", RepoPermission.PathType.LITERAL, RepoPermission.Operations.PUSH));
+        RepoPermission incoming = grant(
+                "alice", "github", "/acme/repo", RepoPermission.PathType.LITERAL, RepoPermission.Operations.REVIEW);
+        assertTrue(svc.findConflict(incoming).isEmpty());
+    }
+
+    @Test
+    void findConflict_differentUser_noConflict() {
+        svc.save(grant("alice", "github", "/acme/repo"));
+        RepoPermission incoming =
+                grant("bob", "github", "/acme/repo", RepoPermission.PathType.LITERAL, RepoPermission.Operations.PUSH);
+        assertTrue(svc.findConflict(incoming).isEmpty());
+    }
+
+    @Test
+    void findConflict_differentProvider_noConflict() {
+        svc.save(grant("alice", "github", "/acme/repo"));
+        RepoPermission incoming =
+                grant("alice", "gitlab", "/acme/repo", RepoPermission.PathType.LITERAL, RepoPermission.Operations.PUSH);
+        assertTrue(svc.findConflict(incoming).isEmpty());
+    }
+
+    @Test
+    void findConflict_literalMatchedByExistingGlob_detected() {
+        svc.save(grant("alice", "github", "/acme/**", RepoPermission.PathType.GLOB, RepoPermission.Operations.PUSH));
+        RepoPermission incoming =
+                grant("alice", "github", "/acme/repo", RepoPermission.PathType.LITERAL, RepoPermission.Operations.PUSH);
+        assertTrue(svc.findConflict(incoming).isPresent());
+    }
+
+    @Test
+    void findConflict_incomingGlobMatchesExistingLiteral_detected() {
+        svc.save(grant("alice", "github", "/acme/repo"));
+        RepoPermission incoming = grant(
+                "alice", "github", "/acme/**", RepoPermission.PathType.GLOB, RepoPermission.Operations.PUSH_AND_REVIEW);
+        assertTrue(svc.findConflict(incoming).isPresent());
+    }
+
+    @Test
+    void findConflict_globOverlap_subsetDetected() {
+        svc.save(grant(
+                "alice",
+                "github",
+                "/acme/**",
+                RepoPermission.PathType.GLOB,
+                RepoPermission.Operations.PUSH_AND_REVIEW));
+        RepoPermission incoming = grant(
+                "alice", "github", "/acme/*", RepoPermission.PathType.GLOB, RepoPermission.Operations.PUSH_AND_REVIEW);
+        assertTrue(svc.findConflict(incoming).isPresent());
+    }
+
+    @Test
+    void findConflict_noOverlap_noConflict() {
+        svc.save(grant("alice", "github", "/acme/repo-a"));
+        RepoPermission incoming = grant(
+                "alice", "github", "/acme/repo-b", RepoPermission.PathType.LITERAL, RepoPermission.Operations.PUSH);
+        assertTrue(svc.findConflict(incoming).isEmpty());
+    }
+
+    @Test
+    void seedFromConfig_conflictingRows_throwsIllegalStateException() {
+        // Two CONFIG rows for the same user+provider+path with overlapping operations
+        List<RepoPermission> permissions = List.of(
+                RepoPermission.builder()
+                        .username("alice")
+                        .provider("github")
+                        .path("/acme/**")
+                        .pathType(RepoPermission.PathType.GLOB)
+                        .operations(RepoPermission.Operations.PUSH_AND_REVIEW)
+                        .source(RepoPermission.Source.CONFIG)
+                        .build(),
+                RepoPermission.builder()
+                        .username("alice")
+                        .provider("github")
+                        .path("/acme/*")
+                        .pathType(RepoPermission.PathType.GLOB)
+                        .operations(RepoPermission.Operations.PUSH)
+                        .source(RepoPermission.Source.CONFIG)
+                        .build());
+        assertThrows(IllegalStateException.class, () -> svc.seedFromConfig(permissions));
+    }
+
+    @Test
+    void seedFromConfig_configConflictsWithExistingDb_throwsIllegalStateException() {
+        // Existing DB row for PUSH; CONFIG row tries to add PUSH_AND_REVIEW on an overlapping path
+        svc.save(grant(
+                "alice", "github", "/acme/repo", RepoPermission.PathType.LITERAL, RepoPermission.Operations.PUSH));
+        List<RepoPermission> permissions = List.of(RepoPermission.builder()
+                .username("alice")
+                .provider("github")
+                .path("/acme/**")
+                .pathType(RepoPermission.PathType.GLOB)
+                .operations(RepoPermission.Operations.PUSH_AND_REVIEW)
+                .source(RepoPermission.Source.CONFIG)
+                .build());
+        assertThrows(IllegalStateException.class, () -> svc.seedFromConfig(permissions));
+    }
+
+    @Test
+    void seedFromConfig_selfCertifyAlongsidePushAndReview_noConflict() {
+        // Trusted committer pattern — both entries are needed and must coexist
+        List<RepoPermission> permissions = List.of(
+                RepoPermission.builder()
+                        .username("alice")
+                        .provider("github")
+                        .path("/acme/**")
+                        .pathType(RepoPermission.PathType.GLOB)
+                        .operations(RepoPermission.Operations.PUSH_AND_REVIEW)
+                        .source(RepoPermission.Source.CONFIG)
+                        .build(),
+                RepoPermission.builder()
+                        .username("alice")
+                        .provider("github")
+                        .path("/acme/**")
+                        .pathType(RepoPermission.PathType.GLOB)
+                        .operations(RepoPermission.Operations.SELF_CERTIFY)
+                        .source(RepoPermission.Source.CONFIG)
+                        .build());
+        assertDoesNotThrow(() -> svc.seedFromConfig(permissions));
     }
 
     // ---- CRUD delegation ----

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/controller/PermissionController.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/controller/PermissionController.java
@@ -70,6 +70,16 @@ public class PermissionController {
                 .operations(operations)
                 .source(RepoPermission.Source.DB)
                 .build();
+        var conflict = permissionService.findConflict(permission);
+        if (conflict.isPresent()) {
+            var c = conflict.get();
+            return ResponseEntity.badRequest()
+                    .body(Map.of(
+                            "error",
+                            String.format(
+                                    "Conflicts with existing permission: path '%s' (%s)",
+                                    c.getPath(), c.getPathType())));
+        }
         permissionService.save(permission);
         return ResponseEntity.status(HttpStatus.CREATED).body(permission);
     }

--- a/git-proxy-java-dashboard/src/test/java/org/finos/gitproxy/dashboard/controller/PermissionControllerTest.java
+++ b/git-proxy-java-dashboard/src/test/java/org/finos/gitproxy/dashboard/controller/PermissionControllerTest.java
@@ -150,6 +150,18 @@ class PermissionControllerTest {
     }
 
     @Test
+    void add_conflictingPermission_returns400() {
+        when(userStore.findByUsername("alice")).thenReturn(Optional.of(ALICE));
+        when(permissionService.findConflict(any())).thenReturn(Optional.of(CONFIG_PERM));
+
+        var resp = controller.add(
+                "alice", new PermissionController.AddPermissionRequest("github", "/acme/repo", "LITERAL", "PUSH"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+        verify(permissionService, never()).save(any());
+    }
+
+    @Test
     void add_explicitGlobAndPush_saved() {
         when(userStore.findByUsername("alice")).thenReturn(Optional.of(ALICE));
         var captor = ArgumentCaptor.forClass(RepoPermission.class);


### PR DESCRIPTION
## Summary

- `RepoPermissionService.findConflict()`: detects overlapping paths for the same username+provider — exact string equality, or one path's GLOB/REGEX pattern matches the other path string as a literal (covers LITERAL-vs-GLOB, LITERAL-vs-REGEX, GLOB-vs-GLOB subset cases)
- `seedFromConfig`: throws `IllegalStateException` on first conflict, failing startup loudly rather than silently evaluating in undefined order
- `PermissionController.add`: returns `400` with the conflicting path before saving, blocking new conflicts via the dashboard API
- CONFIG-vs-DB conflicts are checked (not just within each source)
- Comprehensive GLOB behaviour tests: `*` vs `**`, hyphenated names, path separator crossing, wildcard owner/repo patterns, `?` single-char matching
- `CONFIGURATION.md`: new GLOB semantics table + conflict detection note in the permissions section

## Test plan

- [ ] All existing permission tests still pass
- [ ] New conflict tests: exact duplicate, glob-overlaps-literal (both directions), glob-subset, different user/provider do not conflict
- [ ] `seedFromConfig` throws on both CONFIG-vs-CONFIG and CONFIG-vs-DB conflicts
- [ ] Controller returns 400 on conflict, does not call `save`
- [ ] `jacocoTestCoverageVerification` passes

closes #215