### PR TITLE
chore: bump version to 1.0.0-rc.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
 
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM docker.io/eclipse-temurin:25-jdk@sha256:e23592541431eaeef5c13c84c21db71f97cdca0e70181ea6222ec9bccac24f6c AS builder
+FROM docker.io/eclipse-temurin:25-jdk-noble@sha256:29d2d8af5d12f9ee7aec18f4fb2cd8bc8e6501b748ac62631acd31c867cfa262 AS builder
 
 # Install Node.js directly from the official distribution with SHA256 verification.
 # To update: download the new tarball, verify against nodejs.org/dist/vX.Y.Z/SHASUMS256.txt,
@@ -56,7 +56,7 @@ RUN sed -i \
     git-proxy-java-dashboard/build/install/git-proxy-java-dashboard/bin/git-proxy-java-dashboard
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM docker.io/eclipse-temurin:25-jre@sha256:9c9e7c4f5f3840e5254be62ea9a7de56b2d0af23864032a8a3654bf63c31cd5b
+FROM docker.io/eclipse-temurin:25-jre-noble@sha256:b27ca47660a8fa837e47a8533b9b1a3a430295cf29ca28d91af4fd121572dc29
 
 WORKDIR /app
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ ext {
 
 allprojects {
     group = 'org.finos.gitproxy'
-    version = '1.0.0-rc.2'
+    version = '1.0.0-rc.3'
     
     repositories {
         mavenCentral()


### PR DESCRIPTION
## Summary

- Bump version to `1.0.0-rc.3`
- Switch Dockerfile base images from `eclipse-temurin:25-{jdk,jre}` (Ubuntu 26.04/Resolute) to `eclipse-temurin:25-{jdk,jre}-noble` (Ubuntu 24.04 LTS/Noble) to eliminate 11 pebble CVEs (6 High, 5 Medium)

## Background

`eclipse-temurin:25-*` now defaults to Ubuntu 26.04 (Resolute Raccoon), which ships `/usr/bin/pebble` — Canonical's container service manager compiled with Go 1.26.2. This binary carried 11 stdlib CVEs all fixed in Go 1.26.3. Since we override `ENTRYPOINT` directly, pebble serves no purpose and is just dead weight with a CVE surface. The `-noble` variants (Ubuntu 24.04 LTS) do not include pebble.

Addresses: CVE-2026-39820, CVE-2026-42499, CVE-2026-33814, CVE-2026-33811, CVE-2026-39836, CVE-2026-42501, CVE-2026-39817, CVE-2026-39826, CVE-2026-39823, CVE-2026-39825, CVE-2026-39819

🤖 Generated with [Claude Code](https://claude.ai/claude-code)