### PR TITLE
feat: per-user API key for REST API authentication

### DIFF
--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/db/jdbc/DatabaseMigrator.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/db/jdbc/DatabaseMigrator.java
@@ -41,7 +41,8 @@ public class DatabaseMigrator {
                     "2.1", "widen provider columns", "db/migration-postgresql/V2_1__widen_provider_columns.sql", true),
             new Migration("3", "email unique constraint", "db/migration/V3__email_unique.sql", false),
             new Migration("4", "spring session tables", "db/migration/V4__spring_session.sql", false),
-            new Migration("5", "unified rule shape", "db/migration/V5__unified_rule_shape.sql", false));
+            new Migration("5", "unified rule shape", "db/migration/V5__unified_rule_shape.sql", false),
+            new Migration("6", "api key hash", "db/migration/V6__api_key.sql", false));
 
     // ---------------------------------------------------------------------------
 

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/CompositeUserStore.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/CompositeUserStore.java
@@ -190,6 +190,26 @@ public class CompositeUserStore implements UserStore {
     }
 
     @Override
+    public void setApiKey(String username, String keyHash) {
+        mutableStore.setApiKey(username, keyHash);
+    }
+
+    @Override
+    public void revokeApiKey(String username) {
+        mutableStore.revokeApiKey(username);
+    }
+
+    @Override
+    public Optional<UserEntry> findByApiKey(String keyHash) {
+        return mutableStore.findByApiKey(keyHash);
+    }
+
+    @Override
+    public boolean hasApiKey(String username) {
+        return mutableStore.hasApiKey(username);
+    }
+
+    @Override
     public void upsertLockedEmail(String username, String email, String authSource) {
         mutableStore.upsertLockedEmail(username, email, authSource);
     }

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/JdbcUserStore.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/JdbcUserStore.java
@@ -301,6 +301,42 @@ public class JdbcUserStore implements UserStore {
         log.debug("Upserted locked email '{}' ({}) for user '{}'", email, authSource, username);
     }
 
