### PR TITLE
fix: skip diff generation for tag pushes

### DIFF
--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/DiffGenerationHook.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/git/DiffGenerationHook.java
@@ -50,6 +50,11 @@ public class DiffGenerationHook implements GitProxyHook {
             }
 
             String refName = cmd.getRefName();
+
+            if (refName.startsWith("refs/tags/")) {
+                log.debug("Skipping diff generation for tag push: {}", refName);
+                continue;
+            }
             String commitFrom = cmd.getOldId().name();
             String commitTo = cmd.getNewId().name();
             boolean isNewBranch = ObjectId.zeroId().equals(cmd.getOldId());

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/ScanDiffFilter.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/ScanDiffFilter.java
@@ -63,6 +63,11 @@ public class ScanDiffFilter extends AbstractProviderAwareGitProxyFilter {
             return;
         }
 
+        if (requestDetails.isTagPush()) {
+            log.debug("Skipping diff generation for tag push: {}", requestDetails.getBranch());
+            return;
+        }
+
         String fromCommit = requestDetails.getCommitFrom();
         String toCommit = requestDetails.getCommitTo();
         if (toCommit == null || toCommit.isEmpty()) {

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/DiffGenerationHookTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/git/DiffGenerationHookTest.java
@@ -1,0 +1,87 @@
+package org.finos.gitproxy.git;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.transport.ReceiveCommand;
+import org.eclipse.jgit.transport.ReceivePack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DiffGenerationHookTest {
+
+    @TempDir
+    Path tempDir;
+
+    Git git;
+    Repository repo;
+    ObjectId c1;
+    ObjectId c2;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        git = Git.init().setDirectory(tempDir.toFile()).call();
+        repo = git.getRepository();
+        repo.getConfig().setBoolean("commit", null, "gpgsign", false);
+        repo.getConfig().save();
+        c1 = commit("init.txt", "initial content").getId();
+        c2 = commit("change.txt", "second content").getId();
+    }
+
+    private RevCommit commit(String filename, String content) throws Exception {
+        File f = tempDir.resolve(filename).toFile();
+        Files.writeString(f.toPath(), content + "\n");
+        git.add().addFilepattern(".").call();
+        return git.commit()
+                .setAuthor(new PersonIdent("Dev", "dev@example.com"))
+                .setCommitter(new PersonIdent("Dev", "dev@example.com"))
+                .setMessage("add " + filename)
+                .call();
+    }
+
+    @Test
+    void branchPush_generatesDiffStep() {
+        ReceivePack rp = new ReceivePack(repo);
+        ReceiveCommand cmd = new ReceiveCommand(c1, c2, "refs/heads/main", ReceiveCommand.Type.UPDATE);
+        PushContext ctx = new PushContext();
+
+        new DiffGenerationHook(ctx).onPreReceive(rp, List.of(cmd));
+
+        boolean hasDiff =
+                ctx.getSteps().stream().anyMatch(s -> DiffGenerationHook.STEP_NAME_PUSH_DIFF.equals(s.getStepName()));
+        assertTrue(hasDiff, "branch push must generate a diff step");
+    }
+
+    @Test
+    void tagPush_skipsDiffGeneration() {
+        ReceivePack rp = new ReceivePack(repo);
+        ReceiveCommand cmd = new ReceiveCommand(ObjectId.zeroId(), c2, "refs/tags/v1.0.0");
+        PushContext ctx = new PushContext();
+
+        new DiffGenerationHook(ctx).onPreReceive(rp, List.of(cmd));
+
+        boolean hasDiff =
+                ctx.getSteps().stream().anyMatch(s -> DiffGenerationHook.STEP_NAME_PUSH_DIFF.equals(s.getStepName()));
+        assertFalse(hasDiff, "tag push must not generate a diff step");
+    }
+
+    @Test
+    void deleteCommand_skipped() {
+        ReceivePack rp = new ReceivePack(repo);
+        ReceiveCommand cmd = new ReceiveCommand(c1, ObjectId.zeroId(), "refs/heads/main", ReceiveCommand.Type.DELETE);
+        PushContext ctx = new PushContext();
+
+        new DiffGenerationHook(ctx).onPreReceive(rp, List.of(cmd));
+
+        assertTrue(ctx.getSteps().isEmpty(), "delete command must not generate any steps");
+    }
+}

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/servlet/filter/ScanDiffFilterTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/servlet/filter/ScanDiffFilterTest.java
@@ -272,6 +272,22 @@ class ScanDiffFilterTest {
                 "content should include the matching line, got: " + scanStep.getContent());
     }
 
+    // ---- tag push → skipped entirely, no diff step ----
+
+    @Test
+    void tagPush_skipsDiffGeneration() throws Exception {
+        GitRequestDetails details = pushDetails(baseCommit, cleanCommit);
+        details.setBranch("refs/tags/v1.0.0");
+        FakeResponse resp = new FakeResponse();
+
+        filterNoRules().doHttpFilter(mockRequest(details), resp.mock);
+
+        assertFalse(resp.committed.get());
+        boolean hasDiffStep = details.getSteps().stream().anyMatch(s -> "diff".equals(s.getStepName()));
+        assertFalse(hasDiffStep, "tag push must not generate a diff step");
+        assertEquals(GitRequestDetails.GitResult.PENDING, details.getResult());
+    }
+
     // ---- diff step content contains the actual diff text ----
 
     @Test

--- a/git-proxy-java-dashboard/frontend/src/pages/PushList.tsx
+++ b/git-proxy-java-dashboard/frontend/src/pages/PushList.tsx
@@ -171,10 +171,7 @@ export function PushList({ currentUser }: PushListProps) {
   // Reload counts when filter-relevant state changes, with auto-refresh
   useEffect(() => {
     void Promise.resolve().then(() => loadCounts(filterRepo, myPushesOnly))
-    const timer = setInterval(
-      () => loadCounts(filterRepo, myPushesOnly),
-      10_000,
-    )
+    const timer = setInterval(() => loadCounts(filterRepo, myPushesOnly), 10_000)
     return () => clearInterval(timer)
   }, [filterRepo, myPushesOnly, loadCounts])
 


### PR DESCRIPTION
## Summary

- Skip diff generation in `DiffGenerationHook` (store-and-forward) when the pushed ref is under `refs/tags/`
- Skip diff generation in `ScanDiffFilter` (transparent proxy) via the existing `isTagPush()` check on `GitRequestDetails`
- Add `DiffGenerationHookTest` covering branch push, tag push skip, and delete skip
- Add `tagPush_skipsDiffGeneration` test to `ScanDiffFilterTest`

Closes #240

## Test plan

- [ ] `./gradlew :git-proxy-java-core:test` passes
- [ ] Push a release tag through the proxy and confirm no diff record is created