### PR TITLE
fix(ci): lowercase GHCR image name in retag workflow; guard release-tag against stale HEAD

### DIFF
--- a/.claude/commands/release-tag.md
+++ b/.claude/commands/release-tag.md
@@ -46,7 +46,20 @@ Arguments passed: `$ARGUMENTS`
 
 4. **Verify the tag doesn't already exist.** Run `git tag -l v<version>`. If it exists, stop and tell the user.
 
-5. **Create the signed annotated tag.** Attempt a signed tag first:
+5. **Sync with origin/main and verify HEAD.** Run:
+   ```
+   git fetch origin main
+   git rev-parse HEAD
+   git rev-parse origin/main
+   ```
+   If the two SHAs differ, **stop** and tell the user:
+   > Your local HEAD (`<local sha>`) is not the same commit as `origin/main` (`<remote sha>`).
+   > The Docker build ran on `origin/main`. Tagging a different commit will break the promote-not-rebuild flow.
+   > Run `git checkout main && git reset --hard origin/main` to fix this, then re-run `/release-tag`.
+
+   Only proceed once HEAD == origin/main.
+
+6. **Create the signed annotated tag.** Attempt a signed tag first:
    ```
    git tag -s v<version> -m "Release v<version>"
    ```
@@ -55,13 +68,13 @@ Arguments passed: `$ARGUMENTS`
    git tag -a v<version> -m "Release v<version>"
    ```
 
-6. **Show and confirm.** Show the user:
+7. **Show and confirm.** Show the user:
    - `git show v<version> --stat`
 
    Then ask: "Ready to push the tag? This will trigger the Docker publish workflow."
    If they confirm, run `git push origin v<version>`. If they decline, remind them to push manually.
 
-7. **Create GitHub release with auto-generated notes.**
+8. **Create GitHub release with auto-generated notes.**
    ```
    gh release create v<version> \
      --title "v<version>" \

--- a/.github/workflows/retag.yml
+++ b/.github/workflows/retag.yml
@@ -38,12 +38,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # ratchet:docker/setup-buildx-action@v4
 
+      - name: Set image name
+        run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
       - name: Retag
         run: |
-          SOURCE="ghcr.io/${{ github.repository }}@${{ inputs.source-digest }}"
+          SOURCE="${IMAGE}@${{ inputs.source-digest }}"
           TAG_ARGS=""
           for tag in ${{ inputs.target-tags }}; do
-            TAG_ARGS="$TAG_ARGS --tag ghcr.io/${{ github.repository }}:${tag}"
+            TAG_ARGS="$TAG_ARGS --tag ${IMAGE}:${tag}"
           done
           echo "Retagging ${SOURCE} -> ${{ inputs.target-tags }}"
           docker buildx imagetools create ${TAG_ARGS} ${SOURCE}


### PR DESCRIPTION
## Summary

- **retag.yml**: `github.repository` returns `RBC/git-proxy-java` with uppercase org — `docker buildx imagetools` requires all-lowercase registry paths, causing the retag workflow to fail with _invalid reference format_
- **release-tag skill**: adds `git fetch origin main` + `HEAD == origin/main` guard before tagging; previously the skill tagged local HEAD which could be a branch tip rather than the merge commit CI built, causing `publish-release` to fail with `build-<sha>: not found` (root cause of the v1.0.0 tag issue)

## Test plan

- [ ] Trigger retag workflow manually with a valid digest — verify it completes without the lowercase error
- [ ] Run `/release-tag` on a future release — verify it refuses to proceed if local HEAD doesn't match `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)