### PR TITLE
fix: skip major/minor/latest Docker tags for pre-release versions; bump to 1.0.0-rc.2

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -191,12 +191,23 @@ jobs:
       - name: Promote build image to release tags
         run: |
           VERSION=${GITHUB_REF_NAME}
-          MAJOR=$(echo ${VERSION} | cut -d. -f1)
-          MINOR=$(echo ${VERSION} | cut -d. -f1-2)
           SOURCE="ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}"
-          docker buildx imagetools create \
-            --tag "ghcr.io/${{ github.repository }}:${VERSION}" \
-            --tag "ghcr.io/${{ github.repository }}:${MINOR}" \
-            --tag "ghcr.io/${{ github.repository }}:${MAJOR}" \
-            --tag "ghcr.io/${{ github.repository }}:latest" \
-            ${SOURCE}
+
+          if [[ "${VERSION}" == *-* ]]; then
+            # Pre-release (contains -): push the explicit version tag only.
+            # Major/minor/latest convenience tags must not point at a pre-release.
+            echo "Pre-release detected (${VERSION}) — skipping major/minor/latest tags"
+            docker buildx imagetools create \
+              --tag "ghcr.io/${{ github.repository }}:${VERSION}" \
+              ${SOURCE}
+          else
+            # Stable release: push all convenience tags.
+            MAJOR=$(echo ${VERSION} | cut -d. -f1)
+            MINOR=$(echo ${VERSION} | cut -d. -f1-2)
+            docker buildx imagetools create \
+              --tag "ghcr.io/${{ github.repository }}:${VERSION}" \
+              --tag "ghcr.io/${{ github.repository }}:${MINOR}" \
+              --tag "ghcr.io/${{ github.repository }}:${MAJOR}" \
+              --tag "ghcr.io/${{ github.repository }}:latest" \
+              ${SOURCE}
+          fi

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ ext {
 
 allprojects {
     group = 'org.finos.gitproxy'
-    version = '1.0.0-rc.1'
+    version = '1.0.0-rc.2'
     
     repositories {
         mavenCentral()


### PR DESCRIPTION
## Summary

- Pre-release versions (any tag containing `-`, e.g. `-alpha`, `-beta`, `-rc`) now only push the explicit version tag to GHCR. Major (`v1`), minor (`v1.0`), and `:latest` are reserved for stable semver releases only.
- Gradle version bumped to `1.0.0-rc.2`

## Why

`v1.0.0-beta.7` was incorrectly pushing `v1` and `v1.0` convenience tags, implying it was the latest stable release. Pre-release images should only be reachable via their explicit tag.

## Test plan

- [ ] CI passes
- [ ] On merge, Docker publish produces only `:edge` and `build-{sha7}` (no release tags)
- [ ] `/release-tag 1.0.0-rc.2` — publish workflow pushes only `v1.0.0-rc.2`, no `v1`/`v1.0`/`latest`