### PR TITLE
fix: skip RFC format check when no email policy is configured, drop commons-validator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,9 +56,6 @@ ext {
     // BouncyCastle
     bouncyCastleVersion = '1.84'
 
-    // Commons
-    commonsValidatorVersion = '1.10.1'
-
     // Lombok
     lombokVersion = '1.18.46'
 

--- a/fogwall-core/build.gradle
+++ b/fogwall-core/build.gradle
@@ -34,9 +34,6 @@ dependencies {
     // Jakarta annotations
     api "jakarta.annotation:jakarta.annotation-api:3.0.0"
     
-    // Apache Commons Validator for email validation
-    implementation "commons-validator:commons-validator:${commonsValidatorVersion}"
-
     // BouncyCastle for GPG signature verification
     implementation "org.bouncycastle:bcprov-jdk18on:${bouncyCastleVersion}"
     implementation "org.bouncycastle:bcpg-jdk18on:${bouncyCastleVersion}"

--- a/fogwall-core/src/main/java/com/rbc/fogwall/validation/AuthorEmailCheck.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/validation/AuthorEmailCheck.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.validator.routines.EmailValidator;
 
 /**
  * Validates committer and author emails in the pushed commits against configured domain/local rules.
@@ -63,26 +62,28 @@ public class AuthorEmailCheck implements CommitCheck {
 
     /** Returns the reason the email is rejected under the given email config, or {@code null} if it is allowed. */
     private String violationReason(String email, CommitConfig.EmailConfig emailConfig) {
+        Pattern localBlock = emailConfig.getLocal().getBlock();
+        Pattern domainAllow = emailConfig.getDomain().getAllow();
+
+        if (localBlock == null && domainAllow == null) {
+            return null;
+        }
+
         if (email == null || email.isEmpty()) {
             return "empty email";
         }
-        if (!EmailValidator.getInstance().isValid(email)) {
-            return "invalid email format";
-        }
 
-        String[] parts = email.split("@");
-        if (parts.length != 2) {
-            return "invalid email format";
+        int atIndex = email.lastIndexOf('@');
+        if (atIndex < 0) {
+            return "missing @ in email";
         }
-        String local = parts[0];
-        String domain = parts[1];
+        String local = email.substring(0, atIndex);
+        String domain = email.substring(atIndex + 1);
 
-        Pattern localBlock = emailConfig.getLocal().getBlock();
         if (localBlock != null && localBlock.matcher(local).find()) {
             return "blocked local part (" + local + ")";
         }
 
-        Pattern domainAllow = emailConfig.getDomain().getAllow();
         if (domainAllow != null && !domainAllow.matcher(domain).find()) {
             return "domain not allowed (" + domain + ")";
         }

--- a/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/CheckAuthorEmailsFilterTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/CheckAuthorEmailsFilterTest.java
@@ -201,7 +201,7 @@ class CheckAuthorEmailsFilterTest {
     }
 
     @Test
-    void invalidEmailFormat_blocks() throws Exception {
+    void missingAtSign_blocks() throws Exception {
         GitRequestDetails details = makeRequestDetails(List.of(commitWithEmail("notanemail")));
         CheckAuthorEmailsFilter filter = new CheckAuthorEmailsFilter(testConfig());
         FakeResponse fakeResponse = new FakeResponse();
@@ -209,6 +209,29 @@ class CheckAuthorEmailsFilterTest {
         filter.doHttpFilter(mockPushRequest(details), fakeResponse.mock);
 
         assertEquals(GitRequestDetails.GitResult.REJECTED, details.getResult());
+    }
+
+    @Test
+    void githubBotEmail_withDomainPolicy_allowedWhenDomainMatches() throws Exception {
+        // RFC-noncompliant bot emails must be evaluated against configured policy only — no format gatekeeping.
+        String botEmail = "49699333+dependabot[bot]@users.noreply.github.com";
+        CommitConfig config = CommitConfig.builder()
+                .committer(CommitConfig.CommitterConfig.builder()
+                        .email(CommitConfig.EmailConfig.builder()
+                                .domain(CommitConfig.DomainConfig.builder()
+                                        .allow(Pattern.compile("github\\.com$"))
+                                        .build())
+                                .local(CommitConfig.LocalConfig.builder().build())
+                                .build())
+                        .build())
+                .build();
+        GitRequestDetails details = makeRequestDetails(List.of(commitWithEmail(botEmail)));
+        CheckAuthorEmailsFilter filter = new CheckAuthorEmailsFilter(config);
+        FakeResponse fakeResponse = new FakeResponse();
+
+        filter.doHttpFilter(mockPushRequest(details), fakeResponse.mock);
+
+        assertEquals(GitRequestDetails.GitResult.PENDING, details.getResult());
     }
 
     @Test
@@ -289,6 +312,20 @@ class CheckAuthorEmailsFilterTest {
     @Test
     void noConfigRestrictions_anyEmailPasses() throws Exception {
         GitRequestDetails details = makeRequestDetails(List.of(commitWithEmail("anything@notrestricted.biz")));
+        CheckAuthorEmailsFilter filter = new CheckAuthorEmailsFilter(CommitConfig.defaultConfig());
+        FakeResponse fakeResponse = new FakeResponse();
+
+        filter.doHttpFilter(mockPushRequest(details), fakeResponse.mock);
+
+        assertEquals(GitRequestDetails.GitResult.PENDING, details.getResult());
+    }
+
+    @Test
+    void noConfigRestrictions_githubBotEmail_passes() throws Exception {
+        // GitHub generates RFC-noncompliant emails for bot accounts (square brackets in local part).
+        // The format check must be skipped when no policy is configured.
+        String botEmail = "49699333+dependabot[bot]@users.noreply.github.com";
+        GitRequestDetails details = makeRequestDetails(List.of(commitWithEmail(botEmail)));
         CheckAuthorEmailsFilter filter = new CheckAuthorEmailsFilter(CommitConfig.defaultConfig());
         FakeResponse fakeResponse = new FakeResponse();
 


### PR DESCRIPTION
## Summary

- `EmailValidator` (Apache Commons) rejects real-world bot emails like `dependabot[bot]@users.noreply.github.com` (square brackets in local part fail RFC 5321).
- Format validation is not fogwall's job — configured `domainAllow`/`localBlock` patterns are the enforcement mechanism.
- Removed `EmailValidator` entirely, replaced with `lastIndexOf('@')` split. Early-return guard when no policy is configured.
- Dropped `commons-validator` and its transitive deps (commons-beanutils, commons-digester, commons-logging).

closes #357

## Test plan

- [ ] Existing tests pass unchanged
- [ ] New: GitHub bot email passes with default (no-policy) config
- [ ] New: GitHub bot email passes when domainAllow matches its domain
- [ ] Renamed `invalidEmailFormat_blocks` to `missingAtSign_blocks`

🤖 Generated with Claude Code
