### PR TITLE
fix: strip v prefix from Docker image tags on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -200,7 +200,7 @@ jobs:
 
       - name: Promote build image to release tags
         run: |
-          VERSION=${GITHUB_REF_NAME}
+          VERSION=${GITHUB_REF_NAME#v}
           SOURCE="${IMAGE}@${{ steps.build.outputs.digest }}"
 
           if [[ "${VERSION}" == *-* ]]; then


### PR DESCRIPTION
## Summary

`GITHUB_REF_NAME` includes the `v` prefix (e.g. `v1.0.0-rc.4`); Docker image tags should not (e.g. `1.0.0-rc.4`). Fixes a regression introduced in 78758f6 that caused image tags from `1.0.0-beta.7` onwards to be published with a leading `v`.

## Test plan

- [ ] Merge, let CI pass, cut next release tag and confirm image is published as `1.0.0-rc.x` not `v1.0.0-rc.x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)