### PR TITLE
feat: rc.1 fixes — GLOB default alignment, commit-pinned image promotion, weekly interim image cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    name: CI / Build & Test
+    name: Build & Test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -58,7 +58,7 @@ jobs:
           retention-days: 14
 
   docker-smoke-test:
-    name: CI / Docker Smoke Test (${{ matrix.db }})
+    name: Docker Smoke Test (${{ matrix.db }})
     runs-on: ubuntu-latest
     if: >
       github.ref == 'refs/heads/main' ||
@@ -121,7 +121,7 @@ jobs:
           fi
 
   dependency-submission:
-    name: CI / Dependency Submission
+    name: Dependency Submission
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     permissions:
@@ -140,7 +140,7 @@ jobs:
         uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # ratchet:gradle/actions/dependency-submission@v6
 
   e2e-test:
-    name: CI / E2E Test
+    name: E2E Test
     runs-on: ubuntu-latest
     # E2E tests spin up containers; only run on push/PR to the main branches
     # to avoid burning minutes on every feature branch commit.

--- a/.github/workflows/cleanup-interim-images.yml
+++ b/.github/workflows/cleanup-interim-images.yml
@@ -1,0 +1,81 @@
+name: Cleanup Interim Images
+
+# Deletes GHCR package versions whose tags are exclusively build-* (ephemeral
+# per-commit images). Versions carrying any other tag (v*, edge, latest, etc.)
+# are never touched. Runs weekly and can be triggered manually.
+
+on:
+  schedule:
+    - cron: '0 8 * * 1' # Monday 08:00 UTC
+  workflow_dispatch:
+
+# Serialise with docker-publish to avoid deleting a build-* image that a
+# concurrent release promotion is about to resolve. cancel-in-progress: false
+# makes cleanup wait rather than be killed.
+concurrency:
+  group: docker-refs/heads/main
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete stale build-* package versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OWNER="${{ github.repository_owner }}"
+          PACKAGE="${{ github.event.repository.name }}"
+          DELETED=0
+          KEPT=0
+
+          echo "Fetching package versions for ${OWNER}/${PACKAGE}..."
+
+          # Collect all versions into a temp file (handles pagination via --paginate)
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/users/${OWNER}/packages/container/${PACKAGE}/versions" \
+            --paginate > /tmp/versions.json
+
+          TOTAL=$(jq 'length' /tmp/versions.json)
+          echo "Found ${TOTAL} total package versions."
+          echo ""
+
+          jq -c '.[]' /tmp/versions.json | while read -r version; do
+            VERSION_ID=$(echo "$version" | jq -r '.id')
+            TAGS=$(echo "$version" | jq -r '.metadata.container.tags // [] | .[]')
+
+            # Skip untagged versions — never delete them (likely referenced by a manifest list)
+            if [ -z "$TAGS" ]; then
+              echo "KEEP  [${VERSION_ID}] (untagged)"
+              continue
+            fi
+
+            TAG_LIST=$(echo "$TAGS" | tr '\n' ' ' | sed 's/ $//')
+
+            # Guard: keep if ANY tag does not match build-[0-9a-f]+
+            PROTECTED=false
+            while IFS= read -r tag; do
+              if [[ ! "$tag" =~ ^build-[0-9a-f]+$ ]]; then
+                PROTECTED=true
+                break
+              fi
+            done <<< "$TAGS"
+
+            if [ "$PROTECTED" = true ]; then
+              echo "KEEP  [${VERSION_ID}] tags: ${TAG_LIST}"
+            else
+              echo "DELETE [${VERSION_ID}] tags: ${TAG_LIST}"
+              gh api \
+                --method DELETE \
+                -H "Accept: application/vnd.github+json" \
+                "/users/${OWNER}/packages/container/${PACKAGE}/versions/${VERSION_ID}"
+            fi
+          done
+
+          echo ""
+          echo "Cleanup complete."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   analyze:
-    name: CodeQL / ${{ matrix.language }}
+    name: ${{ matrix.language }}
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/cve.yml
+++ b/.github/workflows/cve.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   grype-npm:
-    name: CVE / npm
+    name: npm
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -56,7 +56,7 @@ jobs:
           retention-days: 30
 
   grype-gradle:
-    name: CVE / Gradle
+    name: Gradle
     if: true
     runs-on: ubuntu-latest
     permissions:
@@ -103,7 +103,7 @@ jobs:
           retention-days: 30
 
   depcheck:
-    name: CVE / Dependency Check (Gradle)
+    name: Dependency Check (Gradle)
     if: false # disabled — NVD API reliability issues; re-enable when stable
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    name: Docker / Build & Push
+    name: Build & Push
     # Tags are released by promoting the already-built build image — no rebuild needed.
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,8 @@ concurrency:
 
 jobs:
   build-and-push:
-    # Tags are released by promoting the already-built edge image — no rebuild needed.
+    name: Docker / Build & Push
+    # Tags are released by promoting the already-built build image — no rebuild needed.
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     outputs:
@@ -55,6 +56,7 @@ jobs:
           tags: |
             type=ref,event=pr
             type=raw,value=edge,enable={{is_default_branch}}
