### PR TITLE
fix: lowercase GHCR image URL, bump version to 1.0.0-rc.4

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
 
+      - name: Set image name
+        run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
@@ -52,7 +55,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # ratchet:docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ env.IMAGE }}
           tags: |
             type=ref,event=pr
             type=raw,value=edge,enable={{is_default_branch}}
@@ -77,7 +80,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # ratchet:actions/attest-build-provenance@v4
         with:
-          subject-name: ghcr.io/${{ github.repository }}
+          subject-name: ${{ env.IMAGE }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
@@ -94,6 +97,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
+      - name: Set image name
+        run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Install grype
         run: |
           cd /tmp
@@ -106,7 +112,7 @@ jobs:
 
       - name: Scan image
         run: |
-          grype ghcr.io/${{ github.repository }}@${{ needs.build-and-push.outputs.digest }} \
+          grype "${IMAGE}@${{ needs.build-and-push.outputs.digest }}" \
             --config .grype.yaml \
             -o "template=grype-report.txt" \
             -o "json=grype-report.json"
@@ -143,6 +149,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set image name
+        run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Install grype
         env:
           GRYPE_VERSION: "0.112.0"
@@ -165,7 +174,7 @@ jobs:
         run: |
           TAG="build-${GITHUB_SHA::7}"
           DIGEST=$(docker buildx imagetools inspect \
-            "ghcr.io/${{ github.repository }}:${TAG}" \
+            "${IMAGE}:${TAG}" \
             --format '{{.Manifest.Digest}}')
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
@@ -173,7 +182,7 @@ jobs:
 
       - name: Scan build image
         run: |
-          grype "ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}" \
+          grype "${IMAGE}@${{ steps.build.outputs.digest }}" \
             --config .grype.yaml \
             -o "template=grype-report.txt" \
             -o "json=grype-report.json"
@@ -191,23 +200,23 @@ jobs:
       - name: Promote build image to release tags
         run: |
           VERSION=${GITHUB_REF_NAME}
-          SOURCE="ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}"
+          SOURCE="${IMAGE}@${{ steps.build.outputs.digest }}"
 
           if [[ "${VERSION}" == *-* ]]; then
             # Pre-release (contains -): push the explicit version tag only.
             # Major/minor/latest convenience tags must not point at a pre-release.
             echo "Pre-release detected (${VERSION}) — skipping major/minor/latest tags"
             docker buildx imagetools create \
-              --tag "ghcr.io/${{ github.repository }}:${VERSION}" \
+              --tag "${IMAGE}:${VERSION}" \
               ${SOURCE}
           else
             # Stable release: push all convenience tags.
             MAJOR=$(echo ${VERSION} | cut -d. -f1)
             MINOR=$(echo ${VERSION} | cut -d. -f1-2)
             docker buildx imagetools create \
-              --tag "ghcr.io/${{ github.repository }}:${VERSION}" \
-              --tag "ghcr.io/${{ github.repository }}:${MINOR}" \
-              --tag "ghcr.io/${{ github.repository }}:${MAJOR}" \
-              --tag "ghcr.io/${{ github.repository }}:latest" \
+              --tag "${IMAGE}:${VERSION}" \
+              --tag "${IMAGE}:${MINOR}" \
+              --tag "${IMAGE}:${MAJOR}" \
+              --tag "${IMAGE}:latest" \
               ${SOURCE}
           fi

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ ext {
 
 allprojects {
     group = 'org.finos.gitproxy'
-    version = '1.0.0-rc.3'
+    version = '1.0.0-rc.4'
     
     repositories {
         mavenCentral()


### PR DESCRIPTION
## Summary

- Adds a \"Set image name\" step to each job in `docker-publish.yml` that lowercases `github.repository` before using it as the GHCR image reference — required after repo transfer to an org whose name contains uppercase letters (Docker image refs must be fully lowercase)
- Bumps version to `1.0.0-rc.4`

## Test plan

- [ ] PR CI passes (build + push to GHCR with lowercased image URL)
- [ ] Merge to main, confirm `build-{sha}` image appears under `ghcr.io/rbc/git-proxy-java`
- [ ] Run `/release-tag` to cut `v1.0.0-rc.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)