### PR TITLE
fix(security): bump Netty to 4.1.135.Final, update base image digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
 
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM docker.io/eclipse-temurin:25-jdk-noble@sha256:29d2d8af5d12f9ee7aec18f4fb2cd8bc8e6501b748ac62631acd31c867cfa262 AS builder
+FROM docker.io/eclipse-temurin:25-jdk-noble@sha256:02aba7518e48cfed96403ac9634e357a40329d6ec9418feb0b32636e43b245a1 AS builder
 
 # Install Node.js directly from the official distribution with SHA256 verification.
 # To update: download the new tarball, verify against nodejs.org/dist/vX.Y.Z/SHASUMS256.txt,
@@ -56,7 +56,7 @@ RUN sed -i \
     git-proxy-java-dashboard/build/install/git-proxy-java-dashboard/bin/git-proxy-java-dashboard
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM docker.io/eclipse-temurin:25-jre-noble@sha256:b27ca47660a8fa837e47a8533b9b1a3a430295cf29ca28d91af4fd121572dc29
+FROM docker.io/eclipse-temurin:25-jre-noble@sha256:f9bd8815e73632c22985ebb133ec49b9fc4ad5ffe0657594ac02748ad0431ab7
 
 WORKDIR /app
 

--- a/git-proxy-java-dashboard/build.gradle
+++ b/git-proxy-java-dashboard/build.gradle
@@ -143,12 +143,13 @@ tasks.register('stop') {
 }
 
 // Force Netty to a patched version — transitively pulled in by lettuce-core via spring-session-data-redis.
-// Resolves GHSA-mj4r-2hfc-f8p6 (netty-codec) and GHSA-cm33-6792-r9fm (netty-codec-dns).
+// Resolves GHSA-3qp7-7mw8-wx86, GHSA-x4gw-5cx5-pgmh (netty-handler) and GHSA-5pvg-856g-cp85,
+// GHSA-676x-f7gg-47vc, GHSA-xmv7-r254-6q78 (netty-resolver-dns).
 configurations.configureEach {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
         if (details.requested.group == 'io.netty') {
-            details.useVersion '4.1.133.Final'
-            details.because 'CVE fix: GHSA-mj4r-2hfc-f8p6, GHSA-cm33-6792-r9fm'
+            details.useVersion '4.1.135.Final'
+            details.because 'CVE fix: GHSA-3qp7-7mw8-wx86, GHSA-x4gw-5cx5-pgmh, GHSA-5pvg-856g-cp85, GHSA-676x-f7gg-47vc, GHSA-xmv7-r254-6q78'
         }
     }
 }


### PR DESCRIPTION
Netty 4.1.133.Final has 4 High CVEs fixed in 4.1.135.Final:
- GHSA-3qp7-7mw8-wx86, GHSA-x4gw-5cx5-pgmh (netty-handler)
- GHSA-5pvg-856g-cp85, GHSA-676x-f7gg-47vc, GHSA-xmv7-r254-6q78 (netty-resolver-dns)

Also updates eclipse-temurin:25-jdk-noble and 25-jre-noble digest pins to latest to clear OS-level CVEs in libgnutls30t64, libpng16-16t64, and others.