### PR TITLE
fix: sync IdP-resolved roles to DB on every OIDC/LDAP login

### DIFF
--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/CompositeUserStore.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/CompositeUserStore.java
@@ -185,6 +185,11 @@ public class CompositeUserStore implements UserStore {
     }
 
     @Override
+    public void upsertUser(String username, List<String> roles) {
+        mutableStore.upsertUser(username, roles);
+    }
+
+    @Override
     public void upsertLockedEmail(String username, String email, String authSource) {
         mutableStore.upsertLockedEmail(username, email, authSource);
     }

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/JdbcUserStore.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/JdbcUserStore.java
@@ -208,14 +208,25 @@ public class JdbcUserStore implements UserStore {
      * The password is left NULL so the account cannot be used for form login.
      */
     public void upsertUser(String username) {
+        upsertUser(username, List.of("USER"));
+    }
+
+    @Override
+    public void upsertUser(String username, List<String> roles) {
+        String rolesStr = roles.isEmpty() ? "USER" : String.join(",", roles);
         boolean exists = !jdbc.queryForList(
                         "SELECT username FROM proxy_users WHERE username = :u", Map.of("u", username), String.class)
                 .isEmpty();
         if (!exists) {
             jdbc.update(
-                    "INSERT INTO proxy_users (username, password_hash, roles) VALUES (:u, NULL, 'USER')",
-                    Map.of("u", username));
-            log.debug("Auto-provisioned IdP user '{}'", username);
+                    "INSERT INTO proxy_users (username, password_hash, roles) VALUES (:u, NULL, :roles)",
+                    Map.of("u", username, "roles", rolesStr));
+            log.debug("Auto-provisioned IdP user '{}' with roles {}", username, rolesStr);
+        } else {
+            jdbc.update(
+                    "UPDATE proxy_users SET roles = :roles WHERE username = :u",
+                    Map.of("u", username, "roles", rolesStr));
+            log.debug("Synced IdP roles for user '{}': {}", username, rolesStr);
         }
     }
 

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/MongoUserStore.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/MongoUserStore.java
@@ -157,14 +157,23 @@ public class MongoUserStore implements UserStore {
 
     @Override
     public void upsertUser(String username) {
+        upsertUser(username, List.of("USER"));
+    }
+
+    @Override
+    public void upsertUser(String username, List<String> roles) {
+        String rolesStr = roles.isEmpty() ? "USER" : String.join(",", roles);
         if (getCollection().find(Filters.eq("_id", username)).first() == null) {
             getCollection()
                     .insertOne(new Document("_id", username)
                             .append("passwordHash", null)
-                            .append("roles", "USER")
+                            .append("roles", rolesStr)
                             .append("emails", List.of())
                             .append("scmIdentities", List.of()));
-            log.debug("Auto-provisioned IdP user '{}'", username);
+            log.debug("Auto-provisioned IdP user '{}' with roles {}", username, rolesStr);
+        } else {
+            getCollection().updateOne(Filters.eq("_id", username), Updates.set("roles", rolesStr));
+            log.debug("Synced IdP roles for user '{}': {}", username, rolesStr);
         }
     }
 

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/UserStore.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/UserStore.java
@@ -62,6 +62,14 @@ public interface UserStore extends ReadOnlyUserStore {
      */
     void upsertUser(String username);
 
+    /**
+     * Ensures a user row exists and syncs the given roles on every IdP login. Roles are authoritative from the IdP —
+     * any existing roles are overwritten so that IdP group changes take effect on next sign-in.
+     */
+    default void upsertUser(String username, List<String> roles) {
+        upsertUser(username);
+    }
+
     /** Inserts or updates an email for a user as locked (owned by the identity provider). */
     void upsertLockedEmail(String username, String email, String authSource);
 

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/user/JdbcUserStoreIntegrationTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/user/JdbcUserStoreIntegrationTest.java
@@ -247,6 +247,38 @@ class JdbcUserStoreIntegrationTest {
         assertEquals("{noop}pw", result.get().getPasswordHash());
     }
 
+    @Test
+    void upsertUser_withRoles_setsRolesOnNewUser() {
+        store.upsertUser("oidcuser", List.of("USER", "ADMIN"));
+
+        var result = store.findByUsername("oidcuser");
+        assertTrue(result.isPresent());
+        assertNull(result.get().getPasswordHash());
+        assertTrue(result.get().getRoles().contains("ADMIN"));
+        assertTrue(result.get().getRoles().contains("USER"));
+    }
+
+    @Test
+    void upsertUser_withRoles_syncsRolesOnSubsequentLogin() {
+        store.upsertUser("oidcuser", List.of("USER"));
+        store.upsertUser("oidcuser", List.of("USER", "SELF_CERTIFY"));
+
+        var result = store.findByUsername("oidcuser");
+        assertTrue(result.isPresent());
+        assertTrue(result.get().getRoles().contains("SELF_CERTIFY"));
+    }
+
+    @Test
+    void upsertUser_withRoles_syncsRolesForYamlUser() {
+        store.upsertAll(List.of(user("alice", List.of(), List.of())));
+        store.upsertUser("alice", List.of("USER", "ADMIN"));
+
+        var result = store.findByUsername("alice");
+        assertTrue(result.isPresent());
+        assertEquals("{noop}pw", result.get().getPasswordHash());
+        assertTrue(result.get().getRoles().contains("ADMIN"));
+    }
+
     // ---- upsertLockedEmail ----
 
     @Test

--- a/git-proxy-java-dashboard/frontend/src/pages/PushDetail.tsx
+++ b/git-proxy-java-dashboard/frontend/src/pages/PushDetail.tsx
@@ -100,7 +100,6 @@ function formatTime(ts: string | number | undefined) {
   }
 }
 
-
 /**
  * Build a direct link to the commit on the upstream SCM.
  * GitHub / Gitea / Codeberg: {repo}/commit/{sha}

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SecurityConfig.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SecurityConfig.java
@@ -474,7 +474,13 @@ public class SecurityConfig {
 
         if (authSource == null) return;
 
-        jdbc.upsertUser(username);
+        List<String> roles = auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .filter(a -> a.startsWith("ROLE_"))
+                .map(a -> a.substring(5))
+                .toList();
+        if (roles.isEmpty()) roles = List.of("USER");
+        jdbc.upsertUser(username, roles);
         if (email != null && !email.isBlank()) {
             try {
                 jdbc.upsertLockedEmail(username, email.strip().toLowerCase(), authSource);


### PR DESCRIPTION
## Summary

- `provisionIdpUser()` was calling `upsertUser(username)` which hardcoded `USER` regardless of the resolved OIDC group authorities or LDAP group mappings — users with `ROLE_ADMIN` / `ROLE_SELF_CERTIFY` had correct session auth but `proxy_users.roles` stayed `USER` forever
- Adds `upsertUser(String, List<String>)` to `UserStore`, `JdbcUserStore`, `MongoUserStore`, and `CompositeUserStore` — inserts with resolved roles on first login, updates on subsequent logins so IdP group changes take effect on next sign-in
- `SecurityConfig.provisionIdpUser()` now extracts role names from `auth.getAuthorities()` (stripping `ROLE_` prefix) and calls the new overload for both OIDC and LDAP paths

Closes #249

## Test plan

- [ ] 3 new `JdbcUserStoreIntegrationTest` cases: new user gets correct roles, subsequent login syncs updated roles, YAML-seeded user gets DB roles overwritten by IdP on login
- [ ] All existing `upsertUser` tests still pass — no-arg callers (`CompositeUserStore` internal provisioning) are unaffected
- [ ] Manual: OIDC or LDAP login with a user mapped to `ADMIN` or `SELF_CERTIFY` group — verify `proxy_users.roles` reflects the correct roles after login