+    @Override
+    public void setApiKey(String username, String keyHash) {
+        int updated = jdbc.update(
+                "UPDATE proxy_users SET api_key_hash = :hash WHERE username = :u",
+                Map.of("u", username, "hash", keyHash));
+        if (updated == 0) throw new IllegalArgumentException("User not found: " + username);
+        log.debug("Set API key for user '{}'", username);
+    }
+
+    @Override
+    public void revokeApiKey(String username) {
+        jdbc.update("UPDATE proxy_users SET api_key_hash = NULL WHERE username = :u", Map.of("u", username));
+        log.debug("Revoked API key for user '{}'", username);
+    }
+
+    @Override
+    public Optional<UserEntry> findByApiKey(String keyHash) {
+        List<Map<String, Object>> rows = jdbc.queryForList(
+                "SELECT username, password_hash, roles FROM proxy_users WHERE api_key_hash = :hash",
+                Map.of("hash", keyHash));
+        if (rows.isEmpty()) return Optional.empty();
+        String username = (String) rows.get(0).get("username");
+        String hash = (String) rows.get(0).get("password_hash");
+        String rolesStr = (String) rows.get(0).get("roles");
+        return Optional.of(buildEntry(username, hash, rolesStr));
+    }
+
+    @Override
+    public boolean hasApiKey(String username) {
+        List<String> rows = jdbc.queryForList(
+                "SELECT api_key_hash FROM proxy_users WHERE username = :u AND api_key_hash IS NOT NULL",
+                Map.of("u", username),
+                String.class);
+        return !rows.isEmpty();
+    }
+
     private UserEntry buildEntry(String username, String passwordHash, String rolesStr) {
         List<String> emails = jdbc.queryForList(
                 "SELECT email FROM user_emails WHERE username = :u ORDER BY email",

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/MongoUserStore.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/MongoUserStore.java
@@ -178,6 +178,33 @@ public class MongoUserStore implements UserStore {
     }
 
     @Override
+    public void setApiKey(String username, String keyHash) {
+        getCollection().updateOne(Filters.eq("_id", username), Updates.set("apiKeyHash", keyHash));
+        log.debug("Set API key for user '{}'", username);
+    }
+
+    @Override
+    public void revokeApiKey(String username) {
+        getCollection().updateOne(Filters.eq("_id", username), Updates.unset("apiKeyHash"));
+        log.debug("Revoked API key for user '{}'", username);
+    }
+
+    @Override
+    public Optional<UserEntry> findByApiKey(String keyHash) {
+        Document doc = getCollection().find(Filters.eq("apiKeyHash", keyHash)).first();
+        if (doc == null) return Optional.empty();
+        return findByUsername(doc.getString("_id"));
+    }
+
+    @Override
+    public boolean hasApiKey(String username) {
+        return getCollection()
+                        .find(Filters.and(Filters.eq("_id", username), Filters.exists("apiKeyHash")))
+                        .first()
+                != null;
+    }
+
+    @Override
     public void addEmail(String username, String email) {
         String normalized = email.toLowerCase();
         Document owner = getCollection()

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/UserStore.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/user/UserStore.java
@@ -2,6 +2,7 @@ package org.finos.gitproxy.user;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Full user store interface: extends read access with write operations for user, email, and SCM identity management.
@@ -72,6 +73,20 @@ public interface UserStore extends ReadOnlyUserStore {
 
     /** Inserts or updates an email for a user as locked (owned by the identity provider). */
     void upsertLockedEmail(String username, String email, String authSource);
+
+    // ── API key management ────────────────────────────────────────────────────
+
+    /** Stores the SHA-256 hash of the user's API key. Replaces any existing key. */
+    void setApiKey(String username, String keyHash);
+
+    /** Removes the API key for the given user. No-op if no key is set. */
+    void revokeApiKey(String username);
+
+    /** Returns the user whose {@code api_key_hash} matches, or empty if none. */
+    Optional<UserEntry> findByApiKey(String keyHash);
+
+    /** Returns {@code true} if the user currently has an active API key. */
+    boolean hasApiKey(String username);
 
     // ── enriched queries (for admin UI) ──────────────────────────────────────────
 

--- a/git-proxy-java-core/src/main/resources/db/migration/V6__api_key.sql
+++ b/git-proxy-java-core/src/main/resources/db/migration/V6__api_key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE proxy_users ADD COLUMN api_key_hash VARCHAR(128);

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/user/JdbcUserStoreIntegrationTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/user/JdbcUserStoreIntegrationTest.java
@@ -355,4 +355,49 @@ class JdbcUserStoreIntegrationTest {
                 ScmIdentityConflictException.class, () -> store.addScmIdentity("bob", "github", "shared-handle"));
         assertEquals("alice", ex.getOwner());
     }
+
+    // ---- API key management ----
+
+    @Test
+    void setApiKey_storesHash_andFindByApiKeyReturnsUser() {
+        store.upsertUser("alice");
+        store.setApiKey("alice", "deadbeef");
+
+        var result = store.findByApiKey("deadbeef");
+        assertTrue(result.isPresent());
+        assertEquals("alice", result.get().getUsername());
+    }
+
+    @Test
+    void findByApiKey_unknownHash_returnsEmpty() {
+        assertFalse(store.findByApiKey("notahash").isPresent());
+    }
+
+    @Test
+    void hasApiKey_returnsTrueAfterSet_falseAfterRevoke() {
+        store.upsertUser("alice");
+        assertFalse(store.hasApiKey("alice"));
+
+        store.setApiKey("alice", "deadbeef");
+        assertTrue(store.hasApiKey("alice"));
+
+        store.revokeApiKey("alice");
+        assertFalse(store.hasApiKey("alice"));
+    }
+
+    @Test
+    void revokeApiKey_noKeySet_isNoOp() {
+        store.upsertUser("alice");
+        assertDoesNotThrow(() -> store.revokeApiKey("alice"));
+    }
+
+    @Test
+    void setApiKey_replacesExistingKey() {
+        store.upsertUser("alice");
+        store.setApiKey("alice", "oldhash");
+        store.setApiKey("alice", "newhash");
+
+        assertFalse(store.findByApiKey("oldhash").isPresent());
+        assertTrue(store.findByApiKey("newhash").isPresent());
+    }
 }

--- a/git-proxy-java-dashboard/frontend/src/api.ts
+++ b/git-proxy-java-dashboard/frontend/src/api.ts
@@ -155,6 +155,17 @@ export async function addScmIdentity(provider: string, username: string) {
   return res.json()
 }
 
+export async function generateApiKey(): Promise<{ key: string }> {
+  const res = await apiFetch('/api/me/api-key', { method: 'POST' })
+  if (!res.ok) await parseErrorResponse(res, 'Failed to generate API key')
+  return res.json()
+}
+
+export async function revokeApiKey(): Promise<void> {
+  const res = await apiFetch('/api/me/api-key', { method: 'DELETE' })
+  if (!res.ok) await parseErrorResponse(res, 'Failed to revoke API key')
+}
+
 export async function removeScmIdentity(provider: string, scmUsername: string) {
   const res = await apiFetch(
     `/api/me/identities/${encodeURIComponent(provider)}/${encodeURIComponent(scmUsername)}`,

--- a/git-proxy-java-dashboard/frontend/src/pages/Profile.tsx
+++ b/git-proxy-java-dashboard/frontend/src/pages/Profile.tsx
@@ -4,8 +4,10 @@ import {
   addScmIdentity,
   fetchMe,
   fetchProviders,
+  generateApiKey,
   removeEmail,
   removeScmIdentity,
+  revokeApiKey,
 } from '../api'
 import { OperationsBadge, PathTypeBadge } from '../components/PermissionBadges'
 import type { CurrentUser, EmailEntry, RepoPermission, ScmIdentity } from '../types'
@@ -118,6 +120,38 @@ export function Profile() {
       )
     } catch (err: unknown) {
       setIdentityError(err instanceof Error ? err.message : 'Failed to remove identity')
+    }
+  }
+
+  const [generatedKey, setGeneratedKey] = useState<string | null>(null)
+  const [apiKeyBusy, setApiKeyBusy] = useState(false)
+  const [apiKeyError, setApiKeyError] = useState<string | null>(null)
+
+  async function handleGenerateApiKey() {
+    setApiKeyBusy(true)
+    setApiKeyError(null)
+    try {
+      const { key } = await generateApiKey()
+      setGeneratedKey(key)
+      setProfile((p) => p && { ...p, hasApiKey: true })
+    } catch (err: unknown) {
+      setApiKeyError(err instanceof Error ? err.message : 'Failed to generate API key')
+    } finally {
+      setApiKeyBusy(false)
+    }
+  }
+
+  async function handleRevokeApiKey() {
+    setApiKeyBusy(true)
+    setApiKeyError(null)
+    try {
+      await revokeApiKey()
+      setGeneratedKey(null)
+      setProfile((p) => p && { ...p, hasApiKey: false })
+    } catch (err: unknown) {
+      setApiKeyError(err instanceof Error ? err.message : 'Failed to revoke API key')
+    } finally {
+      setApiKeyBusy(false)
     }
   }
 
@@ -294,6 +328,69 @@ export function Profile() {
               </table>
             </div>
           )}
+        </div>
+      )}
+
+      {/* API Key section — SELF_CERTIFY users only */}
+      {profile.authorities.includes('ROLE_SELF_CERTIFY') && (
+        <div className="space-y-3 border-t border-gray-100 pt-6">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-700">API Key</h3>
+            <p className="text-xs text-gray-500 mt-0.5">
+              Use this key with the <code className="font-mono">X-Api-Key</code> header to
+              authenticate API calls (e.g. self-certify) from automated pipelines.
+            </p>
+          </div>
+
+          {generatedKey ? (
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+                Copy this key now — it will not be shown again.
+              </p>
+              <div className="flex gap-2">
+                <input
+                  readOnly
+                  value={generatedKey}
+                  className="flex-1 font-mono text-xs rounded border border-gray-300 px-3 py-2 bg-gray-50 select-all"
+                  onClick={(e) => (e.target as HTMLInputElement).select()}
+                />
+                <button
+                  onClick={() => navigator.clipboard.writeText(generatedKey)}
+                  className="px-3 py-2 rounded border border-gray-300 text-xs text-gray-600 hover:bg-gray-50"
+                >
+                  Copy
+                </button>
+              </div>
+              <button
+                onClick={handleRevokeApiKey}
+                disabled={apiKeyBusy}
+                className="text-xs text-red-600 hover:underline disabled:opacity-50"
+              >
+                Revoke key
+              </button>
+            </div>
+          ) : profile.hasApiKey ? (
+            <div className="flex items-center gap-4">
+              <span className="text-sm text-gray-600">API key active</span>
+              <button
+                onClick={handleRevokeApiKey}
+                disabled={apiKeyBusy}
+                className="text-xs text-red-600 hover:underline disabled:opacity-50"
+              >
+                Revoke
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={handleGenerateApiKey}
+              disabled={apiKeyBusy}
+              className="px-4 py-2 rounded bg-slate-700 text-white text-sm hover:bg-slate-600 disabled:opacity-50 transition-colors"
+            >
+              {apiKeyBusy ? 'Generating…' : 'Generate API Key'}
+            </button>
+          )}
+
+          {apiKeyError && <p className="text-sm text-red-600">{apiKeyError}</p>}
         </div>
       )}
 

