### PR TITLE
ci: run all required checks and Docker build on release/* branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release/*"]
   pull_request:
     branches: ["main"]
 
@@ -189,7 +189,8 @@ jobs:
     if: >
       github.ref == 'refs/heads/main' ||
       github.ref == 'refs/heads/jetty' ||
-      github.event_name == 'pull_request'
+      github.event_name == 'pull_request' ||
+      startsWith(github.ref, 'refs/heads/release/')
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ permissions: read-all
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release/*"]
   pull_request:
     branches: ["main"]
   schedule:

--- a/.github/workflows/cve.yml
+++ b/.github/workflows/cve.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release/*"]
   pull_request:
     branches: ["main"]
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker Build & Publish
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release/*"]
     tags: ["v*"]
   pull_request:
     branches: ["main"]
@@ -60,7 +60,7 @@ jobs:
           tags: |
             type=ref,event=pr
             type=raw,value=edge,enable={{is_default_branch}}
-            type=sha,prefix=build-,format=short,enable={{is_default_branch}}
+            type=sha,prefix=build-,format=short,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') }}
             type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push


### PR DESCRIPTION
## Summary

- Adds `release/*` to push triggers for `ci.yml` (e2e-test job condition), `codeql.yml`, `cve.yml`, and `docker-publish.yml`
- Extends the `build-<sha>` image tag to fire on `release/*` pushes so the promote-not-rebuild flow works for hotfix/patch releases cut from release branches
- All seven Release gate required checks now run on release branch commits, unblocking tag creation without manual intervention

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm no change to main branch release flow (edge/build-sha/latest tags unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)