### PR TITLE
fix: pin io.netty to 4.1.133.Final in dashboard to resolve transitive CVEs

### DIFF
--- a/git-proxy-java-dashboard/build.gradle
+++ b/git-proxy-java-dashboard/build.gradle
@@ -140,6 +140,17 @@ tasks.register('stop') {
     }
 }
 
+// Force Netty to a patched version — transitively pulled in by lettuce-core via spring-session-data-redis.
+// Resolves GHSA-mj4r-2hfc-f8p6 (netty-codec) and GHSA-cm33-6792-r9fm (netty-codec-dns).
+configurations.configureEach {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'io.netty') {
+            details.useVersion '4.1.133.Final'
+            details.because 'CVE fix: GHSA-mj4r-2hfc-f8p6, GHSA-cm33-6792-r9fm'
+        }
+    }
+}
+
 dependencies {
     // Core library (direct dep — server uses `implementation` so core isn't transitively visible)
     implementation project(':git-proxy-java-core')


### PR DESCRIPTION
## Summary

- `spring-session-data-redis:4.0.3` (used for the Redis session store backend) transitively pulls in `lettuce-core:6.8.2.RELEASE`, which depends on `netty-resolver-dns:4.1.125.Final` — bringing two high-severity CVEs onto the runtime classpath of the dashboard module
- Adds a `resolutionStrategy` block in `git-proxy-java-dashboard/build.gradle` that pins all `io.netty` artifacts to `4.1.133.Final`, where both CVEs are fixed
- Scoped to the dashboard module only — the only module that carries the Redis session store dependency

## Dependency chain

```
spring-session-data-redis:4.0.3
  └─ lettuce-core:6.8.2.RELEASE
       └─ netty-resolver-dns:4.1.125.Final
            ├─ netty-codec:4.1.125.Final      ← GHSA-mj4r-2hfc-f8p6 (High)
            ├─ netty-codec-dns:4.1.125.Final  ← GHSA-cm33-6792-r9fm (High)
            └─ netty-handler:4.1.125.Final
```

The full `io.netty` group is pinned (not just the two flagged artifacts) because Netty artifacts within a release are tightly coupled and mixing versions within 4.1.x is unsupported by the Netty team.

## Upstream status

`lettuce-core:6.8.3-SNAPSHOT` still carries `netty.version=4.1.125.Final` — the fix has not yet been applied to the 6.8.x branch. `spring-session-data-redis:4.1.0-M1` also remains on `lettuce-core:6.8.2.RELEASE`. This override can be removed once lettuce ships a 6.8.x patch (or spring-session bumps to a lettuce version that pulls in Netty ≥ 4.1.133.Final).

## Test plan

- [ ] `./gradlew :git-proxy-java-dashboard:dependencyInsight --dependency netty-codec --configuration runtimeClasspath` confirms `4.1.133.Final` with `Selected by rule: CVE fix: GHSA-mj4r-2hfc-f8p6, GHSA-cm33-6792-r9fm`
- [ ] `./gradlew build` passes
- [ ] Grype scan no longer flags `netty-codec` or `netty-codec-dns`

🤖 Generated with [Claude Code](https://claude.com/claude-code)