+            type=sha,prefix=build-,format=short,enable={{is_default_branch}}
             type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push
@@ -153,21 +155,25 @@ jobs:
           grep "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" "grype_${GRYPE_VERSION}_checksums.txt" | sha256sum --check
           tar -xzf "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -C /usr/local/bin grype
 
-      # Resolve the digest of the already-built, already-scanned edge image.
-      # The tag ruleset enforces Container Scan passed on this commit before the tag
-      # could be pushed, so edge is guaranteed clean at this point.
-      - name: Resolve edge digest
-        id: edge
+      # Resolve the digest of the build-{sha} image produced when this commit landed on main.
+      # The tag ruleset enforces Container Scan passed on this commit before the tag could be
+      # pushed, so the build image is guaranteed scanned. Using the commit-pinned build tag
+      # (not :edge) ensures we promote the exact image for this release regardless of how
+      # many commits have landed on main since.
+      - name: Resolve build image digest
+        id: build
         run: |
+          TAG="build-${GITHUB_SHA::7}"
           DIGEST=$(docker buildx imagetools inspect \
-            ghcr.io/${{ github.repository }}:edge \
+            "ghcr.io/${{ github.repository }}:${TAG}" \
             --format '{{.Manifest.Digest}}')
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
-          echo "Promoting edge digest: ${DIGEST}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Promoting ${TAG} @ ${DIGEST}"
 
-      - name: Scan edge image
+      - name: Scan build image
         run: |
-          grype ghcr.io/${{ github.repository }}@${{ steps.edge.outputs.digest }} \
+          grype "ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}" \
             --config .grype.yaml \
             -o "template=grype-report.txt" \
             -o "json=grype-report.json"
@@ -182,12 +188,12 @@ jobs:
             grype-report.json
           retention-days: 90
 
-      - name: Promote edge to release tags
+      - name: Promote build image to release tags
         run: |
           VERSION=${GITHUB_REF_NAME}
           MAJOR=$(echo ${VERSION} | cut -d. -f1)
           MINOR=$(echo ${VERSION} | cut -d. -f1-2)
-          SOURCE="ghcr.io/${{ github.repository }}@${{ steps.edge.outputs.digest }}"
+          SOURCE="ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}"
           docker buildx imagetools create \
             --tag "ghcr.io/${{ github.repository }}:${VERSION}" \
             --tag "ghcr.io/${{ github.repository }}:${MINOR}" \

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ ext {
 
 allprojects {
     group = 'org.finos.gitproxy'
-    version = '1.0.0-beta.7'
+    version = '1.0.0-rc.1'
     
     repositories {
         mavenCentral()

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/permission/RepoPermission.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/permission/RepoPermission.java
@@ -13,8 +13,8 @@ import org.finos.gitproxy.db.model.MatchType;
  * {@link #value} at {@link #provider}.
  *
  * <p>{@link #target} selects which part of the repo URL is compared (default {@link MatchTarget#SLUG});
- * {@link #matchType} controls how {@link #value} is interpreted: {@code LITERAL} for exact equality, {@code GLOB} for
- * {@code *}/{@code ?} wildcards, {@code REGEX} for full Java regex.
+ * {@link #matchType} controls how {@link #value} is interpreted: {@code GLOB} for {@code *}/{@code ?} wildcards
+ * (default), {@code LITERAL} for exact equality, {@code REGEX} for full Java regex.
  */
 @Data
 @Builder
@@ -35,9 +35,9 @@ public class RepoPermission {
     /** Pattern to match against the {@link #target} portion of the URL. */
     private String value;
 
-    /** How {@link #value} is interpreted when matching. Defaults to {@link MatchType#LITERAL}. */
+    /** How {@link #value} is interpreted when matching. Defaults to {@link MatchType#GLOB}. */
     @Builder.Default
-    private MatchType matchType = MatchType.LITERAL;
+    private MatchType matchType = MatchType.GLOB;
 
     @Builder.Default
     private Operations operations = Operations.PUSH;


### PR DESCRIPTION
## Summary

- Aligns `RepoPermission` Java model default `matchType` to `GLOB`, matching the YAML config path default — permissions created via REST API now behave identically to those loaded from config
- Pins Docker release promotion to `build-{sha7}` (commit-stable) instead of `:edge`, eliminating the race condition where edge moves forward between tag cut and workflow run
- Adds `build-{sha7}` tag on every main push alongside `:edge`
- Adds weekly cleanup workflow (`cleanup-interim-images.yml`) that deletes GHCR versions exclusively tagged `build-*`; protected tags (`v*`, `edge`, `latest`, untagged) are never touched; serialised with main push via concurrency group
- Gradle version bumped to `1.0.0-rc.1`

Closes #193

## Test plan

- [ ] CI passes
- [ ] Docker Build & Publish produces both `:edge` and `build-{sha7}` tags on merge
- [ ] Cleanup workflow can be triggered manually via `workflow_dispatch` to verify dry-run behaviour before first scheduled run