### PR TITLE
fix(ci): scan ghcr.io/rbc/git-proxy-java:edge, not stale personal image

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -30,10 +30,13 @@ jobs:
       # Single scan — fail on high+, emit template report and JSON in one pass.
       # SARIF upload intentionally omitted — OS-layer CVEs are triaged with application
       # context; uploading creates misleading noise in the GitHub Security tab.
+      - name: Set image name
+        run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Scan image
         if: always()
         run: |
-          grype ghcr.io/coopernetes/git-proxy-java:latest \
+          grype "${IMAGE}:edge" \
             --config .grype.yaml \
             -o "template=grype-report.txt" \
             -o "json=grype-report.json"


### PR DESCRIPTION
## Summary

- The standalone `container-scan.yml` was hardcoded to `ghcr.io/coopernetes/git-proxy-java:latest` — a personal GHCR image that was never updated after the repository moved to RBC
- Every weekly scan was reporting CVEs from a months-old image with no relation to the actual published artifact
- Fixed to derive the image from `github.repository` (same pattern used in `docker-publish.yml`), scanning `:edge`

## Notes

- The inline `scan` job in `docker-publish.yml` has always scanned the correct image (by digest, right after build) — that was never broken
- The `publish-release` job also re-scans before promoting to release tags, so the release gate was independently correct
- This standalone cron scan is the one surfaced in the weekly schedule; fixing it gives an honest weekly picture of the `:edge` image

🤖 Generated with [Claude Code](https://claude.com/claude-code)