--- a/git-proxy-java-dashboard/frontend/src/types.ts
+++ b/git-proxy-java-dashboard/frontend/src/types.ts
@@ -108,6 +108,7 @@ export interface CurrentUser {
   emails: EmailEntry[]
   scmIdentities: ScmIdentity[]
   authorities: string[]
+  hasApiKey: boolean
 }
 
 export interface UserSummary {

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/ApiKeyAuthFilter.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/ApiKeyAuthFilter.java
@@ -40,7 +40,7 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
                     && MessageDigest.isEqual(expectedKey.getBytes(), provided.getBytes())
                     && SecurityContextHolder.getContext().getAuthentication() == null) {
                 var auth = new UsernamePasswordAuthenticationToken(
-                        "api-key",
+                        "operator-api-key",
                         null,
                         List.of(new SimpleGrantedAuthority("ROLE_USER"), new SimpleGrantedAuthority("ROLE_ADMIN")));
                 SecurityContextHolder.getContext().setAuthentication(auth);

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SecurityConfig.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/SecurityConfig.java
@@ -133,6 +133,10 @@ public class SecurityConfig {
             http.addFilterBefore(new ApiKeyAuthFilter(generated), UsernamePasswordAuthenticationFilter.class);
         }
 
+        if (userStore instanceof UserStore mutableStore) {
+            http.addFilterBefore(new UserApiKeyAuthFilter(mutableStore), UsernamePasswordAuthenticationFilter.class);
+        }
+
         List<String> allowedOrigins = gitProxyConfig.getServer().getAllowedOrigins();
         if (!allowedOrigins.isEmpty()) {
             log.info("CORS enabled for origins: {}", allowedOrigins);

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/UserApiKeyAuthFilter.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/UserApiKeyAuthFilter.java
@@ -1,0 +1,62 @@
+package org.finos.gitproxy.dashboard;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.finos.gitproxy.user.UserStore;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Authenticates REST API requests that carry an {@code X-Api-Key} header matching a per-user proxy API key. Resolves
+ * the user from the stored SHA-256 hash and sets up their full Spring {@link Authentication} with their actual roles,
+ * so all downstream permission checks behave identically to session-based auth.
+ *
+ * <p>Only activates when no session authentication is already present. Runs after the operator-level
+ * {@link ApiKeyAuthFilter} so the break-glass key takes precedence.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class UserApiKeyAuthFilter extends OncePerRequestFilter {
+
+    private final UserStore userStore;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        String provided = request.getHeader(ApiKeyAuthFilter.HEADER);
+        if (provided != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            String hash = sha256(provided);
+            userStore.findByApiKey(hash).ifPresent(user -> {
+                List<SimpleGrantedAuthority> authorities = user.getRoles().stream()
+                        .map(r -> new SimpleGrantedAuthority("ROLE_" + r))
+                        .toList();
+                var auth = new UsernamePasswordAuthenticationToken(user.getUsername(), null, authorities);
+                SecurityContextHolder.getContext().setAuthentication(auth);
+                log.debug("Authenticated API request for user '{}' via user API key", user.getUsername());
+            });
+        }
+        chain.doFilter(request, response);
+    }
+
+    private static String sha256(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+}

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/controller/AuthController.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/controller/AuthController.java
@@ -71,11 +71,14 @@ public class AuthController {
                 ? repoPermissionService.findByUsername(username)
                 : List.of();
 
+        boolean hasApiKey = userStore instanceof UserStore jdbc && user != null && jdbc.hasApiKey(username);
+
         return Map.of(
                 "username", username != null ? username : "",
                 "emails", emails,
                 "scmIdentities", scmIdentities,
                 "authorities", authorities,
-                "permissions", permissions);
+                "permissions", permissions,
+                "hasApiKey", hasApiKey);
     }
 }

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/controller/ProfileController.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/controller/ProfileController.java
@@ -2,6 +2,11 @@ package org.finos.gitproxy.dashboard.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.HexFormat;
 import java.util.Map;
 import org.finos.gitproxy.user.EmailConflictException;
 import org.finos.gitproxy.user.LockedByConfigException;
