### PR TITLE
fix: surface actionable validation step messages in push detail view

### DIFF
--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/DiffScanningHook.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/DiffScanningHook.java
@@ -61,7 +61,7 @@ public class DiffScanningHook implements GitProxyHook {
 
                 if (!violations.isEmpty()) {
                     for (Violation violation : violations) {
-                        validationContext.addIssue("scanDiff", violation.reason(), "ref: " + cmd.getRefName());
+                        validationContext.addIssue("scanDiff", violation.reason(), violation.formattedDetail());
                         logs.add("FAIL: " + violation.reason());
                     }
                     anyFailed = true;

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/GitClientUtils.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/GitClientUtils.java
@@ -191,7 +191,7 @@ public class GitClientUtils {
         return content;
     }
 
-    private static String stripColors(String content) {
+    public static String stripColors(String content) {
         for (var color : AnsiColor.values()) {
             content = content.replace(color.getValue(), "");
         }

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/IdentityVerificationHook.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/IdentityVerificationHook.java
@@ -126,12 +126,18 @@ public class IdentityVerificationHook implements GitProxyHook {
             validationContext.addIssue(
                     STEP_NAME, "Commit identity does not match push user " + user.getUsername(), detail);
         } else {
-            // WARN mode — push proceeds; violations are surfaced via the validation summary, not
-            // immediate per-message streaming, so they appear in the correct order with context.
+            // WARN mode — push proceeds but developer is warned at the terminal and in the dashboard.
             log.warn(
                     "Identity verification warnings for push user '{}': {} mismatch(es)",
                     user.getUsername(),
                     violations.size());
+            rp.sendMessage(GitClientUtils.color(
+                    YELLOW,
+                    sym(WARNING) + "  Identity warning: " + violations.size() + " commit email(s) not registered to "
+                            + user.getUsername()));
+            for (String v : violations) {
+                rp.sendMessage("  " + v);
+            }
             pushContext.addStep(PushStep.builder()
                     .stepName(STEP_NAME)
                     .stepOrder(ORDER)

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/PushStorePersistenceHook.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/PushStorePersistenceHook.java
@@ -45,6 +45,7 @@ public class PushStorePersistenceHook {
      * sort validation steps in the same order as proxy mode.
      */
     private static final Map<String, Integer> HOOK_STEP_ORDER = Map.of(
+            "checkUrlRules", 100,
             "checkAuthorEmails", 2100,
             "checkCommitMessages", 2200,
             "scanDiff", 2300,
@@ -142,7 +143,7 @@ public class PushStorePersistenceHook {
                                     .stepName(issue.hookName())
                                     .stepOrder(stepOrder)
                                     .status(StepStatus.FAIL)
-                                    .content(issue.detail())
+                                    .content(GitClientUtils.stripColors(issue.detail()))
                                     .errorMessage(issue.summary())
                                     .build());
                             fallbackOrder++;

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/RepositoryUrlRuleHook.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/RepositoryUrlRuleHook.java
@@ -44,7 +44,12 @@ public class RepositoryUrlRuleHook implements GitProxyHook {
         String repoSlug = pushContext.getRepoSlug();
         if (repoSlug == null || repoSlug.isBlank()) {
             log.warn("No repoSlug in push context — cannot evaluate URL rules, blocking push (fail-closed)");
-            blockPush(rp, commands, "Repository path unavailable");
+            blockPush(
+                    rp,
+                    commands,
+                    "Repository path unavailable",
+                    "Push Blocked - Repository Not Allowed",
+                    "Repository path could not be determined. Contact an administrator.");
             return;
         }
 
@@ -59,7 +64,13 @@ public class RepositoryUrlRuleHook implements GitProxyHook {
         switch (result) {
             case UrlRuleEvaluator.Result.Denied d -> {
                 log.debug("Push blocked by deny rule: {}", d.ruleId());
-                blockPush(rp, commands, "Repository denied by access rule");
+                blockPush(
+                        rp,
+                        commands,
+                        "Repository blocked by deny rule",
+                        "Push Blocked - Repository Denied",
+                        "Pushes to this repository are not permitted.\n\n"
+                                + "This repository has been explicitly denied by an administrator.");
             }
             case UrlRuleEvaluator.Result.Allowed a -> {
                 log.debug("Push allowed by rule: {}", a.ruleId());
@@ -67,22 +78,24 @@ public class RepositoryUrlRuleHook implements GitProxyHook {
             }
             case UrlRuleEvaluator.Result.NotAllowed n -> {
                 log.debug("Push blocked — no rule matched");
-                blockPush(rp, commands, "Repository is not in the allow list");
+                blockPush(
+                        rp,
+                        commands,
+                        "Repository not in allow list",
+                        "Push Blocked - Repository Not Allowed",
+                        "Pushes to this repository are not permitted.\n\n"
+                                + "Contact an administrator to add this repository to the allow rules.");
             }
         }
     }
 
-    private void blockPush(ReceivePack rp, Collection<ReceiveCommand> commands, String reason) {
-        String detail = GitClientUtils.format(
-                sym(NO_ENTRY) + "  Push Blocked - Repository Not Allowed",
-                sym(CROSS_MARK)
-                        + "  "
-                        + reason
-                        + ".\n\nContact an administrator to add this repository to the allow rules.",
-                RED,
-                null);
+    private void blockPush(
+            ReceivePack rp, Collection<ReceiveCommand> commands, String reason, String title, String message) {
+        String detail =
+                GitClientUtils.format(sym(NO_ENTRY) + "  " + title, sym(CROSS_MARK) + "  " + message, RED, null);
         if (validationContext != null) {
-            validationContext.addIssue("RepositoryUrlRuleHook", reason, detail);
+            validationContext.addIssue("checkUrlRules", reason, detail);
+            // PushStorePersistenceHook creates the FAIL step from the issue; don't also add it to pushContext
         } else {
             rp.sendMessage(detail);
             for (ReceiveCommand cmd : commands) {
@@ -90,13 +103,13 @@ public class RepositoryUrlRuleHook implements GitProxyHook {
                     cmd.setResult(ReceiveCommand.Result.REJECTED_OTHER_REASON, reason);
                 }
             }
+            pushContext.addStep(PushStep.builder()
+                    .stepName("checkUrlRules")
+                    .stepOrder(ORDER)
+                    .status(StepStatus.FAIL)
+                    .content(reason)
+                    .build());
         }
-        pushContext.addStep(PushStep.builder()
-                .stepName("checkUrlRules")
-                .stepOrder(ORDER)
-                .status(StepStatus.FAIL)
-                .content(reason)
-                .build());
     }
 
     private void recordPass() {

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/SecretScanningHook.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/SecretScanningHook.java
@@ -34,6 +34,8 @@ public class SecretScanningHook implements GitProxyHook {
 
     private static final int ORDER = 340;
     private static final String STEP_NAME = "scanSecrets";
+    private static final String REMEDIATION_HINT =
+            "→ Rotate any exposed credentials and remove the secret from your commit history before pushing.";
 
     private final SecretScanConfig config;
     private final ValidationContext validationContext;
@@ -68,7 +70,7 @@ public class SecretScanningHook implements GitProxyHook {
 
             for (GitleaksRunner.Finding f : result.get()) {
                 String msg = f.toMessage();
-                allViolations.add(new Violation(msg, msg, sym(CROSS_MARK) + "  " + msg));
+                allViolations.add(new Violation(msg, msg, sym(CROSS_MARK) + "  " + msg + "\n" + REMEDIATION_HINT));
             }
         }
 
@@ -76,7 +78,7 @@ public class SecretScanningHook implements GitProxyHook {
             if (config.isEnabled()) {
                 String msg = "Secret scanning failed — scanner error or unavailable. "
                         + "Push blocked because secret-scan is enabled. Check server logs for details.";
-                allViolations.add(new Violation(msg, msg, sym(CROSS_MARK) + "  " + msg));
+                allViolations.add(new Violation(msg, msg, sym(CROSS_MARK) + "  " + msg + "\n" + REMEDIATION_HINT));
             } else {
                 pushContext.addStep(PushStep.builder()
                         .stepName(STEP_NAME)

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/CheckHiddenCommitsFilter.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/CheckHiddenCommitsFilter.java
@@ -109,7 +109,7 @@ public class CheckHiddenCommitsFilter extends AbstractProviderAwareGitProxyFilte
 
         } catch (Exception e) {
             log.warn("Skipping hidden commits check: {}", e.getMessage());
-            recordStep(request, StepStatus.SKIPPED, null, e.getMessage());
+            recordStep(request, StepStatus.SKIPPED, "", e.getMessage());
         }
     }
 

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/GitProxyFilter.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/GitProxyFilter.java
@@ -18,6 +18,7 @@ import org.eclipse.jgit.transport.PacketLineOut;
 import org.eclipse.jgit.transport.SideBandOutputStream;
 import org.finos.gitproxy.db.model.PushStep;
 import org.finos.gitproxy.db.model.StepStatus;
+import org.finos.gitproxy.git.GitClientUtils;
 import org.finos.gitproxy.git.GitRequestDetails;
 import org.finos.gitproxy.git.HttpOperation;
 // import org.springframework.core.Ordered;
@@ -130,7 +131,7 @@ public interface GitProxyFilter extends Filter {
             // so we must not overwrite that with a spurious PASS.
             int stepsAfter = details != null ? details.getSteps().size() : 0;
             if (stepsAfter == stepsBefore) {
-                recordStep(httpRequest, StepStatus.PASS, null, null);
+                recordStep(httpRequest, StepStatus.PASS, "", "");
             }
         }
         chain.doFilter(request, response);
@@ -222,7 +223,7 @@ public interface GitProxyFilter extends Filter {
                 .stepName(getStepName())
                 .stepOrder(this.getOrder())
                 .status(status)
-                .content(content)
+                .content(GitClientUtils.stripColors(content))
                 .blockedMessage(status == StepStatus.BLOCKED ? reason : null)
                 .errorMessage(status == StepStatus.FAIL ? reason : null)
                 .build();

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/ScanDiffFilter.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/ScanDiffFilter.java
@@ -1,8 +1,5 @@
 package org.finos.gitproxy.servlet.filter;
 
-import static org.finos.gitproxy.git.GitClientUtils.AnsiColor.*;
-import static org.finos.gitproxy.git.GitClientUtils.SymbolCodes.*;
-import static org.finos.gitproxy.git.GitClientUtils.sym;
 import static org.finos.gitproxy.servlet.GitProxyServlet.GIT_REQUEST_ATTR;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,7 +8,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jgit.lib.Repository;
 import org.finos.gitproxy.config.DiffScanConfig;
@@ -19,7 +15,6 @@ import org.finos.gitproxy.db.model.PushStep;
 import org.finos.gitproxy.db.model.StepStatus;
 import org.finos.gitproxy.git.CommitInspectionService;
 import org.finos.gitproxy.git.DiffGenerationHook;
-import org.finos.gitproxy.git.GitClientUtils;
 import org.finos.gitproxy.git.GitRequestDetails;
 import org.finos.gitproxy.git.HttpOperation;
 import org.finos.gitproxy.provider.GitProxyProvider;
@@ -101,23 +96,17 @@ public class ScanDiffFilter extends AbstractProviderAwareGitProxyFilter {
 
             if (!violations.isEmpty()) {
                 log.warn("Diff scan found {} violation(s)", violations.size());
-                String title = sym(NO_ENTRY) + "  Push Blocked - Diff Contains Blocked Content";
-                String violationList = violations.stream()
-                        .map(v -> sym(CROSS_MARK) + "  " + v.reason())
-                        .collect(Collectors.joining("\n"));
-                String message = "Diff content contains blocked patterns:\n\n" + violationList;
-                recordIssue(
-                        request,
-                        "Diff contains blocked content",
-                        GitClientUtils.color(RED, GitClientUtils.format(title, message, RED, null)));
+                for (Violation v : violations) {
+                    recordIssue(request, v.reason(), v.formattedDetail());
+                }
             } else {
                 log.debug("Diff scan passed for {}..{}", fromCommit, toCommit);
-                recordStep(request, StepStatus.PASS, null, null);
+                recordStep(request, StepStatus.PASS, "", "");
             }
 
         } catch (Exception e) {
             log.warn("Skipping diff scan for push {}..{}: {}", fromCommit, toCommit, e.getMessage());
-            recordStep(request, StepStatus.SKIPPED, null, e.getMessage());
+            recordStep(request, StepStatus.SKIPPED, "", e.getMessage());
         }
     }
 }

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/SecretScanningFilter.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/SecretScanningFilter.java
@@ -33,6 +33,8 @@ import org.finos.gitproxy.git.HttpOperation;
 public class SecretScanningFilter extends AbstractGitProxyFilter {
 
     private static final int ORDER = 340;
+    private static final String REMEDIATION_HINT =
+            "→ Rotate any exposed credentials and remove the secret from your commit history before pushing.";
 
     private final Supplier<SecretScanConfig> configSupplier;
     private final GitleaksRunner runner;
@@ -114,7 +116,7 @@ public class SecretScanningFilter extends AbstractGitProxyFilter {
         log.warn("Secret scan found {} finding(s)", findings.size());
         for (GitleaksRunner.Finding f : findings) {
             String msg = f.toMessage();
-            recordIssue(request, msg, sym(CROSS_MARK) + "  " + msg);
+            recordIssue(request, msg, sym(CROSS_MARK) + "  " + msg + "\n" + REMEDIATION_HINT);
         }
     }
 }

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/UrlRuleAggregateFilter.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/UrlRuleAggregateFilter.java
@@ -121,16 +121,15 @@ public class UrlRuleAggregateFilter extends AbstractProviderAwareGitProxyFilter 
     private void sendNotAllowed(HttpServletRequest request, HttpServletResponse response, HttpOperation operation)
             throws java.io.IOException {
         String action = operation == HttpOperation.PUSH ? "Push" : "Fetch";
-        String title = action + " blocked - Repository Not Allowed";
+        String title = sym(NO_ENTRY) + "  " + action + " Blocked - Repository Not Allowed";
         String verb = operation == HttpOperation.PUSH ? "Pushes to" : "Fetches from";
         String message = verb + " this repository are not permitted.\n"
                 + "\n"
-                + "Contact an administrator to add this repository\n"
-                + "to the allow rules.";
+                + "Contact an administrator to add this repository to the allow rules.";
         rejectAndSendError(
                 request,
                 response,
-                "Repository not in allow rules",
+                "Repository not in allow list",
                 GitClientUtils.formatForOperation(title, message, GitClientUtils.AnsiColor.RED, operation));
     }
 

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/validation/BlockedContentDiffCheck.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/validation/BlockedContentDiffCheck.java
@@ -1,9 +1,9 @@
 package org.finos.gitproxy.validation;
 
-import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.finos.gitproxy.config.CommitConfig;
@@ -28,7 +28,8 @@ public class BlockedContentDiffCheck implements DiffCheck {
             return Optional.of(List.of());
         }
 
-        Set<String> violations = new LinkedHashSet<>();
+        // Map from violation summary → first matching line (putIfAbsent deduplicates per pattern+file)
+        Map<String, String> violations = new LinkedHashMap<>();
         String currentFile = null;
 
         for (String line : diff.lines().toList()) {
@@ -45,20 +46,21 @@ public class BlockedContentDiffCheck implements DiffCheck {
             for (String literal : block.getLiterals()) {
                 if (content.toLowerCase().contains(literal.toLowerCase())) {
                     String location = currentFile != null ? " in " + currentFile : "";
-                    violations.add("blocked term: \"" + literal + "\"" + location);
+                    violations.putIfAbsent("blocked term: \"" + literal + "\"" + location, content.strip());
                 }
             }
 
             for (Pattern pattern : block.getPatterns()) {
                 if (pattern.matcher(content).find()) {
                     String location = currentFile != null ? " in " + currentFile : "";
-                    violations.add("blocked pattern: " + pattern.pattern() + location);
+                    violations.putIfAbsent("blocked pattern: " + pattern.pattern() + location, content.strip());
                 }
             }
         }
 
-        return Optional.of(
-                violations.stream().map(v -> new Violation(v, v, null)).collect(java.util.stream.Collectors.toList()));
+        return Optional.of(violations.entrySet().stream()
+                .map(e -> new Violation(e.getKey(), e.getKey(), e.getKey() + "\n  " + e.getValue()))
+                .collect(java.util.stream.Collectors.toList()));
     }
 
     /** Extracts the {@code b/} path from a {@code diff --git a/... b/...} header line. */

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/servlet/filter/ScanDiffFilterTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/servlet/filter/ScanDiffFilterTest.java
@@ -244,6 +244,34 @@ class ScanDiffFilterTest {
         assertEquals(GitRequestDetails.GitResult.PENDING, details.getResult());
     }
 
+    // ---- blocked step has specific errorMessage and matching line in content ----
+
+    @Test
+    void blockedLiteral_stepHasSpecificErrorMessageAndMatchingLine() throws Exception {
+        GitRequestDetails details = pushDetails(cleanCommit, blockedCommit);
+        FakeResponse resp = new FakeResponse();
+
+        filterWithLiteral("supersecret").doHttpFilter(mockRequest(details), resp.mock);
+
+        PushStep scanStep = details.getSteps().stream()
+                .filter(s -> "scanDiff".equals(s.getStepName()) && s.getStatus() == StepStatus.FAIL)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("scanDiff FAIL step not found"));
+
+        assertNotNull(scanStep.getErrorMessage(), "errorMessage must be set");
+        assertTrue(
+                scanStep.getErrorMessage().contains("supersecret"),
+                "errorMessage should name the blocked term, got: " + scanStep.getErrorMessage());
+        assertFalse(
+                scanStep.getErrorMessage().equals("Diff contains blocked content"),
+                "errorMessage must be violation-specific, not a generic label");
+
+        assertNotNull(scanStep.getContent(), "content must be set");
+        assertTrue(
+                scanStep.getContent().contains("supersecret"),
+                "content should include the matching line, got: " + scanStep.getContent());
+    }
+
     // ---- diff step content contains the actual diff text ----
 
     @Test

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/validation/BlockedContentDiffCheckTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/validation/BlockedContentDiffCheckTest.java
@@ -101,6 +101,35 @@ class BlockedContentDiffCheckTest {
     }
 
     @Test
+    void violationFormattedDetailIncludesMatchingLine() {
+        BlockedContentDiffCheck check = checkWithLiterals("secret");
+        List<Violation> violations = check.check(SAMPLE_DIFF).orElseThrow();
+        assertEquals(1, violations.size());
+        String detail = violations.get(0).formattedDetail();
+        assertNotNull(detail);
+        assertTrue(detail.contains("src/Foo.java"), "detail must reference the file");
+        assertTrue(detail.contains("added line with secret content"), "detail must include the matching line");
+    }
+
+    @Test
+    void deduplication_formattedDetailContainsFirstMatchingLine() {
+        String diff = """
+                diff --git a/a.txt b/a.txt
+                --- a/a.txt
+                +++ b/a.txt
+                @@ -1 +1,2 @@
+                +first password occurrence
+                +second password occurrence
+                """;
+        BlockedContentDiffCheck check = checkWithLiterals("password");
+        List<Violation> violations = check.check(diff).orElseThrow();
+        assertEquals(1, violations.size());
+        assertTrue(
+                violations.get(0).formattedDetail().contains("first password occurrence"),
+                "formattedDetail should show the first matching line");
+    }
+
+    @Test
     void extractFileName_standardHeader() {
         assertEquals(
                 "src/Foo.java", BlockedContentDiffCheck.extractFileName("diff --git a/src/Foo.java b/src/Foo.java"));

--- a/git-proxy-java-dashboard/frontend/src/api.ts
+++ b/git-proxy-java-dashboard/frontend/src/api.ts
@@ -251,9 +251,9 @@ export async function addUserPermission(
 export async function createUrlRule(rule: {
   access: 'ALLOW' | 'DENY'
   operations: 'BOTH' | 'PUSH' | 'FETCH'
-  slug?: string
-  owner?: string
-  name?: string
+  target: 'SLUG' | 'OWNER' | 'NAME'
+  value: string
+  matchType: 'LITERAL' | 'GLOB' | 'REGEX'
   provider?: string
   description?: string
   ruleOrder?: number

--- a/git-proxy-java-dashboard/frontend/src/api.ts
+++ b/git-proxy-java-dashboard/frontend/src/api.ts
@@ -248,7 +248,7 @@ export async function addUserPermission(
   return res.json()
 }
 
-export async function createAccessRule(rule: {
+export async function createUrlRule(rule: {
   access: 'ALLOW' | 'DENY'
   operations: 'BOTH' | 'PUSH' | 'FETCH'
   slug?: string
@@ -263,13 +263,13 @@ export async function createAccessRule(rule: {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ ...rule, enabled: true, source: 'DB' }),
   })
-  if (!res.ok) await parseErrorResponse(res, 'Failed to create access rule')
+  if (!res.ok) await parseErrorResponse(res, 'Failed to create URL rule')
   return res.json()
 }
 
-export async function deleteAccessRule(id: string) {
+export async function deleteUrlRule(id: string) {
   const res = await apiFetch(`/api/repos/rules/${encodeURIComponent(id)}`, { method: 'DELETE' })
-  if (!res.ok) await parseErrorResponse(res, 'Failed to delete access rule')
+  if (!res.ok) await parseErrorResponse(res, 'Failed to delete URL rule')
 }
 
 export interface TcpResult {

--- a/git-proxy-java-dashboard/frontend/src/api.ts
+++ b/git-proxy-java-dashboard/frontend/src/api.ts
@@ -330,8 +330,8 @@ export interface LogStep {
 export interface ProviderConnectivity {
   uri: string
   tcp: TcpResult
-  tls: TlsResult | null
-  http: HttpResult | null
+  tls?: TlsResult | null
+  http?: HttpResult | null
   /** Only present on targeted checks (provider + repoPath supplied) */
   gitProbe?: GitProbe | null
   /** Structured step log — only present on targeted checks */

--- a/git-proxy-java-dashboard/frontend/src/pages/Admin.tsx
+++ b/git-proxy-java-dashboard/frontend/src/pages/Admin.tsx
@@ -30,8 +30,8 @@ function TcpBadge({ tcp }: { tcp: TcpResult }) {
   )
 }
 
-function TlsBadge({ tls }: { tls: TlsResult | null }) {
-  if (tls === null) return null
+function TlsBadge({ tls }: { tls: TlsResult | null | undefined }) {
+  if (tls == null) return null
   const ok = tls.status === 'ok'
   return (
     <span
@@ -44,8 +44,8 @@ function TlsBadge({ tls }: { tls: TlsResult | null }) {
   )
 }
 
-function HttpBadge({ http }: { http: HttpResult | null }) {
-  if (http === null) return null
+function HttpBadge({ http }: { http: HttpResult | null | undefined }) {
+  if (http == null) return null
   const ok = typeof http.status === 'number' && http.status < 500
   const label =
     typeof http.status === 'number' ? `HTTP ${http.status} ${ms(http.durationMs)}` : 'HTTP ERROR'
@@ -117,7 +117,7 @@ function DiagnosticLog({ steps }: { steps: LogStep[] }) {
 
 function ConnectivityRow({ result }: { name: string; result: ProviderConnectivity }) {
   const tcpOk = result.tcp.status === 'ok'
-  const tlsOk = result.tls === null || result.tls.status === 'ok'
+  const tlsOk = result.tls == null || result.tls.status === 'ok'
 
   return (
     <div className="border border-gray-200 rounded-lg p-4 space-y-2">

--- a/git-proxy-java-dashboard/frontend/src/pages/Profile.tsx
+++ b/git-proxy-java-dashboard/frontend/src/pages/Profile.tsx
@@ -346,7 +346,7 @@ export function Profile() {
             >
               {providers.map((p) => (
                 <option key={p.name} value={p.id}>
-                  {p.host}
+                  {p.name}
                 </option>
               ))}
             </select>

--- a/git-proxy-java-dashboard/frontend/src/pages/Repos.tsx
+++ b/git-proxy-java-dashboard/frontend/src/pages/Repos.tsx
@@ -13,9 +13,9 @@ interface ActiveRepo {
 interface Rule {
   id: string
   provider: string | null
-  slug: string | null
-  owner: string | null
-  name: string | null
+  target: 'SLUG' | 'OWNER' | 'NAME'
+  value: string | null
+  matchType: 'LITERAL' | 'GLOB' | 'REGEX'
   access: 'ALLOW' | 'DENY'
   operations: 'FETCH' | 'PUSH' | 'BOTH'
   description: string | null
@@ -178,20 +178,15 @@ function AddRuleModal({
     setSubmitting(true)
     setError(null)
     try {
-      // Encode the pattern as the filter expects: regex: prefix for REGEX,
-      // raw string for GLOB (glob chars trigger detection), raw for LITERAL.
-      const raw = form.pattern.trim()
-      const encoded = form.patternType === 'REGEX' ? `regex:${raw}` : raw
-
       const payload: Parameters<typeof createUrlRule>[0] = {
         access: form.access,
         operations: form.operations,
+        target: form.targetType.toUpperCase() as 'SLUG' | 'OWNER' | 'NAME',
+        value: form.pattern.trim(),
+        matchType: form.patternType,
         provider: form.provider || undefined,
         ruleOrder: form.ruleOrder,
       }
-      if (form.targetType === 'slug') payload.slug = encoded
-      else if (form.targetType === 'owner') payload.owner = encoded
-      else payload.name = encoded
 
       const created = await createUrlRule(payload)
       onCreated(created)
@@ -297,11 +292,6 @@ function AddRuleModal({
               }`}
             />
             {regexError && <p className="mt-1 text-xs text-amber-600">⚠ {regexError}</p>}
-            {form.patternType === 'REGEX' && !regexError && form.pattern && (
-              <p className="mt-1 text-xs text-gray-400">
-                Stored as <code className="font-mono">regex:{form.pattern}</code>
-              </p>
-            )}
             {form.targetType === 'slug' && (
               <p className="mt-1 text-xs text-gray-400">
                 Slug rules match the full URL path — must start with{' '}
@@ -539,13 +529,17 @@ export function Repos() {
                     <div className="flex flex-col min-w-0">
                       <div className="flex items-center gap-1.5">
                         <span className="text-xs text-gray-400 shrink-0">
-                          {rule.slug ? 'slug' : rule.owner ? 'owner' : rule.name ? 'name' : 'any'}:
+                          {(rule.target ?? 'SLUG').toLowerCase()}:
                         </span>
                         <span className="font-mono text-sm text-gray-800 truncate">
-                          {rule.slug ?? rule.owner ?? rule.name ?? '*'}
+                          {rule.value ?? '*'}
                         </span>
                       </div>
                       <div className="flex items-center gap-2 mt-0.5">
+                        <span className="text-xs text-gray-400">
+                          {(rule.matchType ?? 'GLOB').toLowerCase()}
+                        </span>
+                        <span className="text-xs text-gray-300">·</span>
                         <span className="text-xs text-gray-400">
                           provider:{' '}
                           <span className="text-gray-600">

--- a/git-proxy-java-dashboard/frontend/src/pages/Repos.tsx
+++ b/git-proxy-java-dashboard/frontend/src/pages/Repos.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { createUrlRule, deleteUrlRule, fetchProviders } from '../api'
+import type { Provider } from '../types'
 
 interface ActiveRepo {
   provider: string
@@ -129,11 +130,11 @@ function AddRuleModal({
   const [error, setError] = useState<string | null>(null)
   const [regexError, setRegexError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
-  const [providers, setProviders] = useState<{ name: string; id: string; host: string }[]>([])
+  const [providers, setProviders] = useState<Provider[]>([])
 
   useEffect(() => {
     fetchProviders()
-      .then((data: { name: string; id: string; host: string }[]) => setProviders(data))
+      .then((data: Provider[]) => setProviders(data))
       .catch(() => {})
   }, [])
 
@@ -312,7 +313,7 @@ function AddRuleModal({
               <option value="">— All providers (applies to any) —</option>
               {providers.map((p) => (
                 <option key={p.name} value={p.id}>
-                  {p.host}
+                  {p.name}
                 </option>
               ))}
             </select>
@@ -381,11 +382,11 @@ export function Repos() {
   const [rules, setRules] = useState<Rule[]>([])
   const [loadedTab, setLoadedTab] = useState<Tab | null>(null)
   const [showAddRule, setShowAddRule] = useState(false)
-  const [providers, setProviders] = useState<{ name: string; id: string; host: string }[]>([])
+  const [providers, setProviders] = useState<Provider[]>([])
 
   useEffect(() => {
     fetchProviders()
-      .then((data: { name: string; id: string; host: string }[]) => setProviders(data))
+      .then((data: Provider[]) => setProviders(data))
       .catch(() => {})
   }, [])
 
@@ -464,7 +465,7 @@ export function Repos() {
                 >
                   <div>
                     <div className="text-xs text-gray-400 mb-0.5">
-                      {providers.find((p) => p.id === repo.provider)?.host ?? repo.provider}
+                      {providers.find((p) => p.id === repo.provider)?.name ?? repo.provider}
                     </div>
                     <div className="font-semibold text-gray-800">
                       {repo.owner}/{repo.repoName}
@@ -488,7 +489,7 @@ export function Repos() {
                       )}
                     </div>
                     <CloneButton
-                      cloneUrl={`${window.location.origin}/proxy/${providers.find((p) => p.id === repo.provider)?.host ?? repo.provider.split('/').slice(1).join('/')}/${repo.owner}/${repo.repoName}.git`}
+                      cloneUrl={`${window.location.origin}${providers.find((p) => p.id === repo.provider)?.proxyPath ?? '/proxy/' + repo.provider}/${repo.owner}/${repo.repoName}.git`}
                     />
                   </div>
                 </div>
@@ -544,7 +545,7 @@ export function Repos() {
                           provider:{' '}
                           <span className="text-gray-600">
                             {rule.provider
-                              ? (providers.find((p) => p.id === rule.provider)?.host ??
+                              ? (providers.find((p) => p.id === rule.provider)?.name ??
                                 rule.provider)
                               : 'all'}
                           </span>

--- a/git-proxy-java-dashboard/frontend/src/pages/Repos.tsx
+++ b/git-proxy-java-dashboard/frontend/src/pages/Repos.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { createAccessRule, deleteAccessRule, fetchProviders } from '../api'
+import { createUrlRule, deleteUrlRule, fetchProviders } from '../api'
 
 interface ActiveRepo {
   provider: string
@@ -183,7 +183,7 @@ function AddRuleModal({
       const raw = form.pattern.trim()
       const encoded = form.patternType === 'REGEX' ? `regex:${raw}` : raw
 
-      const payload: Parameters<typeof createAccessRule>[0] = {
+      const payload: Parameters<typeof createUrlRule>[0] = {
         access: form.access,
         operations: form.operations,
         provider: form.provider || undefined,
@@ -193,7 +193,7 @@ function AddRuleModal({
       else if (form.targetType === 'owner') payload.owner = encoded
       else payload.name = encoded
 
-      const created = await createAccessRule(payload)
+      const created = await createUrlRule(payload)
       onCreated(created)
       onClose()
     } catch (e) {
@@ -217,9 +217,9 @@ function AddRuleModal({
         </div>
 
         <div className="space-y-3">
-          {/* Access type */}
+          {/* Rule type */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Access type</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Rule type</label>
             <div className="flex gap-3">
               {(['ALLOW', 'DENY'] as const).map((a) => (
                 <label key={a} className="flex items-center gap-1.5 cursor-pointer">
@@ -412,7 +412,7 @@ export function Repos() {
   }, [tab])
 
   const deleteRule = async (id: string) => {
-    await deleteAccessRule(id)
+    await deleteUrlRule(id)
     setRules((prev) => prev.filter((r) => r.id !== id))
   }
 

--- a/git-proxy-java-dashboard/frontend/src/pages/UserDetail.tsx
+++ b/git-proxy-java-dashboard/frontend/src/pages/UserDetail.tsx
@@ -171,7 +171,7 @@ function AddScmIdentityModal({
               {providers.length === 0 && <option value="">Loading…</option>}
               {providers.map((p) => (
                 <option key={p.name} value={p.id}>
-                  {p.host}
+                  {p.name}
                 </option>
               ))}
             </select>
@@ -656,7 +656,7 @@ function AddPermissionModal({
               {providers.length === 0 && <option value="">Loading…</option>}
               {providers.map((p) => (
                 <option key={p.name} value={p.id}>
-                  {p.host}
+                  {p.name}
                 </option>
               ))}
             </select>


### PR DESCRIPTION
## Summary

- **Fixes #244**: `scanDiff` step content was showing the branch ref (`ref: refs/heads/...`) instead of the blocked pattern and matching file — `BlockedContentDiffCheck` was producing violations with null `formattedDetail`, and `DiffScanningHook` was hardcoding the ref name as content
- **scanSecrets**: both hook and filter now append a remediation hint (rotate + scrub history) to each finding so the dashboard gives actionable next steps
- **identityVerification WARN mode**: now emits per-violation sideband warnings to the git client terminal so developers see the mismatch even when the push isn't blocked
- **URL rule step consistency**: `RepositoryUrlRuleHook` now uses step name `checkUrlRules` (not class name); fixes a duplicate step bug where both `validationContext.addIssue` and `pushContext.addStep(FAIL)` were called, producing two entries in the push detail view; wording aligned with `UrlRuleAggregateFilter`
- **URL rules page display fixed**: `Repos.tsx` was using the old `slug`/`owner`/`name` field shape; updated to `target`/`value`/`matchType` from the `34aebb9` backend refactor — every rule was showing as "any: *" and new rules created via UI were saving with `value=null` (never matching)
- **Admin connectivity crash fixed**: `SpringWebConfig` sets `NON_NULL` Jackson inclusion globally, so null `tls`/`http` fields are omitted from JSON rather than serialised as `null`; the frontend strict `=== null` check fell through to `tls.status` and crashed — changed to `== null` throughout and updated types to `| undefined`
- **Provider display**: all provider dropdowns (Add Rule, Add Permission, Add SCM identity) and provider labels throughout the UI were showing `host` (e.g. `github.com`) instead of `name` (e.g. `github`); fixed across `Repos.tsx`, `UserDetail.tsx`, `Profile.tsx`; clone URL construction switched to use `provider.proxyPath` from the API response; `Repos.tsx` provider state typed as `Provider[]` instead of an ad-hoc inline type
- **Terminology**: `createAccessRule`/`deleteAccessRule` → `createUrlRule`/`deleteUrlRule` in `api.ts` and `Repos.tsx`; "Access type" label → "Rule type" in the add-rule modal

## Test plan

- [ ] Unit tests: `BlockedContentDiffCheckTest` — assertions for `formattedDetail` content and deduplication with first matching line
- [ ] Unit tests: `ScanDiffFilterTest` — assertion that `errorMessage` contains the blocked pattern and `content` includes the matching line
- [ ] Server e2e tests: all 9/9 pass (proxy push flows, URL rule enforcement, secret scanning)
- [ ] Dashboard LDAP e2e test failure is pre-existing and unrelated (timing/container issue on corporate network; passes on CI)
- [ ] Manual: URL Rules tab shows correct target/value/matchType for each rule; new rules created via UI save and evaluate correctly
- [ ] Manual: Admin → Provider Connectivity no longer crashes when tls/http are absent (HTTP provider or TCP failure path)
- [ ] Manual: All provider dropdowns show friendly name (e.g. "github") not hostname (e.g. "github.com"); clone URL in active repos view is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)