### PR TITLE
chore: restrict GHA workflow token permissions to least privilege

### DIFF
--- a/.github/workflows/cleanup-interim-images.yml
+++ b/.github/workflows/cleanup-interim-images.yml
@@ -18,11 +18,12 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Delete stale build-* package versions
         env:


### PR DESCRIPTION
- cleanup-interim-images.yml: move packages:write from top-level to job-level (scorecard alert 312)

Remaining alerts dismissed with justification:
- alert 313 (retag.yml packages:write): job-level write required to push to GHCR; cannot be avoided
- alert 315 (ci.yml contents:write): required by gradle/actions/dependency-submission
- alert 303 (gradle-wrapper.jar): standard Gradle artifact, integrity via sha256
- alert 299 (branch protection): sole-maintainer project, approvers not enforceable