### PR TITLE
fix: bug fixes for 1.1.1 release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -153,18 +153,6 @@ jobs:
       - name: Set image name
         run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
-      - name: Install grype
-        env:
-          GRYPE_VERSION: "0.112.0"
-        run: |
-          cd /tmp
-          curl -sSfL -o "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" \
-            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz"
-          curl -sSfL -o "grype_${GRYPE_VERSION}_checksums.txt" \
-            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_checksums.txt"
-          grep "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" "grype_${GRYPE_VERSION}_checksums.txt" | sha256sum --check
-          tar -xzf "grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -C /usr/local/bin grype
-
       # Resolve the digest of the build-{sha} image produced when this commit landed on main.
       # The tag ruleset enforces Container Scan passed on this commit before the tag could be
       # pushed, so the build image is guaranteed scanned. Using the commit-pinned build tag
@@ -180,23 +168,6 @@ jobs:
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Promoting ${TAG} @ ${DIGEST}"
-
-      - name: Scan build image
-        run: |
-          grype "${IMAGE}@${{ steps.build.outputs.digest }}" \
-            --config .grype.yaml \
-            -o "template=grype-report.txt" \
-            -o "json=grype-report.json"
-
-      - name: Upload scan reports
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
-        with:
-          name: grype-release-scan
-          path: |
-            grype-report.txt
-            grype-report.json
-          retention-days: 90
 
       - name: Promote build image to release tags
         run: |

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/CommitInspectionService.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/CommitInspectionService.java
@@ -11,6 +11,7 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffFormatter;
+import org.eclipse.jgit.diff.RenameDetector;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.PersonIdent;
@@ -129,10 +130,14 @@ public class CommitInspectionService {
             }
 
             try (Git git = new Git(repository)) {
-                return git.diff()
+                List<DiffEntry> diffs = git.diff()
                         .setOldTree(oldTreeParser)
                         .setNewTree(newTreeParser)
                         .call();
+
+                RenameDetector rd = new RenameDetector(repository);
+                rd.addAll(diffs);
+                return rd.compute();
             } catch (GitAPIException e) {
                 throw new IOException("Failed to get diff", e);
             }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/ForwardingPostReceiveHook.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/ForwardingPostReceiveHook.java
