### PR TITLE
fix: correct request body read loop and improve enrich error logging

### DIFF
--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/RequestBodyWrapper.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/RequestBodyWrapper.java
@@ -28,7 +28,7 @@ public class RequestBodyWrapper extends HttpServletRequestWrapper {
                 bufferedInputStream = new BufferedInputStream(inputStream);
                 byte[] byteBuffer = new byte[128];
                 int bytesRead = -1;
-                while ((bytesRead = bufferedInputStream.read(byteBuffer)) > 0) {
+                while ((bytesRead = bufferedInputStream.read(byteBuffer)) != -1) {
                     byteArrayOutputStream.write(byteBuffer, 0, bytesRead);
                 }
             }

--- a/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/EnrichPushCommitsFilter.java
+++ b/git-proxy-java-core/src/main/java/org/finos/gitproxy/servlet/filter/EnrichPushCommitsFilter.java
@@ -102,7 +102,7 @@ public class EnrichPushCommitsFilter extends AbstractProviderAwareGitProxyFilter
             requestDetails.getPushedCommits().addAll(commits);
 
         } catch (Exception e) {
-            log.warn("Failed to enrich push commits: {}", e.getMessage());
+            log.error("Failed to enrich push commits", e);
             requestDetails.setResult(GitRequestDetails.GitResult.ERROR);
             requestDetails.setReason("Push error: commit inspection failed (" + e.getMessage() + "). "
                     + "Please retry or contact your administrator.");


### PR DESCRIPTION
## Summary

- `RequestBodyWrapper`: fix read loop condition `> 0` → `!= -1` — the previous condition exits early if `read()` returns `0` mid-stream on a large body, truncating the cached bytes and causing `ParseGitRequestFilter` to hit EOF on the first pkt-line read
- `EnrichPushCommitsFilter`: switch `log.warn` to `log.error` with full stack trace so the actual failure is surfaced when commit enrichment fails instead of a message-only swallow

## Impact

Both transparent proxy and store-and-forward paths are affected since both flow through `ParseGitRequestFilter` which owns `RequestBodyWrapper` construction. Symptoms differ by mode:
- **Proxy mode:** empty `GitRequestDetails` → `CheckEmptyBranchFilter` fires → push blocked as "Empty Branch"
- **S&F mode:** truncated body passed to JGit `ReceivePack` → connection drop with no output

## Test plan

- [ ] Deploy to test environment
- [ ] Push a large branch (>1 MiB pack) via proxy mode — should pass validation
- [ ] Push a large branch via S&F mode — should complete without connection drop
- [ ] Confirm `project-rename` branch pushes cleanly through both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)