@@ -13,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -120,8 +126,44 @@ public class ProfileController {
         return ResponseEntity.noContent().build();
     }
 
+    // ---- API key management ----
+
+    @Operation(operationId = "generateApiKey", summary = "Generate a proxy-native API key for the current user")
+    @PostMapping("/api-key")
+    public ResponseEntity<?> generateApiKey() {
+        if (!(userStore instanceof UserStore mutable)) return NOT_MUTABLE;
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_SELF_CERTIFY"))) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", "API key generation requires the SELF_CERTIFY role"));
+        }
+        byte[] raw = new byte[32];
+        new SecureRandom().nextBytes(raw);
+        String key = "gp_" + HexFormat.of().formatHex(raw);
+        mutable.setApiKey(currentUsername(), sha256(key));
+        return ResponseEntity.ok(Map.of("key", key));
+    }
+
+    @Operation(operationId = "revokeApiKey", summary = "Revoke the current user's proxy API key")
+    @DeleteMapping("/api-key")
+    public ResponseEntity<?> revokeApiKey() {
+        if (!(userStore instanceof UserStore mutable)) return NOT_MUTABLE;
+        mutable.revokeApiKey(currentUsername());
+        return ResponseEntity.noContent().build();
+    }
+
     private String currentUsername() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         return auth != null ? auth.getName() : null;
