### PR TITLE
fix(proxy): skip shallow pkt-lines to allow pushes from shallow clones

### DIFF
--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/ParseGitRequestFilter.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/ParseGitRequestFilter.java
@@ -109,6 +109,11 @@ public class ParseGitRequestFilter extends AbstractProviderAwareGitProxyFilter {
                 var pli = new PacketLineIn(request.getInputStream());
                 String packetLine = pli.readStringRaw();
 
+                // Skip shallow pkt-lines sent by shallow-clone clients before the ref update
+                while (packetLine.startsWith("shallow ")) {
+                    packetLine = pli.readStringRaw();
+                }
+
                 // CVE-2025-54583: Reject multi-ref pushes. Read the next pkt-line — it must
                 // be a flush packet (0000). If it's another ref update, the client is pushing
                 // multiple branches and we must reject.

--- a/git-proxy-java-core/src/test/java/org/finos/gitproxy/servlet/filter/ParseGitRequestFilterTest.java
+++ b/git-proxy-java-core/src/test/java/org/finos/gitproxy/servlet/filter/ParseGitRequestFilterTest.java
@@ -344,6 +344,49 @@ class ParseGitRequestFilterTest {
         assertEquals(GitClientUtils.ZERO_OID, details.getCommitTo());
     }
 
+    // ---- shallow clone push (single ref preceded by shallow pkt-lines) ----
+
+    @Test
+    void parse_shallowClonePush_oneShallowLine_isNotRejected() throws Exception {
+        byte[] existingBody = loadResource("push-sample-01-body.bin");
+        byte[] packData = extractPackData(existingBody);
+
+        byte[] body = buildBody(
+                new String[] {"shallow " + PUSH1_OLD, PUSH1_OLD + " " + PUSH1_NEW + " " + PUSH1_REF + "\0 report-status"
+                },
+                packData);
+
+        RequestBodyWrapper wrapper = wrapBody(body, "/owner/repo.git/git-receive-pack");
+        GitRequestDetails details = makeFilter().parse(wrapper);
+
+        assertNotEquals(GitRequestDetails.GitResult.REJECTED, details.getResult());
+        assertEquals(PUSH1_REF, details.getBranch());
+        assertEquals(PUSH1_OLD, details.getCommitFrom());
+        assertEquals(PUSH1_NEW, details.getCommitTo());
+    }
+
+    @Test
+    void parse_shallowClonePush_multipleShallowLines_isNotRejected() throws Exception {
+        byte[] existingBody = loadResource("push-sample-01-body.bin");
+        byte[] packData = extractPackData(existingBody);
+
+        byte[] body = buildBody(
+                new String[] {
+                    "shallow " + PUSH1_OLD,
+                    "shallow " + PUSH1_NEW,
+                    PUSH1_OLD + " " + PUSH1_NEW + " " + PUSH1_REF + "\0 report-status"
+                },
+                packData);
+
+        RequestBodyWrapper wrapper = wrapBody(body, "/owner/repo.git/git-receive-pack");
+        GitRequestDetails details = makeFilter().parse(wrapper);
+
+        assertNotEquals(GitRequestDetails.GitResult.REJECTED, details.getResult());
+        assertEquals(PUSH1_REF, details.getBranch());
+        assertEquals(PUSH1_OLD, details.getCommitFrom());
+        assertEquals(PUSH1_NEW, details.getCommitTo());
+    }
+
     // ---- tag push (single ref) ----
 
     @Test


### PR DESCRIPTION
## Summary

- Shallow clone clients send one or more `shallow <sha>` pkt-lines before the ref update line in the git receive-pack protocol
- `ParseGitRequestFilter.parse()` was reading the first pkt-line and treating any following non-flush pkt-line as a multi-ref push, causing valid single-branch pushes from shallow clones to be rejected with _"Multi-branch pushes are not allowed"_
- Fix: skip all leading `shallow ` pkt-lines so the multi-ref check always operates on the actual ref update line

## Test plan

- [ ] `parse_shallowClonePush_oneShallowLine_isNotRejected` — single `shallow` line before ref, parses branch/SHAs correctly
- [ ] `parse_shallowClonePush_multipleShallowLines_isNotRejected` — two `shallow` lines before ref, parses correctly
- [ ] All existing CVE-2025-54583 multi-ref rejection tests still pass
- [ ] JaCoCo coverage threshold passes

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)