@@ -8,6 +8,7 @@ import static com.rbc.fogwall.git.GitClientUtils.sym;
 import com.rbc.fogwall.db.model.PushStep;
 import com.rbc.fogwall.db.model.StepStatus;
 import com.rbc.fogwall.provider.FogwallProvider;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -33,9 +34,11 @@ public class ForwardingPostReceiveHook implements PostReceiveHook {
     /** JGit transport timeout in seconds. 0 = no timeout (JGit default). */
     private final int connectTimeoutSeconds;
 
+    private final LocalRepositoryCache cache;
+
     public ForwardingPostReceiveHook(
             FogwallProvider provider, CredentialsProvider credentials, PushContext pushContext) {
-        this(provider, credentials, pushContext, 0);
+        this(provider, credentials, pushContext, 0, null);
     }
 
     public ForwardingPostReceiveHook(
@@ -43,10 +46,20 @@ public class ForwardingPostReceiveHook implements PostReceiveHook {
             CredentialsProvider credentials,
             PushContext pushContext,
             int connectTimeoutSeconds) {
+        this(provider, credentials, pushContext, connectTimeoutSeconds, null);
+    }
+
+    public ForwardingPostReceiveHook(
+            FogwallProvider provider,
+            CredentialsProvider credentials,
+            PushContext pushContext,
+            int connectTimeoutSeconds,
+            LocalRepositoryCache cache) {
         this.provider = provider;
         this.credentials = credentials;
         this.pushContext = pushContext;
         this.connectTimeoutSeconds = connectTimeoutSeconds;
+        this.cache = cache;
     }
 
     @Override
@@ -106,6 +119,15 @@ public class ForwardingPostReceiveHook implements PostReceiveHook {
             logs.add("ERROR: " + e.getMessage());
             forwardFailed = true;
             forwardError = e.getMessage();
+        }
+
+        if (forwardFailed && cache != null && upstreamUrl != null) {
+            try {
+                cache.remove(upstreamUrl);
+                log.info("Invalidated local mirror for {} after forward failure", upstreamUrl);
+            } catch (IOException e) {
+                log.warn("Failed to invalidate local mirror for {}", upstreamUrl, e);
+            }
         }
 
         pushContext.addStep(PushStep.builder()

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/IdentityVerificationHook.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/IdentityVerificationHook.java
@@ -131,12 +131,8 @@ public class IdentityVerificationHook implements FogwallHook {
                     "Identity verification warnings for push user '{}': {} mismatch(es)",
                     user.getUsername(),
                     violations.size());
-            rp.sendMessage(GitClientUtils.color(
-                    YELLOW,
-                    sym(WARNING) + "  Identity warning: " + violations.size() + " commit email(s) not registered to "
-                            + user.getUsername()));
             for (String v : violations) {
-                rp.sendMessage("  " + v);
+                rp.sendMessage(GitClientUtils.color(YELLOW, sym(WARNING) + "  " + v));
             }
             pushContext.addStep(PushStep.builder()
                     .stepName(STEP_NAME)
@@ -155,7 +151,8 @@ public class IdentityVerificationHook implements FogwallHook {
         if (commit.getAuthor() != null) {
             String email = commit.getAuthor().getEmail();
             if (email != null && !registeredEmails.contains(email)) {
-                violations.add(sha + ": author <" + email + "> not registered to " + pushUsername);
+                violations.add("Unrecognised commit email: <" + email + "> (commit " + sha
+                        + ", author) — not in proxy user registry");
                 authorFlagged = true;
             }
         }
@@ -166,9 +163,11 @@ public class IdentityVerificationHook implements FogwallHook {
                 boolean sameAsAuthor = commit.getAuthor() != null
                         && email.equals(commit.getAuthor().getEmail());
                 if (!sameAsAuthor) {
-                    violations.add(sha + ": committer <" + email + "> not registered to " + pushUsername);
+                    violations.add("Unrecognised commit email: <" + email + "> (commit " + sha
+                            + ", committer) — not in proxy user registry");
                 } else if (!authorFlagged) {
-                    violations.add(sha + ": author+committer <" + email + "> not registered to " + pushUsername);
+                    violations.add("Unrecognised commit email: <" + email + "> (commit " + sha
+                            + ", author+committer) — not in proxy user registry");
                 }
             }
         }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/LocalRepositoryCache.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/LocalRepositoryCache.java
@@ -42,7 +42,7 @@ public class LocalRepositoryCache {
      * Default minimum interval between upstream re-fetches for the same repository. Prevents concurrent serve requests
      * from each triggering a separate fetch when the mirror is already fresh.
      */
-    private static final long DEFAULT_FETCH_COOLDOWN_MS = 30_000;
+    private static final long DEFAULT_FETCH_COOLDOWN_MS = 5_000;
 
     private final Path cacheDirectory;
     private final Map<String, CachedRepository> cache = new ConcurrentHashMap<>();

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/StoreAndForwardReceivePackFactory.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/StoreAndForwardReceivePackFactory.java
@@ -50,6 +50,7 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
     private final String serviceUrl;
     private final Duration heartbeatInterval;
     private final UrlRuleRegistry urlRuleRegistry;
+    private LocalRepositoryCache cache;
 
     /** Stop the validation hook chain after the first failure (see {@link ServerConfig#isFailFast()}). */
     private boolean failFast = false;
@@ -65,6 +66,11 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
     /** Set the upstream connect timeout. Call after construction before the factory handles any requests. */
     public void setConnectTimeoutSeconds(int connectTimeoutSeconds) {
         this.connectTimeoutSeconds = connectTimeoutSeconds;
+    }
+
+    /** Set the local repository cache for invalidation on forward failure. */
+    public void setCache(LocalRepositoryCache cache) {
+        this.cache = cache;
     }
 
     /** Fixed-config constructors for use in tests and simple setups (no URL rule enforcement). */
@@ -274,7 +280,7 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
                 chainPreReceiveHooks(heartbeatInterval, validationContext, failFast, disconnectCallback, preHooks));
 
         // Post-receive: forward to upstream, then record final status
-        var forwardingHook = new ForwardingPostReceiveHook(provider, creds, pushContext, connectTimeoutSeconds);
+        var forwardingHook = new ForwardingPostReceiveHook(provider, creds, pushContext, connectTimeoutSeconds, cache);
         if (persistenceHook != null) {
             rp.setPostReceiveHook(chainPostReceiveHooks(forwardingHook, persistenceHook.postReceiveHook()));
         } else {

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/IdentityVerificationFilter.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/IdentityVerificationFilter.java
@@ -140,7 +140,7 @@ public class IdentityVerificationFilter extends AbstractFogwallFilter {
                     request,
                     StepStatus.PASS,
                     null,
-                    violations.size() + " commit email(s) not registered to " + user.getUsername());
+                    violations.size() + " unrecognised commit email(s) — not in proxy user registry");
         }
     }
 
@@ -151,8 +151,8 @@ public class IdentityVerificationFilter extends AbstractFogwallFilter {
         if (commit.getAuthor() != null) {
             String email = commit.getAuthor().getEmail();
             if (email != null && !registeredEmails.contains(email)) {
-                violations.add(
-                        sym(CROSS_MARK) + "  " + sha + ": author <" + email + "> is not registered to " + pushUsername);
+                violations.add(sym(CROSS_MARK) + "  Unrecognised commit email: <" + email + "> (commit " + sha
+                        + ", author) — not in proxy user registry");
             }
         }
 
@@ -162,8 +162,8 @@ public class IdentityVerificationFilter extends AbstractFogwallFilter {
                 boolean sameAsAuthor = commit.getAuthor() != null
                         && email.equals(commit.getAuthor().getEmail());
                 if (!sameAsAuthor) {
-                    violations.add(sym(CROSS_MARK) + "  " + sha + ": committer <" + email + "> is not registered to "
-                            + pushUsername);
+                    violations.add(sym(CROSS_MARK) + "  Unrecognised commit email: <" + email + "> (commit " + sha
+                            + ", committer) — not in proxy user registry");
                 }
             }
         }

--- a/fogwall-core/src/test/java/com/rbc/fogwall/git/IdentityVerificationHookTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/git/IdentityVerificationHookTest.java
@@ -261,7 +261,7 @@ class IdentityVerificationHookTest {
                 .findFirst();
         assertTrue(step.isPresent(), "WARN mode should record an identityVerification step");
         assertNotNull(step.get().getContent(), "Step content should contain violation details");
-        assertTrue(step.get().getContent().contains("not registered"));
+        assertTrue(step.get().getContent().contains("not in proxy user registry"));
     }
 
     // ---- resolver returns empty → skip (CheckUserPushPermissionHook handles "not registered") ----

--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallServletRegistrar.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallServletRegistrar.java
@@ -155,6 +155,7 @@ public final class FogwallServletRegistrar {
                 urlRuleRegistry);
         factory.setFailFast(failFast);
         factory.setConnectTimeoutSeconds(connectTimeoutSeconds);
+        factory.setCache(cache);
 
         var gitServlet = new GitServlet();
         gitServlet.setRepositoryResolver(resolver);


### PR DESCRIPTION
- Detect renames in diff viewer via JGit RenameDetector (closes #318)
- Reword identity warnings to describe the unrecognised email rather than framing relative to the pusher, and remove duplicate preamble message (closes #301)
- Remove redundant Grype scan from publish-release workflow — the Container Scan required check on main is the authoritative gate (closes #241)
- Reduce S&F mirror fetch cooldown from 30s to 5s to shrink the stale-mirror race window (closes #336, closes #304)
- Invalidate S&F local mirror cache on upstream forward failure to prevent poisoned cache state requiring pod restart