### PR TITLE
feat: upgrade to Java 25 (Temurin LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: gradle
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: gradle
 
       - name: Submit dependency graph
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: gradle
 
       - name: Run e2e tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: gradle
 
       - name: Set up Node

--- a/.github/workflows/cve.yml
+++ b/.github/workflows/cve.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: gradle
 
       - name: Generate SBOM
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: gradle
 
       - name: Cache NVD database

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
 
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM docker.io/eclipse-temurin:21-jdk@sha256:e58e492628c1428ceb838afc1a1b8762673d5eaa09296f560c363daea0fdcf3b AS builder
+FROM docker.io/eclipse-temurin:25-jdk@sha256:c3a5cfd77c9a43dd95269a266290d365b79b174381d8336a3f76a7ae117beefa AS builder
 
 # Install Node.js directly from the official distribution with SHA256 verification.
 # To update: download the new tarball, verify against nodejs.org/dist/vX.Y.Z/SHASUMS256.txt,
@@ -54,7 +54,7 @@ RUN sed -i \
     git-proxy-java-dashboard/build/install/git-proxy-java-dashboard/bin/git-proxy-java-dashboard
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM docker.io/eclipse-temurin:21-jre@sha256:ff65ff0d43c73d2b675eb4b758665a5cb487e7df127436a9979f8172c144c819
+FROM docker.io/eclipse-temurin:25-jre@sha256:5742cdb98ef117621ad75f57475ab127db04f344d9c523307cc60b9955bdd676
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ FROM docker.io/eclipse-temurin:25-jdk@sha256:c3a5cfd77c9a43dd95269a266290d365b79
 # Install Node.js directly from the official distribution with SHA256 verification.
 # To update: download the new tarball, verify against nodejs.org/dist/vX.Y.Z/SHASUMS256.txt,
 # and update both NODE_VERSION and NODE_SHA256 below.
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
 ARG NODE_VERSION=24.15.0
 ARG NODE_SHA256_AMD64=44836872d9aec49f1e6b52a9a922872db9a2b02d235a616a5681b6a85fec8d89
 ARG NODE_SHA256_ARM64=73afc234d558c24919875f51c2d1ea002a2ada4ea6f83601a383869fefa64eed

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ ext {
     springVersion = '7.0.7'
     springSecurityVersion = '7.0.5'
     springSessionVersion = '4.0.3'
+    lettuceVersion = '6.8.2.RELEASE'
 
     // YAML
     snakeyamlVersion = '2.6'

--- a/git-proxy-java-core/build.gradle
+++ b/git-proxy-java-core/build.gradle
@@ -11,10 +11,10 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
         vendor = JvmVendorSpec.ADOPTIUM
     }
 }

--- a/git-proxy-java-dashboard/build.gradle
+++ b/git-proxy-java-dashboard/build.gradle
@@ -5,10 +5,10 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
         vendor = JvmVendorSpec.ADOPTIUM
     }
 }
@@ -169,6 +169,8 @@ dependencies {
     runtimeOnly "org.postgresql:postgresql:${postgresVersion}"
     // MongoDB driver — compile-scoped because MongoSessionRepository uses the sync client directly.
     implementation "org.mongodb:mongodb-driver-sync:${mongoVersion}"
+
+    compileOnly "io.lettuce:lettuce-core:${lettuceVersion}"
 
     // OpenAPI spec generation — core model + YAML/JSON serialisation only (no JAX-RS required).
     // The spec is built programmatically from Spring's RequestMappingHandlerMapping.

--- a/git-proxy-java-server/build.gradle
+++ b/git-proxy-java-server/build.gradle
@@ -4,10 +4,10 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
         vendor = JvmVendorSpec.ADOPTIUM
     }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-java = "temurin-21"
+java = "temurin-25"
 node = "24.15.0"


### PR DESCRIPTION
closes #192

## Summary

- Bumps all Java toolchain references from 21 → 25 (Temurin LTS) across build files, Dockerfile, and CI workflows
- Fixes a Java 25 compile error: `lettuce-core` is `optional` in spring-data-redis' POM so Gradle omits it from the compile classpath; Java 25's `javac` now errors (not warns) when it can't resolve type annotations from a dependency's class files — fix is one `compileOnly` declaration in the dashboard module

## Changes

| File | Change |
|---|---|
| `mise.toml` | `temurin-21` → `temurin-25` |
| All 3 module `build.gradle` | toolchain + source/targetCompatibility 21 → 25 |
| `build.gradle` | `lettuceVersion = '6.8.2.RELEASE'` |
| `git-proxy-java-dashboard/build.gradle` | `compileOnly "io.lettuce:lettuce-core:${lettuceVersion}"` |
| `Dockerfile` | `eclipse-temurin:21-jdk/jre` → `25-jdk/jre` with fresh pinned digests |
| `ci.yml`, `codeql.yml`, `cve.yml` | `java-version: 21` → `java-version: 25` |

## Test plan

- [x] `./gradlew compileJava` — clean
- [x] `./gradlew test --rerun` — all unit tests pass
- [x] `./gradlew :git-proxy-java-core:jacocoTestCoverageVerification --rerun` — coverage thresholds hold
- [ ] CI (Docker smoke tests, CodeQL, e2e)