### PR TITLE
fix: decompose identity-verification into independent committer and author checks

### DIFF
--- a/fogwall-core/src/main/java/com/rbc/fogwall/config/CommitConfig.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/config/CommitConfig.java
@@ -19,13 +19,13 @@ import lombok.Data;
 @Builder
 public class CommitConfig {
 
-    /** Controls whether commit identity is verified against the authenticated push user. */
+    /** Per-check mode for identity verification. */
     public enum IdentityVerificationMode {
-        /** Block the push when any commit author/committer email is not registered to the push user. */
+        /** Block the push when the email is not registered to the push user. */
         STRICT,
-        /** Warn the push user but allow the push through. Default. */
+        /** Warn the push user but allow the push through. */
         WARN,
-        /** Skip identity verification entirely. */
+        /** Skip this check entirely. */
         OFF;
 
         public static IdentityVerificationMode fromString(String value) {
@@ -39,12 +39,35 @@ public class CommitConfig {
     }
 
     /**
-     * Whether to verify that commit author/committer emails are registered to the authenticated push user. When users
-     * are configured, {@code WARN} is the default — mismatches produce a warning but do not block. {@code STRICT}
-     * blocks the push. {@code OFF} skips the check entirely.
+     * Independent mode settings for each identity check. Committer email is the primary mechanism for linking commit
+     * data back to a fogwall identity — it identifies who last touched the commit object (or the rebaser/amender).
+     * Author email is attribution metadata and should not gate push access for most workflows.
+     */
+    @Data
+    @Builder
+    public static class IdentityVerificationConfig {
+
+        /** Check that each commit's committer email is registered to the push user. Default: {@code WARN}. */
+        @Builder.Default
+        private IdentityVerificationMode committer = IdentityVerificationMode.WARN;
+
+        /** Check that each commit's author email is registered to the push user. Default: {@code OFF}. */
+        @Builder.Default
+        private IdentityVerificationMode author = IdentityVerificationMode.OFF;
+
+        /** {@code true} when both checks are off — used to short-circuit resolver calls. */
+        public boolean isEffectivelyOff() {
+            return committer == IdentityVerificationMode.OFF && author == IdentityVerificationMode.OFF;
+        }
+    }
+
+    /**
+     * Per-check identity verification configuration. Committer defaults to {@code WARN}; author defaults to {@code OFF}
+     * so rebase workflows (which preserve the original author email) are not blocked by default.
      */
     @Builder.Default
-    private IdentityVerificationMode identityVerification = IdentityVerificationMode.WARN;
+    private IdentityVerificationConfig identityVerification =
+            IdentityVerificationConfig.builder().build();
 
     /** Configuration for author email validation. */
     @Builder.Default

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/IdentityVerificationHook.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/IdentityVerificationHook.java
@@ -42,19 +42,21 @@ public class IdentityVerificationHook implements FogwallHook {
     static final String STEP_NAME = "identityVerification";
 
     private final PushIdentityResolver identityResolver;
-    private final CommitConfig.IdentityVerificationMode mode;
+    private final CommitConfig.IdentityVerificationConfig config;
     private final ValidationContext validationContext;
     private final PushContext pushContext;
     private final FogwallProvider provider;
 
     public IdentityVerificationHook(
             PushIdentityResolver identityResolver,
-            CommitConfig.IdentityVerificationMode mode,
+            CommitConfig.IdentityVerificationConfig config,
             ValidationContext validationContext,
             PushContext pushContext,
             FogwallProvider provider) {
         this.identityResolver = identityResolver;
-        this.mode = mode != null ? mode : CommitConfig.IdentityVerificationMode.WARN;
+        this.config = config != null
+                ? config
+                : CommitConfig.IdentityVerificationConfig.builder().build();
         this.validationContext = validationContext;
         this.pushContext = pushContext;
         this.provider = provider;
@@ -62,8 +64,8 @@ public class IdentityVerificationHook implements FogwallHook {
 
     @Override
     public void onPreReceive(ReceivePack rp, Collection<ReceiveCommand> commands) {
-        if (mode == CommitConfig.IdentityVerificationMode.OFF) {
-            log.debug("Identity verification disabled (mode=off)");
+        if (config.isEffectivelyOff()) {
+            log.debug("Identity verification disabled (committer=off, author=off)");
             recordPass();
             return;
         }
@@ -85,7 +87,6 @@ public class IdentityVerificationHook implements FogwallHook {
 
         Optional<UserEntry> resolved = identityResolver.resolve(provider, pushUser, pushToken);
         if (resolved.isEmpty()) {
-            // CheckUserPushPermissionHook handles "user not registered" upstream; skip silently here
             log.debug("Push user '{}' could not be resolved — skipping identity verification", pushUser);
             return;
         }
@@ -93,83 +94,81 @@ public class IdentityVerificationHook implements FogwallHook {
         UserEntry user = resolved.get();
         List<String> registeredEmails = user.getEmails() != null ? user.getEmails() : List.of();
         Repository repo = rp.getRepository();
-        List<String> violations = new ArrayList<>();
+        List<String> blockingViolations = new ArrayList<>();
+        List<String> warnViolations = new ArrayList<>();
 
         for (ReceiveCommand cmd : commands) {
             if (cmd.getType() == ReceiveCommand.Type.DELETE) continue;
             try {
-                List<Commit> commits = getCommits(repo, cmd);
-                for (Commit commit : commits) {
-                    collectViolations(commit, user.getUsername(), registeredEmails, violations);
+                for (Commit commit : getCommits(repo, cmd)) {
+                    String sha = abbrev(commit.getSha());
+
+                    if (config.getCommitter() != CommitConfig.IdentityVerificationMode.OFF
+                            && commit.getCommitter() != null) {
+                        String email = commit.getCommitter().getEmail();
+                        if (email != null && !registeredEmails.contains(email)) {
+                            String msg = "Unrecognised committer email: <" + email + "> (commit " + sha
+                                    + ") — not in proxy user registry";
+                            if (config.getCommitter() == CommitConfig.IdentityVerificationMode.STRICT) {
+                                blockingViolations.add(msg);
+                            } else {
+                                warnViolations.add(msg);
+                            }
+                        }
+                    }
+
+                    if (config.getAuthor() != CommitConfig.IdentityVerificationMode.OFF && commit.getAuthor() != null) {
+                        String email = commit.getAuthor().getEmail();
+                        if (email != null && !registeredEmails.contains(email)) {
+                            String msg = "Unrecognised author email: <" + email + "> (commit " + sha
+                                    + ") — not in proxy user registry";
+                            if (config.getAuthor() == CommitConfig.IdentityVerificationMode.STRICT) {
+                                blockingViolations.add(msg);
+                            } else {
+                                warnViolations.add(msg);
+                            }
+                        }
+                    }
                 }
             } catch (Exception e) {
                 log.error("Failed to verify identity for {}", cmd.getRefName(), e);
             }
         }
 
-        if (violations.isEmpty()) {
+        if (blockingViolations.isEmpty() && warnViolations.isEmpty()) {
             log.debug("Identity verification passed for push user '{}'", user.getUsername());
             recordPass();
             return;
         }
 
-        if (mode == CommitConfig.IdentityVerificationMode.STRICT) {
+        if (!blockingViolations.isEmpty()) {
+            List<String> allViolations = new ArrayList<>(blockingViolations);
+            allViolations.addAll(warnViolations);
             log.warn(
-                    "Identity verification failed for push user '{}': {} mismatch(es)",
+                    "Identity verification failed for push user '{}': {} violation(s)",
                     user.getUsername(),
-                    violations.size());
+                    allViolations.size());
             String detail = GitClientUtils.format(
                     sym(NO_ENTRY) + "  Push Blocked — Commit Identity Mismatch",
-                    String.join("\n", violations),
+                    String.join("\n", allViolations),
                     RED,
                     null);
             validationContext.addIssue(
                     STEP_NAME, "Commit identity does not match push user " + user.getUsername(), detail);
         } else {
-            // WARN mode — push proceeds but developer is warned at the terminal and in the dashboard.
             log.warn(
                     "Identity verification warnings for push user '{}': {} mismatch(es)",
                     user.getUsername(),
-                    violations.size());
-            for (String v : violations) {
+                    warnViolations.size());
+            for (String v : warnViolations) {
                 rp.sendMessage(GitClientUtils.color(YELLOW, sym(WARNING) + "  " + v));
             }
             pushContext.addStep(PushStep.builder()
                     .stepName(STEP_NAME)
                     .stepOrder(ORDER)
                     .status(StepStatus.PASS)
-                    .content(String.join("\n", violations))
+                    .content(String.join("\n", warnViolations))
                     .build());
-        }
-    }
-
-    private void collectViolations(
-            Commit commit, String pushUsername, List<String> registeredEmails, List<String> violations) {
-        String sha = abbrev(commit.getSha());
-        boolean authorFlagged = false;
-
-        if (commit.getAuthor() != null) {
-            String email = commit.getAuthor().getEmail();
-            if (email != null && !registeredEmails.contains(email)) {
-                violations.add("Unrecognised commit email: <" + email + "> (commit " + sha
-                        + ", author) — not in proxy user registry");
-                authorFlagged = true;
-            }
-        }
-
-        if (commit.getCommitter() != null) {
-            String email = commit.getCommitter().getEmail();
-            if (email != null && !registeredEmails.contains(email)) {
-                boolean sameAsAuthor = commit.getAuthor() != null
-                        && email.equals(commit.getAuthor().getEmail());
-                if (!sameAsAuthor) {
-                    violations.add("Unrecognised commit email: <" + email + "> (commit " + sha
-                            + ", committer) — not in proxy user registry");
-                } else if (!authorFlagged) {
-                    violations.add("Unrecognised commit email: <" + email + "> (commit " + sha
-                            + ", author+committer) — not in proxy user registry");
-                }
-            }
         }
     }
 

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/IdentityVerificationFilter.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/IdentityVerificationFilter.java
@@ -43,25 +43,30 @@ public class IdentityVerificationFilter extends AbstractFogwallFilter {
     private static final String STEP_NAME = "identityVerification";
 
     private final PushIdentityResolver identityResolver;
-    private final Supplier<CommitConfig.IdentityVerificationMode> modeSupplier;
+    private final Supplier<CommitConfig.IdentityVerificationConfig> configSupplier;
 
-    /** Live-reload constructor — identity verification mode is read from the supplier on every request. */
+    /** Live-reload constructor — config is read from the supplier on every request. */
     public IdentityVerificationFilter(
             PushIdentityResolver identityResolver, Supplier<CommitConfig> commitConfigSupplier) {
         super(ORDER, Set.of(HttpOperation.PUSH));
         this.identityResolver = identityResolver;
-        this.modeSupplier = () -> {
-            CommitConfig.IdentityVerificationMode m = commitConfigSupplier.get().getIdentityVerification();
-            return m != null ? m : CommitConfig.IdentityVerificationMode.WARN;
+        this.configSupplier = () -> {
+            CommitConfig.IdentityVerificationConfig c =
+                    commitConfigSupplier.get().getIdentityVerification();
+            return c != null
+                    ? c
+                    : CommitConfig.IdentityVerificationConfig.builder().build();
         };
     }
 
-    /** Fixed-mode constructor. Useful in tests; wraps the value in a constant supplier. */
+    /** Fixed-config constructor. Useful in tests. */
     public IdentityVerificationFilter(
-            PushIdentityResolver identityResolver, CommitConfig.IdentityVerificationMode mode) {
+            PushIdentityResolver identityResolver, CommitConfig.IdentityVerificationConfig config) {
         super(ORDER, Set.of(HttpOperation.PUSH));
         this.identityResolver = identityResolver;
-        this.modeSupplier = () -> mode != null ? mode : CommitConfig.IdentityVerificationMode.WARN;
+        this.configSupplier = () -> config != null
+                ? config
+                : CommitConfig.IdentityVerificationConfig.builder().build();
     }
 
     @Override
@@ -71,9 +76,9 @@ public class IdentityVerificationFilter extends AbstractFogwallFilter {
 
     @Override
     public void doHttpFilter(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        var mode = modeSupplier.get();
-        if (mode == CommitConfig.IdentityVerificationMode.OFF) {
-            log.debug("Identity verification disabled (mode=off)");
+        var config = configSupplier.get();
+        if (config.isEffectivelyOff()) {
+            log.debug("Identity verification disabled (committer=off, author=off)");
             return;
         }
 
@@ -100,72 +105,73 @@ public class IdentityVerificationFilter extends AbstractFogwallFilter {
 
         Optional<UserEntry> resolved = identityResolver.resolve(requestDetails.getProvider(), pushUsername, pushToken);
         if (resolved.isEmpty()) {
-            // CheckUserPushPermissionFilter handles "user not registered"; skip silently here
             log.debug("Push user '{}' could not be resolved — skipping identity verification", pushUsername);
             return;
         }
 
         UserEntry user = resolved.get();
         List<String> registeredEmails = user.getEmails() != null ? user.getEmails() : List.of();
-        List<String> violations = new ArrayList<>();
+        List<String> blockingViolations = new ArrayList<>();
+        List<String> warnViolations = new ArrayList<>();
 
         for (Commit commit : commits) {
-            collectViolations(commit, user.getUsername(), registeredEmails, violations);
+            String sha = abbrev(commit.getSha());
+
+            if (config.getCommitter() != CommitConfig.IdentityVerificationMode.OFF && commit.getCommitter() != null) {
+                String email = commit.getCommitter().getEmail();
+                if (email != null && !registeredEmails.contains(email)) {
+                    String msg = sym(CROSS_MARK) + "  Unrecognised committer email: <" + email + "> (commit " + sha
+                            + ") — not in proxy user registry";
+                    if (config.getCommitter() == CommitConfig.IdentityVerificationMode.STRICT) {
+                        blockingViolations.add(msg);
+                    } else {
+                        warnViolations.add(msg);
+                    }
+                }
+            }
+
+            if (config.getAuthor() != CommitConfig.IdentityVerificationMode.OFF && commit.getAuthor() != null) {
+                String email = commit.getAuthor().getEmail();
+                if (email != null && !registeredEmails.contains(email)) {
+                    String msg = sym(CROSS_MARK) + "  Unrecognised author email: <" + email + "> (commit " + sha
+                            + ") — not in proxy user registry";
+                    if (config.getAuthor() == CommitConfig.IdentityVerificationMode.STRICT) {
+                        blockingViolations.add(msg);
+                    } else {
+                        warnViolations.add(msg);
+                    }
+                }
+            }
         }
 
-        if (violations.isEmpty()) {
+        if (blockingViolations.isEmpty() && warnViolations.isEmpty()) {
             log.debug("Identity verification passed for push user '{}'", user.getUsername());
             return;
         }
 
-        if (mode == CommitConfig.IdentityVerificationMode.STRICT) {
+        if (!blockingViolations.isEmpty()) {
+            List<String> allViolations = new ArrayList<>(blockingViolations);
+            allViolations.addAll(warnViolations);
             log.warn(
-                    "Identity verification failed for push user '{}': {} mismatch(es)",
+                    "Identity verification failed for push user '{}': {} violation(s)",
                     user.getUsername(),
-                    violations.size());
+                    allViolations.size());
             String detail = GitClientUtils.format(
                     sym(NO_ENTRY) + "  Push Blocked — Commit Identity Mismatch",
-                    String.join("\n", violations),
+                    String.join("\n", allViolations),
                     RED,
                     null);
             recordIssue(request, "Commit identity does not match push user " + user.getUsername(), detail);
         } else {
-            // WARN mode — push proceeds but record violation count for the dashboard amber badge
             log.warn(
-                    "Identity verification warnings for push user '{}': {} mismatch(es): {}",
+                    "Identity verification warnings for push user '{}': {} mismatch(es)",
                     user.getUsername(),
-                    violations.size(),
-                    violations);
+                    warnViolations.size());
             recordStep(
                     request,
                     StepStatus.PASS,
                     null,
-                    violations.size() + " unrecognised commit email(s) — not in proxy user registry");
-        }
-    }
-
-    private static void collectViolations(
-            Commit commit, String pushUsername, List<String> registeredEmails, List<String> violations) {
-        String sha = abbrev(commit.getSha());
-
-        if (commit.getAuthor() != null) {
-            String email = commit.getAuthor().getEmail();
-            if (email != null && !registeredEmails.contains(email)) {
-                violations.add(sym(CROSS_MARK) + "  Unrecognised commit email: <" + email + "> (commit " + sha
-                        + ", author) — not in proxy user registry");
-            }
-        }
-
-        if (commit.getCommitter() != null) {
-            String email = commit.getCommitter().getEmail();
-            if (email != null && !registeredEmails.contains(email)) {
-                boolean sameAsAuthor = commit.getAuthor() != null
-                        && email.equals(commit.getAuthor().getEmail());
-                if (!sameAsAuthor) {
-                    violations.add(sym(CROSS_MARK) + "  Unrecognised commit email: <" + email + "> (commit " + sha
-                            + ", committer) — not in proxy user registry");
-                }
-            }
+                    warnViolations.size() + " unrecognised commit email(s) — not in proxy user registry");
         }
     }
 

--- a/fogwall-core/src/test/java/com/rbc/fogwall/git/IdentityVerificationHookTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/git/IdentityVerificationHookTest.java
@@ -57,8 +57,31 @@ class IdentityVerificationHookTest {
     }
 
     private IdentityVerificationHook hook(
-            CommitConfig.IdentityVerificationMode mode, ValidationContext vc, PushContext pc) {
-        return new IdentityVerificationHook(resolver, mode, vc, pc, GITHUB);
+            CommitConfig.IdentityVerificationConfig config, ValidationContext vc, PushContext pc) {
+        return new IdentityVerificationHook(resolver, config, vc, pc, GITHUB);
+    }
+
+    private static CommitConfig.IdentityVerificationConfig committerOnly(
+            CommitConfig.IdentityVerificationMode committerMode) {
+        return CommitConfig.IdentityVerificationConfig.builder()
+                .committer(committerMode)
+                .author(CommitConfig.IdentityVerificationMode.OFF)
+                .build();
+    }
+
+    private static CommitConfig.IdentityVerificationConfig authorOnly(
+            CommitConfig.IdentityVerificationMode authorMode) {
+        return CommitConfig.IdentityVerificationConfig.builder()
+                .committer(CommitConfig.IdentityVerificationMode.OFF)
+                .author(authorMode)
+                .build();
+    }
+
+    private static CommitConfig.IdentityVerificationConfig bothOff() {
+        return CommitConfig.IdentityVerificationConfig.builder()
+                .committer(CommitConfig.IdentityVerificationMode.OFF)
+                .author(CommitConfig.IdentityVerificationMode.OFF)
+                .build();
     }
 
     private static UserEntry alice() {
@@ -80,7 +103,7 @@ class IdentityVerificationHookTest {
         PushContext pc = new PushContext();
         ValidationContext vc = new ValidationContext();
 
-        hook(CommitConfig.IdentityVerificationMode.OFF, vc, pc).onPreReceive(rp, List.of(cmd));
+        hook(bothOff(), vc, pc).onPreReceive(rp, List.of(cmd));
 
         assertFalse(vc.hasIssues());
         assertFalse(pc.getSteps().isEmpty());
@@ -99,7 +122,7 @@ class IdentityVerificationHookTest {
         PushContext pc = new PushContext();
         ValidationContext vc = new ValidationContext();
 
-        new IdentityVerificationHook(null, CommitConfig.IdentityVerificationMode.STRICT, vc, pc, GITHUB)
+        new IdentityVerificationHook(null, committerOnly(CommitConfig.IdentityVerificationMode.STRICT), vc, pc, GITHUB)
                 .onPreReceive(rp, List.of(cmd));
 
         assertFalse(vc.hasIssues());
@@ -118,7 +141,7 @@ class IdentityVerificationHookTest {
         PushContext pc = new PushContext();
         ValidationContext vc = new ValidationContext();
 
-        hook(CommitConfig.IdentityVerificationMode.WARN, vc, pc).onPreReceive(rp, List.of(cmd));
+        hook(committerOnly(CommitConfig.IdentityVerificationMode.WARN), vc, pc).onPreReceive(rp, List.of(cmd));
 
         assertFalse(vc.hasIssues());
         assertFalse(pc.getSteps().isEmpty());
@@ -141,17 +164,18 @@ class IdentityVerificationHookTest {
         pc.setPushUser("alice-git");
         ValidationContext vc = new ValidationContext();
 
-        hook(CommitConfig.IdentityVerificationMode.STRICT, vc, pc).onPreReceive(rp, List.of(cmd));
+        hook(committerOnly(CommitConfig.IdentityVerificationMode.STRICT), vc, pc)
+                .onPreReceive(rp, List.of(cmd));
 
         assertFalse(vc.hasIssues());
         assertFalse(pc.getSteps().isEmpty());
         assertEquals(StepStatus.PASS, pc.getSteps().get(0).getStatus());
     }
 
-    // ---- strict mode + email mismatch → validation issue (blocked) ----
+    // ---- committer strict + mismatch → blocked ----
 
     @Test
-    void strictMode_emailMismatch_addsIssue() throws Exception {
+    void committerStrict_mismatch_addsIssue() throws Exception {
         when(resolver.resolve(any(FogwallProvider.class), eq("alice-git"), isNull()))
                 .thenReturn(Optional.of(alice()));
 
@@ -163,17 +187,18 @@ class IdentityVerificationHookTest {
         pc.setPushUser("alice-git");
         ValidationContext vc = new ValidationContext();
 
-        hook(CommitConfig.IdentityVerificationMode.STRICT, vc, pc).onPreReceive(rp, List.of(cmd));
+        hook(committerOnly(CommitConfig.IdentityVerificationMode.STRICT), vc, pc)
+                .onPreReceive(rp, List.of(cmd));
 
         assertTrue(vc.hasIssues());
         assertEquals(IdentityVerificationHook.STEP_NAME, vc.getIssues().get(0).hookName());
         assertTrue(vc.getIssues().get(0).summary().contains("alice"));
     }
 
-    // ---- warn mode + email mismatch → no issue, push proceeds ----
+    // ---- committer warn + mismatch → no issue, push proceeds ----
 
     @Test
-    void warnMode_emailMismatch_noIssue_recordsPass() throws Exception {
+    void committerWarn_mismatch_noIssue_recordsPass() throws Exception {
         when(resolver.resolve(any(FogwallProvider.class), eq("alice-git"), isNull()))
                 .thenReturn(Optional.of(alice()));
 
@@ -185,7 +210,7 @@ class IdentityVerificationHookTest {
         pc.setPushUser("alice-git");
         ValidationContext vc = new ValidationContext();
 
-        hook(CommitConfig.IdentityVerificationMode.WARN, vc, pc).onPreReceive(rp, List.of(cmd));
+        hook(committerOnly(CommitConfig.IdentityVerificationMode.WARN), vc, pc).onPreReceive(rp, List.of(cmd));
 
         assertFalse(vc.hasIssues(), "WARN mode should not block the push");
         assertFalse(pc.getSteps().isEmpty());
@@ -208,39 +233,87 @@ class IdentityVerificationHookTest {
         pc.setPushUser("alice-git");
         ValidationContext vc = new ValidationContext();
 
-        hook(CommitConfig.IdentityVerificationMode.STRICT, vc, pc).onPreReceive(rp, List.of(cmd));
+        hook(committerOnly(CommitConfig.IdentityVerificationMode.STRICT), vc, pc)
+                .onPreReceive(rp, List.of(cmd));
 
         assertFalse(vc.hasIssues(), "DELETE commands should not trigger identity violation");
     }
 
-    // ---- author and committer same unregistered email → single combined violation ----
+    // ---- rebase scenario: committer matches, author is external → passes when author=off ----
 
     @Test
-    void strictMode_authorAndCommitterSameEmail_singleViolation() throws Exception {
+    void rebaseScenario_committerMatches_authorExternal_authorOff_passes() throws Exception {
         when(resolver.resolve(any(FogwallProvider.class), eq("alice-git"), isNull()))
-                .thenReturn(Optional.of(alice())); // alice only has alice@example.com
+                .thenReturn(Optional.of(alice()));
 
-        // Commit where author and committer are both "other@example.com" (unregistered, same address)
-        RevCommit c1 = createCommit("init", "other@example.com");
-        RevCommit c2 = createCommit("second", "other@example.com");
+        // createCommit sets author=committer; we need a commit where committer=alice but author=external.
+        // Use the lower-level JGit API to set them independently.
+        File f = new File(tempDir.toFile(), java.util.UUID.randomUUID() + ".txt");
+        java.nio.file.Files.writeString(f.toPath(), "content");
+        git.add().addFilepattern(".").call();
+        RevCommit base = git.commit()
+                .setAuthor(new PersonIdent("Dev", "alice@example.com"))
+                .setCommitter(new PersonIdent("Dev", "alice@example.com"))
+                .setMessage("base")
+                .call();
+        git.add().addFilepattern(".").call();
+        RevCommit rebased = git.commit()
+                .setAuthor(new PersonIdent("External", "external@other.org")) // preserved author
+                .setCommitter(new PersonIdent("Alice", "alice@example.com")) // rebaser is alice
+                .setMessage("rebased external commit")
+                .call();
+
         ReceivePack rp = new ReceivePack(repo);
-        ReceiveCommand cmd = new ReceiveCommand(c1.getId(), c2.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
+        ReceiveCommand cmd =
+                new ReceiveCommand(base.getId(), rebased.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
         PushContext pc = new PushContext();
         pc.setPushUser("alice-git");
         ValidationContext vc = new ValidationContext();
 
-        hook(CommitConfig.IdentityVerificationMode.STRICT, vc, pc).onPreReceive(rp, List.of(cmd));
+        hook(committerOnly(CommitConfig.IdentityVerificationMode.STRICT), vc, pc)
+                .onPreReceive(rp, List.of(cmd));
 
-        assertTrue(vc.hasIssues());
-        // Should produce exactly one violation per commit (author+committer collapsed), not two
-        String summary = vc.getIssues().get(0).summary();
-        assertTrue(summary.contains("alice"), "Violation should reference the push user");
+        assertFalse(vc.hasIssues(), "Rebase should not be blocked when author check is off");
+    }
+
+    // ---- author strict + external author → blocked ----
+
+    @Test
+    void authorStrict_externalAuthor_addsIssue() throws Exception {
+        when(resolver.resolve(any(FogwallProvider.class), eq("alice-git"), isNull()))
+                .thenReturn(Optional.of(alice()));
+
+        File f = new File(tempDir.toFile(), java.util.UUID.randomUUID() + ".txt");
+        java.nio.file.Files.writeString(f.toPath(), "content");
+        git.add().addFilepattern(".").call();
+        RevCommit base = git.commit()
+                .setAuthor(new PersonIdent("Dev", "alice@example.com"))
+                .setCommitter(new PersonIdent("Dev", "alice@example.com"))
+                .setMessage("base")
+                .call();
+        git.add().addFilepattern(".").call();
+        RevCommit rebased = git.commit()
+                .setAuthor(new PersonIdent("External", "external@other.org"))
+                .setCommitter(new PersonIdent("Alice", "alice@example.com"))
+                .setMessage("rebased external commit")
+                .call();
+
+        ReceivePack rp = new ReceivePack(repo);
+        ReceiveCommand cmd =
+                new ReceiveCommand(base.getId(), rebased.getId(), "refs/heads/main", ReceiveCommand.Type.UPDATE);
+        PushContext pc = new PushContext();
+        pc.setPushUser("alice-git");
+        ValidationContext vc = new ValidationContext();
+
+        hook(authorOnly(CommitConfig.IdentityVerificationMode.STRICT), vc, pc).onPreReceive(rp, List.of(cmd));
+
+        assertTrue(vc.hasIssues(), "Author strict should block external author email");
     }
 
     // ---- warn mode records step content with violation details ----
 
     @Test
-    void warnMode_emailMismatch_stepContentContainsViolations() throws Exception {
+    void committerWarn_mismatch_stepContentContainsViolations() throws Exception {
         when(resolver.resolve(any(FogwallProvider.class), eq("alice-git"), isNull()))
                 .thenReturn(Optional.of(alice()));
 
@@ -252,10 +325,9 @@ class IdentityVerificationHookTest {
         pc.setPushUser("alice-git");
         ValidationContext vc = new ValidationContext();
 
-        hook(CommitConfig.IdentityVerificationMode.WARN, vc, pc).onPreReceive(rp, List.of(cmd));
+        hook(committerOnly(CommitConfig.IdentityVerificationMode.WARN), vc, pc).onPreReceive(rp, List.of(cmd));
 
         assertFalse(vc.hasIssues());
-        // WARN mode records a PASS step with the violation in content (for the amber UI badge)
         var step = pc.getSteps().stream()
                 .filter(s -> "identityVerification".equals(s.getStepName()))
                 .findFirst();
@@ -264,7 +336,7 @@ class IdentityVerificationHookTest {
         assertTrue(step.get().getContent().contains("not in proxy user registry"));
     }
 
-    // ---- resolver returns empty → skip (CheckUserPushPermissionHook handles "not registered") ----
+    // ---- resolver returns empty → skip ----
 
     @Test
     void resolverEmpty_skipsCheck_noStep() throws Exception {
@@ -278,7 +350,8 @@ class IdentityVerificationHookTest {
         pc.setPushUser("unknown");
         ValidationContext vc = new ValidationContext();
 
-        hook(CommitConfig.IdentityVerificationMode.STRICT, vc, pc).onPreReceive(rp, List.of(cmd));
+        hook(committerOnly(CommitConfig.IdentityVerificationMode.STRICT), vc, pc)
+                .onPreReceive(rp, List.of(cmd));
 
         assertFalse(vc.hasIssues());
         assertTrue(pc.getSteps().isEmpty(), "No step should be recorded when user cannot be resolved");

--- a/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/IdentityVerificationFilterTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/IdentityVerificationFilterTest.java
@@ -149,7 +149,12 @@ class IdentityVerificationFilterTest {
                 .thenReturn(Optional.of(aliceEntry()));
         FakeResponse resp = new FakeResponse();
 
-        new IdentityVerificationFilter(resolver, CommitConfig.IdentityVerificationMode.OFF)
+        new IdentityVerificationFilter(
+                        resolver,
+                        CommitConfig.IdentityVerificationConfig.builder()
+                                .committer(CommitConfig.IdentityVerificationMode.OFF)
+                                .author(CommitConfig.IdentityVerificationMode.OFF)
+                                .build())
                 .doHttpFilter(mockRequest(details, basicAuth("alice-git", "token")), resp.mock);
 
         assertFalse(resp.committed.get());
@@ -164,7 +169,11 @@ class IdentityVerificationFilterTest {
         GitRequestDetails details = pushDetailsWithCommits(List.of(commitWith("abc1234", "other@example.com")));
         FakeResponse resp = new FakeResponse();
 
-        new IdentityVerificationFilter(null, CommitConfig.IdentityVerificationMode.STRICT)
+        new IdentityVerificationFilter(
+                        null,
+                        CommitConfig.IdentityVerificationConfig.builder()
+                                .committer(CommitConfig.IdentityVerificationMode.STRICT)
+                                .build())
                 .doHttpFilter(mockRequest(details, basicAuth("alice-git", "token")), resp.mock);
 
         assertFalse(resp.committed.get());
@@ -178,7 +187,11 @@ class IdentityVerificationFilterTest {
         GitRequestDetails details = pushDetailsWithCommits(List.of());
         FakeResponse resp = new FakeResponse();
 
-        new IdentityVerificationFilter(resolver, CommitConfig.IdentityVerificationMode.STRICT)
+        new IdentityVerificationFilter(
+                        resolver,
+                        CommitConfig.IdentityVerificationConfig.builder()
+                                .committer(CommitConfig.IdentityVerificationMode.STRICT)
+                                .build())
                 .doHttpFilter(mockRequest(details, basicAuth("alice-git", "token")), resp.mock);
 
         assertFalse(resp.committed.get());
@@ -194,7 +207,11 @@ class IdentityVerificationFilterTest {
                 .thenReturn(Optional.of(aliceEntry()));
         FakeResponse resp = new FakeResponse();
 
-        new IdentityVerificationFilter(resolver, CommitConfig.IdentityVerificationMode.STRICT)
+        new IdentityVerificationFilter(
+                        resolver,
+                        CommitConfig.IdentityVerificationConfig.builder()
+                                .committer(CommitConfig.IdentityVerificationMode.STRICT)
+                                .build())
                 .doHttpFilter(mockRequest(details, basicAuth("alice-git", "token")), resp.mock);
 
         assertFalse(resp.committed.get());
@@ -210,7 +227,11 @@ class IdentityVerificationFilterTest {
                 .thenReturn(Optional.of(aliceEntry()));
         FakeResponse resp = new FakeResponse();
 
-        new IdentityVerificationFilter(resolver, CommitConfig.IdentityVerificationMode.STRICT)
+        new IdentityVerificationFilter(
+                        resolver,
+                        CommitConfig.IdentityVerificationConfig.builder()
+                                .committer(CommitConfig.IdentityVerificationMode.STRICT)
+                                .build())
                 .doHttpFilter(mockRequest(details, basicAuth("alice-git", "token")), resp.mock);
 
         // recordIssue sets REJECTED but does not commit the response (ValidationSummaryFilter does that)
@@ -229,7 +250,11 @@ class IdentityVerificationFilterTest {
                 .thenReturn(Optional.of(aliceEntry()));
         FakeResponse resp = new FakeResponse();
 
-        new IdentityVerificationFilter(resolver, CommitConfig.IdentityVerificationMode.WARN)
+        new IdentityVerificationFilter(
+                        resolver,
+                        CommitConfig.IdentityVerificationConfig.builder()
+                                .committer(CommitConfig.IdentityVerificationMode.WARN)
+                                .build())
                 .doHttpFilter(mockRequest(details, basicAuth("alice-git", "token")), resp.mock);
 
         assertFalse(resp.committed.get());
@@ -251,17 +276,21 @@ class IdentityVerificationFilterTest {
                 .thenReturn(Optional.empty());
         FakeResponse resp = new FakeResponse();
 
-        new IdentityVerificationFilter(resolver, CommitConfig.IdentityVerificationMode.STRICT)
+        new IdentityVerificationFilter(
+                        resolver,
+                        CommitConfig.IdentityVerificationConfig.builder()
+                                .committer(CommitConfig.IdentityVerificationMode.STRICT)
+                                .build())
                 .doHttpFilter(mockRequest(details, basicAuth("unknown", "token")), resp.mock);
 
         assertFalse(resp.committed.get());
         assertEquals(GitRequestDetails.GitResult.PENDING, details.getResult());
     }
 
-    // ---- committer-only mismatch (different from author) is also flagged in strict mode ----
+    // ---- committer strict: committer mismatch blocks even when author matches ----
 
     @Test
-    void strictMode_committerMismatch_recordsIssue() throws Exception {
+    void committerStrict_committerMismatch_authorMatches_recordsIssue() throws Exception {
         Commit commit = Commit.builder()
                 .sha("abc1234")
                 .author(Contributor.builder()
@@ -278,7 +307,73 @@ class IdentityVerificationFilterTest {
                 .thenReturn(Optional.of(aliceEntry()));
         FakeResponse resp = new FakeResponse();
 
-        new IdentityVerificationFilter(resolver, CommitConfig.IdentityVerificationMode.STRICT)
+        new IdentityVerificationFilter(
+                        resolver,
+                        CommitConfig.IdentityVerificationConfig.builder()
+                                .committer(CommitConfig.IdentityVerificationMode.STRICT)
+                                .build())
+                .doHttpFilter(mockRequest(details, basicAuth("alice-git", "token")), resp.mock);
+
+        assertEquals(GitRequestDetails.GitResult.REJECTED, details.getResult());
+    }
+
+    // ---- rebase scenario: committer strict + author off → external author email does not block ----
+
+    @Test
+    void committerStrict_authorOff_rebaseScenario_passes() throws Exception {
+        Commit commit = Commit.builder()
+                .sha("abc1234")
+                .author(Contributor.builder()
+                        .name("External")
+                        .email("external@other.org")
+                        .build())
+                .committer(Contributor.builder()
+                        .name("Alice")
+                        .email("alice@example.com")
+                        .build())
+                .build();
+        GitRequestDetails details = pushDetailsWithCommits(List.of(commit));
+        when(resolver.resolve(any(FogwallProvider.class), eq("alice-git"), eq("token")))
+                .thenReturn(Optional.of(aliceEntry()));
+        FakeResponse resp = new FakeResponse();
+
+        new IdentityVerificationFilter(
+                        resolver,
+                        CommitConfig.IdentityVerificationConfig.builder()
+                                .committer(CommitConfig.IdentityVerificationMode.STRICT)
+                                .author(CommitConfig.IdentityVerificationMode.OFF)
+                                .build())
+                .doHttpFilter(mockRequest(details, basicAuth("alice-git", "token")), resp.mock);
+
+        assertEquals(GitRequestDetails.GitResult.PENDING, details.getResult());
+    }
+
+    // ---- author strict: external author blocks even when committer matches ----
+
+    @Test
+    void authorStrict_externalAuthor_recordsIssue() throws Exception {
+        Commit commit = Commit.builder()
+                .sha("abc1234")
+                .author(Contributor.builder()
+                        .name("External")
+                        .email("external@other.org")
+                        .build())
+                .committer(Contributor.builder()
+                        .name("Alice")
+                        .email("alice@example.com")
+                        .build())
+                .build();
+        GitRequestDetails details = pushDetailsWithCommits(List.of(commit));
+        when(resolver.resolve(any(FogwallProvider.class), eq("alice-git"), eq("token")))
+                .thenReturn(Optional.of(aliceEntry()));
+        FakeResponse resp = new FakeResponse();
+
+        new IdentityVerificationFilter(
+                        resolver,
+                        CommitConfig.IdentityVerificationConfig.builder()
+                                .committer(CommitConfig.IdentityVerificationMode.OFF)
+                                .author(CommitConfig.IdentityVerificationMode.STRICT)
+                                .build())
                 .doHttpFilter(mockRequest(details, basicAuth("alice-git", "token")), resp.mock);
 
         assertEquals(GitRequestDetails.GitResult.REJECTED, details.getResult());

--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/config/CommitSettings.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/config/CommitSettings.java
@@ -14,11 +14,16 @@ import lombok.Data;
 @Data
 public class CommitSettings {
 
-    /**
-     * Controls whether SCM usernames & author/committer emails are verified against an authenticated user. Options:
-     * {@code warn} (default), {@code strict}, {@code off}.
-     */
-    private String identityVerification = "warn";
+    /** Per-check identity verification modes. */
+    private IdentityVerificationSettings identityVerification = new IdentityVerificationSettings();
+
+    @Data
+    public static class IdentityVerificationSettings {
+        /** Mode for committer email check: {@code warn} (default), {@code strict}, {@code off}. */
+        private String committer = "warn";
+        /** Mode for author email check: {@code warn}, {@code strict}, {@code off} (default). */
+        private String author = "off";
+    }
 
     private AuthorSettings author = new AuthorSettings();
     private CommitterSettings committer = new CommitterSettings();

--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/config/JettyConfigurationBuilder.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/config/JettyConfigurationBuilder.java
@@ -263,11 +263,15 @@ public class JettyConfigurationBuilder {
                 .block(buildBlockConfig(cs.getMessage().getBlock()))
                 .build();
 
-        CommitConfig.IdentityVerificationMode identityVerificationMode =
-                CommitConfig.IdentityVerificationMode.fromString(cs.getIdentityVerification());
+        CommitSettings.IdentityVerificationSettings ivs = cs.getIdentityVerification();
+        CommitConfig.IdentityVerificationConfig identityVerificationConfig =
+                CommitConfig.IdentityVerificationConfig.builder()
+                        .committer(CommitConfig.IdentityVerificationMode.fromString(ivs.getCommitter()))
+                        .author(CommitConfig.IdentityVerificationMode.fromString(ivs.getAuthor()))
+                        .build();
 
         CommitConfig commitConfig = CommitConfig.builder()
-                .identityVerification(identityVerificationMode)
+                .identityVerification(identityVerificationConfig)
                 .author(authorConfig)
                 .committer(committerConfig)
                 .message(messageConfig)

--- a/fogwall-server/src/main/resources/fogwall.yml
+++ b/fogwall-server/src/main/resources/fogwall.yml
@@ -114,15 +114,21 @@ commit:
       patterns: []
 #        - '(?i)(password|secret|token)\s*[=:]\s*\S+'
 
-  # Resolves the pusher's real SCM identity by calling the upstream provider's user API with the
-  # supplied token, then cross-checks the returned username and all commit author/committer emails
-  # against the authenticated fogwall user's scm-identities and emails.
-  #   warn   — allow the push but emit a sideband warning (default; safe starting point)
-  #   strict — block the push if identity cannot be verified (use this in production)
-  #   off    — disable the check entirely
+  # Independent identity checks for committer and author emails. Each can be set to:
+  #   strict — block the push on mismatch
+  #   warn   — allow the push but emit a sideband warning
+  #   off    — skip this check entirely
+  #
+  # committer: who last touched the commit object (or the rebaser/amender).
+  #            Primary mechanism for linking commit data back to a fogwall identity. Default: warn.
+  # author:    who originally wrote the commit (preserved across rebase/cherry-pick).
+  #            Should not gate push access in most workflows. Default: off.
+  #
   # NOTE: 'warn' is not a security control — pushes succeed regardless of outcome.
   # See docs/CONFIGURATION.md#identity-verification for token scope requirements and rollout guidance.
-  # identity-verification: warn
+  # identity-verification:
+  #   committer: warn
+  #   author: off
 
 # Push-level diff content scanning. Runs once per push against the aggregate diff (all commits combined).
 # Blocks pushes that introduce lines matching any configured literal or regex pattern.

--- a/fogwall-server/src/test/java/com/rbc/fogwall/e2e/IdentityResolutionE2ETest.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/e2e/IdentityResolutionE2ETest.java
@@ -195,7 +195,9 @@ class IdentityResolutionE2ETest {
                 UiApprovalGateway::new,
                 strictResolver,
                 new RepoPermissionService(strictPermissionStore),
-                CommitConfig.IdentityVerificationMode.STRICT)) {
+                CommitConfig.IdentityVerificationConfig.builder()
+                        .committer(CommitConfig.IdentityVerificationMode.STRICT)
+                        .build())) {
 
             strictPermissionStore.save(RepoPermission.builder()
                     .username(GiteaContainer.TEST_USER)

--- a/fogwall-server/src/test/java/com/rbc/fogwall/e2e/JettyProxyFixture.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/e2e/JettyProxyFixture.java
@@ -77,8 +77,8 @@ class JettyProxyFixture implements AutoCloseable {
      * Create a fixture with optional identity and permission filters enabled on the transparent proxy path. When
      * {@code identityResolver} is non-null, {@link CheckUserPushPermissionFilter} and
      * {@link IdentityVerificationFilter} are added to the filter chain (matching production order). The
-     * {@code permissionService} must also be non-null when identity checking is enabled. Uses
-     * {@link CommitConfig.IdentityVerificationMode#WARN} by default.
+     * {@code permissionService} must also be non-null when identity checking is enabled. Defaults to committer=warn,
+     * author=off.
      */
     JettyProxyFixture(
             URI giteaUri,
@@ -91,7 +91,7 @@ class JettyProxyFixture implements AutoCloseable {
                 proxyGatewayFactory,
                 identityResolver,
                 permissionService,
-                CommitConfig.IdentityVerificationMode.WARN);
+                CommitConfig.IdentityVerificationConfig.builder().build());
     }
 
     /**
@@ -99,18 +99,26 @@ class JettyProxyFixture implements AutoCloseable {
      * path. Uses auto-approve for the approval gateway so that allowed pushes go through without a review step.
      */
     JettyProxyFixture(URI giteaUri, List<AccessRule> configRules) throws Exception {
-        this(giteaUri, AutoApprovalGateway::new, null, null, CommitConfig.IdentityVerificationMode.WARN, configRules);
+        this(
+                giteaUri,
+                AutoApprovalGateway::new,
+                null,
+                null,
+                CommitConfig.IdentityVerificationConfig.builder().build(),
+                configRules);
     }
 
-    /** Create a fixture with identity and permission filters enabled, using an explicit identity verification mode. */
+    /**
+     * Create a fixture with identity and permission filters enabled, using an explicit identity verification config.
+     */
     JettyProxyFixture(
             URI giteaUri,
             Function<PushStore, ApprovalGateway> proxyGatewayFactory,
             PushIdentityResolver identityResolver,
             RepoPermissionService permissionService,
-            CommitConfig.IdentityVerificationMode identityVerificationMode)
+            CommitConfig.IdentityVerificationConfig identityVerificationConfig)
             throws Exception {
-        this(giteaUri, proxyGatewayFactory, identityResolver, permissionService, identityVerificationMode, List.of());
+        this(giteaUri, proxyGatewayFactory, identityResolver, permissionService, identityVerificationConfig, List.of());
     }
 
     /** Full constructor — all options. */
@@ -119,7 +127,7 @@ class JettyProxyFixture implements AutoCloseable {
             Function<PushStore, ApprovalGateway> proxyGatewayFactory,
             PushIdentityResolver identityResolver,
             RepoPermissionService permissionService,
-            CommitConfig.IdentityVerificationMode identityVerificationMode,
+            CommitConfig.IdentityVerificationConfig identityVerificationConfig,
             List<AccessRule> configRules)
             throws Exception {
         server = new Server();
@@ -218,7 +226,7 @@ class JettyProxyFixture implements AutoCloseable {
         filters.add(new UrlRuleAggregateFilter(100, provider, PROXY_PREFIX, urlRuleRegistry));
         if (identityResolver != null && permissionService != null) {
             filters.add(new CheckUserPushPermissionFilter(identityResolver, permissionService));
-            filters.add(new IdentityVerificationFilter(identityResolver, identityVerificationMode));
+            filters.add(new IdentityVerificationFilter(identityResolver, identityVerificationConfig));
         }
         filters.add(new CheckEmptyBranchFilter());
         filters.add(new CheckHiddenCommitsFilter(provider));

--- a/perf/fogwall-perf.yml
+++ b/perf/fogwall-perf.yml
@@ -29,7 +29,9 @@ commit:
     email:
       domain:
         allow: ".*"
-  identity-verification: OFF
+  identity-verification:
+    committer: off
+    author: off
 
 rules:
   allow:


### PR DESCRIPTION
## Summary

- `identity-verification: strict` was checking author email, which breaks rebase workflows — rebasing preserves the original author but updates the committer, so pushing rebased external commits (dependabot, OSS contributors) would block even when the committer email matched.
- Config is now an object with two independent keys, each accepting `strict | warn | off`:

\`\`\`yaml
identity-verification:
  committer: warn   # who last touched the commit (or the rebaser/amender)
  author: off       # attribution metadata — should not gate push access
\`\`\`

- Committer defaults to `warn`; author defaults to `off` so rebase workflows are not blocked by default.
- **Breaking change:** the previous single-value form (`identity-verification: warn`) is no longer accepted.

closes #348

## Test plan

- [ ] Rebase scenario test (hook path): committer matches, author is external, `author: off` → passes
- [ ] Rebase scenario test (filter path): same scenario
- [ ] Author strict test: external author email blocks when `author: strict`
- [ ] All existing mode tests updated to new config shape
- [ ] Server module compiles cleanly with new `CommitSettings` and `JettyConfigurationBuilder` mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)