### PR TITLE
fix: cancel PENDING push record when git client disconnects during approval wait

### DIFF
--- a/fogwall-core/src/main/java/com/rbc/fogwall/approval/ClientDisconnectedException.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/approval/ClientDisconnectedException.java
@@ -1,0 +1,8 @@
+package com.rbc.fogwall.approval;
+
+/** Thrown by a {@link ProgressSender} when the git client's connection has been lost. */
+public class ClientDisconnectedException extends RuntimeException {
+    public ClientDisconnectedException(Throwable cause) {
+        super("Git client disconnected", cause);
+    }
+}

--- a/fogwall-core/src/main/java/com/rbc/fogwall/approval/UiApprovalGateway.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/approval/UiApprovalGateway.java
@@ -46,6 +46,9 @@ public class UiApprovalGateway implements ApprovalGateway {
                 long remainingSecs = (deadlineMs - System.currentTimeMillis()) / 1000;
                 progress.send(
                         String.format("Awaiting review... (%ds elapsed, ~%ds remaining)", elapsedSecs, remainingSecs));
+            } catch (ClientDisconnectedException e) {
+                log.debug("Client disconnected during approval wait for push {}", pushId);
+                return ApprovalResult.CANCELED;
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 return ApprovalResult.TIMED_OUT;

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/ApprovalPreReceiveHook.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/ApprovalPreReceiveHook.java
@@ -7,8 +7,10 @@ import static com.rbc.fogwall.git.GitClientUtils.sym;
 
 import com.rbc.fogwall.approval.ApprovalGateway;
 import com.rbc.fogwall.approval.ApprovalResult;
+import com.rbc.fogwall.approval.ClientDisconnectedException;
 import com.rbc.fogwall.db.PushStore;
 import com.rbc.fogwall.db.model.Attestation;
+import com.rbc.fogwall.db.model.Attestation.Type;
 import com.rbc.fogwall.db.model.PushRecord;
 import com.rbc.fogwall.db.model.PushStatus;
 import com.rbc.fogwall.permission.RepoPermissionService;
@@ -190,10 +192,35 @@ public class ApprovalPreReceiveHook implements PreReceiveHook {
                     rejectAll(commands, reason);
                 }
                 case CANCELED -> {
-                    sendAndFlush(rp, msgOut, color(YELLOW, "" + sym(WARNING) + "  Push canceled"));
+                    // Transition to CANCELED only if still PENDING — a reviewer-initiated cancel
+                    // already wrote CANCELED to the store; a client disconnect leaves it PENDING.
+                    var current = pushStore.findById(validationRecordId).orElse(null);
+                    if (current != null && current.getStatus() == PushStatus.PENDING) {
+                        pushStore.cancel(
+                                validationRecordId,
+                                Attestation.builder()
+                                        .pushId(validationRecordId)
+                                        .type(Type.CANCELLATION)
+                                        .automated(true)
+                                        .reason("Client disconnected")
+                                        .build());
+                    }
+                    try {
+                        sendAndFlush(rp, msgOut, color(YELLOW, "" + sym(WARNING) + "  Push canceled"));
+                    } catch (ClientDisconnectedException ignored) {
+                        // client already gone; message cannot be delivered
+                    }
                     rejectAll(commands, "Push canceled");
                 }
                 case TIMED_OUT -> {
+                    pushStore.cancel(
+                            validationRecordId,
+                            Attestation.builder()
+                                    .pushId(validationRecordId)
+                                    .type(Type.CANCELLATION)
+                                    .automated(true)
+                                    .reason("Approval timed out after " + timeout.toMinutes() + " minutes")
+                                    .build());
                     sendAndFlush(
                             rp,
                             msgOut,
@@ -253,7 +280,7 @@ public class ApprovalPreReceiveHook implements PreReceiveHook {
         try {
             msgOut.flush();
         } catch (IOException e) {
-            log.warn("Failed to flush sideband message", e);
+            throw new ClientDisconnectedException(e);
         }
     }
 }

--- a/fogwall-core/src/test/java/com/rbc/fogwall/approval/UiApprovalGatewayTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/approval/UiApprovalGatewayTest.java
@@ -168,6 +168,21 @@ class UiApprovalGatewayTest {
                 "Progress message should mention awaiting review");
     }
 
+    // ---- client disconnect ----
+
+    @Test
+    void returnsCanceled_whenProgressSenderThrowsClientDisconnectedException() {
+        PushRecord r = blockedRecord();
+
+        ProgressSender disconnectingSender = msg -> {
+            throw new ClientDisconnectedException(new java.io.IOException("Broken pipe"));
+        };
+
+        ApprovalResult result = gateway.waitForApproval(r.getId(), disconnectingSender, Duration.ofSeconds(10));
+
+        assertEquals(ApprovalResult.CANCELED, result);
+    }
+
     // ---- interrupt handling ----
 
     @Test

--- a/fogwall-core/src/test/java/com/rbc/fogwall/git/ApprovalPreReceiveHookTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/git/ApprovalPreReceiveHookTest.java
@@ -308,7 +308,7 @@ class ApprovalPreReceiveHookTest {
     }
 
     @Test
-    void blockedPush_gatewayTimesOut_commandRejected() throws Exception {
+    void blockedPush_gatewayTimesOut_commandRejectedAndPushStoreCanceled() throws Exception {
         String recordId = UUID.randomUUID().toString();
         PushContext pushContext = new PushContext();
         pushContext.setValidationRecordId(recordId);
@@ -327,5 +327,56 @@ class ApprovalPreReceiveHookTest {
                 .onPreReceive(rp, List.of(cmd));
 
         assertEquals(ReceiveCommand.Result.REJECTED_OTHER_REASON, cmd.getResult());
+        verify(pushStore).cancel(eq(recordId), any(Attestation.class));
+    }
+
+    @Test
+    void blockedPush_clientDisconnects_pushStoreCanceledAndCommandRejected() throws Exception {
+        String recordId = UUID.randomUUID().toString();
+        PushContext pushContext = new PushContext();
+        pushContext.setValidationRecordId(recordId);
+        PushRecord pending =
+                PushRecord.builder().id(recordId).status(PushStatus.PENDING).build();
+        // First call: initial fetch; second call: re-fetch inside CANCELED branch
+        when(pushStore.findById(recordId)).thenReturn(Optional.of(pending));
+        when(approvalGateway.waitForApproval(eq(recordId), any(), any(Duration.class)))
+                .thenReturn(ApprovalResult.CANCELED);
+
+        RevCommit c1 = createCommit("init");
+        RevCommit c2 = createCommit("second");
+        ReceivePack rp = new ReceivePack(repo);
+        ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
+
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, null, pushContext)
+                .onPreReceive(rp, List.of(cmd));
+
+        assertEquals(ReceiveCommand.Result.REJECTED_OTHER_REASON, cmd.getResult());
+        verify(pushStore).cancel(eq(recordId), any(Attestation.class));
+    }
+
+    @Test
+    void blockedPush_reviewerCancels_pushStoreAlreadyCanceled_noDuplicateCancel() throws Exception {
+        String recordId = UUID.randomUUID().toString();
+        PushContext pushContext = new PushContext();
+        pushContext.setValidationRecordId(recordId);
+        PushRecord pending =
+                PushRecord.builder().id(recordId).status(PushStatus.PENDING).build();
+        PushRecord alreadyCanceled =
+                PushRecord.builder().id(recordId).status(PushStatus.CANCELED).build();
+        // First call returns PENDING (hook start), second call returns CANCELED (re-fetch in CANCELED branch)
+        when(pushStore.findById(recordId)).thenReturn(Optional.of(pending)).thenReturn(Optional.of(alreadyCanceled));
+        when(approvalGateway.waitForApproval(eq(recordId), any(), any(Duration.class)))
+                .thenReturn(ApprovalResult.CANCELED);
+
+        RevCommit c1 = createCommit("init");
+        RevCommit c2 = createCommit("second");
+        ReceivePack rp = new ReceivePack(repo);
+        ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
+
+        new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofSeconds(5), null, null, pushContext)
+                .onPreReceive(rp, List.of(cmd));
+
+        assertEquals(ReceiveCommand.Result.REJECTED_OTHER_REASON, cmd.getResult());
+        verify(pushStore, never()).cancel(any(), any());
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause 1:** `sendAndFlush()` was swallowing the `IOException` from a broken sideband pipe. The new `ClientDisconnectedException` propagates through `UiApprovalGateway`, which returns `CANCELED` immediately rather than polling for up to 30 minutes.
- **Root cause 2:** The `CANCELED` and `TIMED_OUT` switch cases in `ApprovalPreReceiveHook` never wrote back to the push store, leaving records PENDING forever. Both cases now call `pushStore.cancel()`. The CANCELED branch re-fetches first to avoid overwriting a reviewer's attestation if they cancelled via the UI.
- Deferred forwarding ("drop off" semantics) is explicitly out of scope — that workflow deserves its own endpoint. S&F exists for live client feedback; once the connection is gone, the push is cancelled.

closes #353

## Test plan

- [ ] New unit test: `UiApprovalGateway` returns `CANCELED` when progress sender throws `ClientDisconnectedException`
- [ ] New unit test: `ApprovalPreReceiveHook` calls `pushStore.cancel()` on client disconnect (record still PENDING)
- [ ] New unit test: `ApprovalPreReceiveHook` does not double-cancel when reviewer already cancelled (record already CANCELED)
- [ ] Updated unit test: timeout case now also verifies `pushStore.cancel()` is called

🤖 Generated with [Claude Code](https://claude.com/claude-code)