+    }
+
+    private static String sha256(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
     }
 }

--- a/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/controller/PushController.java
+++ b/git-proxy-java-dashboard/src/main/java/org/finos/gitproxy/dashboard/controller/PushController.java
@@ -15,6 +15,8 @@ import org.finos.gitproxy.jetty.config.AttestationQuestion;
 import org.finos.gitproxy.jetty.config.GitProxyConfig;
 import org.finos.gitproxy.jetty.reload.ConfigHolder;
 import org.finos.gitproxy.permission.RepoPermissionService;
+import org.finos.gitproxy.user.ReadOnlyUserStore;
+import org.finos.gitproxy.user.UserStore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -39,6 +41,9 @@ public class PushController {
 
     @Autowired
     private ConfigHolder configHolder;
+
+    @Autowired(required = false)
+    private ReadOnlyUserStore userStore;
 
     /** Returns the authenticated username, falling back to {@code body.reviewerUsername}, then {@code "system"}. */
     private static String resolveReviewer(Map<String, String> body) {
@@ -220,11 +225,12 @@ public class PushController {
                     if (attestationError != null) return attestationError;
 
                     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+                    String reviewer = resolveReviewerFromApproveBody(body, auth);
                     var attestation = Attestation.builder()
                             .pushId(id)
                             .type(Attestation.Type.APPROVAL)
-                            .reviewerUsername(resolveReviewerFromApproveBody(body, auth))
-                            .reviewerEmail(body.reviewerEmail())
+                            .reviewerUsername(reviewer)
+                            .reviewerEmail(resolveReviewerEmail(reviewer))
                             .reason(body.reason())
                             .selfApproval(isSelfApproval(record, auth, adminOverride))
                             .answers(body.attestations())
@@ -268,6 +274,31 @@ public class PushController {
         return body != null && body.reviewerUsername() != null ? body.reviewerUsername() : "system";
     }
 
+    /**
+     * Resolves the reviewer's email from the user store. Prefers the IdP-locked email when available (most reliable
+     * across OIDC/LDAP), falls back to any registered email, and returns {@code null} for local users with no email or
+     * when the user store is unavailable (e.g. operator-api-key).
+     */
+    private String resolveReviewerEmail(String username) {
+        if (username == null || userStore == null) return null;
+        if (userStore instanceof UserStore jdbc) {
+            return jdbc.findEmailsWithVerified(username).stream()
+                    .filter(e -> Boolean.TRUE.equals(e.get("locked")))
+                    .map(e -> (String) e.get("email"))
+                    .findFirst()
+                    .orElseGet(() -> userStore
+                            .findByUsername(username)
+                            .filter(u -> !u.getEmails().isEmpty())
+                            .map(u -> u.getEmails().get(0))
+                            .orElse(null));
+        }
+        return userStore
+                .findByUsername(username)
+                .filter(u -> !u.getEmails().isEmpty())
+                .map(u -> u.getEmails().get(0))
+                .orElse(null);
+    }
+
     /** Reject a push. Body: { "reviewerUsername": "...", "reviewerEmail": "...", "reason": "..." } (reason required) */
     @Operation(operationId = "rejectPush", summary = "Reject a push")
     @PostMapping("/{id}/reject")
@@ -286,11 +317,12 @@ public class PushController {
                     ResponseEntity<?> identityError = checkReviewerIdentity(record, true);
                     if (identityError != null) return identityError;
                     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+                    String reviewer = resolveReviewer(body);
                     var attestation = Attestation.builder()
                             .pushId(id)
                             .type(Attestation.Type.REJECTION)
-                            .reviewerUsername(resolveReviewer(body))
-                            .reviewerEmail(body.get("reviewerEmail"))
+                            .reviewerUsername(reviewer)
+                            .reviewerEmail(resolveReviewerEmail(reviewer))
                             .reason(reason)
                             .selfApproval(isSelfApproval(record, auth, true))
                             .build();


### PR DESCRIPTION
## Summary

- Adds per-user proxy-native API keys so users with `SELF_CERTIFY` can authenticate REST API calls (e.g. self-certify endpoint) from automated pipelines without a browser session
- Keys are identified via `X-Api-Key` header — the same header as the existing operator break-glass key, now resolved per-user
- The key is shown exactly once on generation and never stored in plaintext; SHA-256 hash stored in `proxy_users.api_key_hash`

**What this is:** REST API credential for automation (self-certify, etc.)
**What this is not:** git push authentication — pushes continue to use SCM PATs as before

## Changes

- `V6__api_key.sql`: adds nullable `api_key_hash` column to `proxy_users`
- `UserStore` / `JdbcUserStore` / `MongoUserStore` / `CompositeUserStore`: `setApiKey`, `revokeApiKey`, `findByApiKey`, `hasApiKey`
- `UserApiKeyAuthFilter`: Spring `OncePerRequestFilter` that resolves `X-Api-Key` to a full `Authentication` with the user's actual DB roles; wired after the operator `ApiKeyAuthFilter` in `SecurityConfig`
- `ProfileController`: `POST /api/me/api-key` (SELF_CERTIFY gated) and `DELETE /api/me/api-key`
- `AuthController`: `hasApiKey` boolean in `/api/me` response
- `Profile.tsx`: API key section visible to SELF_CERTIFY users — generate, copy-once display, revoke

## Test plan

- [ ] 5 new `JdbcUserStoreIntegrationTest` cases covering set/find/revoke/replace/no-op
- [ ] All existing tests pass, coverage threshold holds
- [ ] Manual: log in as a SELF_CERTIFY user, generate key from Profile page, use `X-Api-Key: <key>` to call `POST /api/push/{id}/authorise` — verify it resolves the correct user and roles
- [ ] Manual: revoke key, verify subsequent `X-Api-Key` requests return 401
- [ ] Manual: non-SELF_CERTIFY user — verify API key section is not shown in Profile

Closes #185