### PR TITLE
feat: add dark mode to dashboard UI (#46)

### DIFF
--- a/fogwall-dashboard/frontend/src/App.tsx
+++ b/fogwall-dashboard/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { fetchConfig, fetchMe } from './api'
 import { Nav } from './components/Nav'
+import { useDarkMode } from './hooks/useDarkMode'
 import { Admin } from './pages/Admin'
 import { Providers } from './pages/Providers'
 import { PushDetail } from './pages/PushDetail'
@@ -14,6 +15,7 @@ import { UserDetail } from './pages/UserDetail'
 import type { CurrentUser } from './types'
 
 export default function App() {
+  const { dark, toggle: toggleDark } = useDarkMode()
   const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null)
   const [authProvider, setAuthProvider] = useState<string>('local')
   const [bulkReview, setBulkReview] = useState<boolean>(false)
@@ -30,16 +32,19 @@ export default function App() {
 
   return (
     <BrowserRouter basename="/dashboard">
-      <div className="bg-gray-100 min-h-screen flex flex-col">
-        <Nav currentUser={currentUser} />
+      <div className="bg-gray-100 dark:bg-slate-900 min-h-screen flex flex-col" data-hmr-test="1">
+        <Nav currentUser={currentUser} dark={dark} toggleDark={toggleDark} />
         <main className="flex-1">
           <Routes>
             <Route
               path="/"
               element={<PushList currentUser={currentUser} bulkReviewEnabled={bulkReview} />}
             />
-            <Route path="/push/:id" element={<PushDetail currentUser={currentUser} />} />
-            <Route path="/push/:id/diff" element={<PushDiff />} />
+            <Route
+              path="/push/:id"
+              element={<PushDetail currentUser={currentUser} dark={dark} />}
+            />
+            <Route path="/push/:id/diff" element={<PushDiff dark={dark} />} />
             <Route path="/providers" element={<Providers />} />
             <Route path="/repos" element={<Repos />} />
             <Route path="/profile" element={<Profile />} />
@@ -51,7 +56,7 @@ export default function App() {
             <Route path="/admin" element={<Admin />} />
           </Routes>
         </main>
-        <footer className="bg-slate-800 text-slate-500 text-xs px-6 py-3 flex items-center justify-between">
+        <footer className="bg-slate-800 dark:bg-slate-950 text-slate-500 text-xs px-6 py-3 flex items-center justify-between">
           <span>
             &copy; 2024&ndash;{new Date().getFullYear()} fogwall contributors &middot;{' '}
             <a

--- a/fogwall-dashboard/frontend/src/components/Nav.tsx
+++ b/fogwall-dashboard/frontend/src/components/Nav.tsx
@@ -3,6 +3,8 @@ import type { CurrentUser } from '../types'
 
 interface NavProps {
   currentUser: CurrentUser | null
+  dark: boolean
+  toggleDark: () => void
 }
 
 function getCsrfToken(): string | null {
@@ -20,7 +22,7 @@ async function logout() {
   window.location.href = '/login.html?logout'
 }
 
-export function Nav({ currentUser }: NavProps) {
+export function Nav({ currentUser, dark, toggleDark }: NavProps) {
   return (
     <header className="bg-slate-800 text-white px-6 py-4 flex items-center gap-4 shadow">
       <NavLink
@@ -136,6 +138,26 @@ export function Nav({ currentUser }: NavProps) {
       </nav>
 
       <div className="ml-auto flex items-center gap-3 text-sm text-slate-300">
+        <button
+          onClick={toggleDark}
+          className="text-slate-400 hover:text-white transition-colors"
+          title={dark ? 'Switch to light mode' : 'Switch to dark mode'}
+          aria-label={dark ? 'Switch to light mode' : 'Switch to dark mode'}
+        >
+          {dark ? (
+            <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fillRule="evenodd"
+                d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
+                clipRule="evenodd"
+              />
+            </svg>
+          ) : (
+            <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+            </svg>
+          )}
+        </button>
         <a
           href="https://github.com/RBC/fogwall/blob/main/docs/CONFIGURATION.md"
           target="_blank"

--- a/fogwall-dashboard/frontend/src/components/PermissionBadges.tsx
+++ b/fogwall-dashboard/frontend/src/components/PermissionBadges.tsx
@@ -2,9 +2,9 @@ import type { RepoPermission } from '../types'
 
 export function PathTypeBadge({ matchType }: { matchType: RepoPermission['matchType'] }) {
   const styles = {
-    LITERAL: 'bg-gray-100 text-gray-600',
-    GLOB: 'bg-purple-50 text-purple-700',
-    REGEX: 'bg-orange-50 text-orange-700',
+    LITERAL: 'bg-gray-100 text-gray-600 dark:bg-slate-700 dark:text-gray-300',
+    GLOB: 'bg-purple-50 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300',
+    REGEX: 'bg-orange-50 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300',
   }
   return (
     <span
@@ -17,10 +17,10 @@ export function PathTypeBadge({ matchType }: { matchType: RepoPermission['matchT
 
 export function OperationsBadge({ operations }: { operations: RepoPermission['grant'] }) {
   const styles: Record<RepoPermission['grant'], string> = {
-    PUSH: 'bg-blue-50 text-blue-700',
-    REVIEW: 'bg-green-50 text-green-700',
-    PUSH_AND_REVIEW: 'bg-teal-50 text-teal-700',
-    SELF_CERTIFY: 'bg-yellow-50 text-yellow-700',
+    PUSH: 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
+    REVIEW: 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-300',
+    PUSH_AND_REVIEW: 'bg-teal-50 text-teal-700 dark:bg-teal-900/30 dark:text-teal-300',
+    SELF_CERTIFY: 'bg-yellow-50 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300',
   }
   return (
     <span

--- a/fogwall-dashboard/frontend/src/components/StatusBadge.tsx
+++ b/fogwall-dashboard/frontend/src/components/StatusBadge.tsx
@@ -1,13 +1,20 @@
 import type { PushStatus } from '../types'
 
 const STATUS_CLASSES: Record<string, string> = {
-  PENDING: 'bg-amber-100 text-amber-800 border border-amber-300',
-  APPROVED: 'bg-green-100 text-green-800 border border-green-300',
-  FORWARDED: 'bg-blue-100 text-blue-800 border border-blue-300',
-  REJECTED: 'bg-red-100 text-red-800 border border-red-300',
-  CANCELED: 'bg-gray-100 text-gray-600 border border-gray-300',
-  RECEIVED: 'bg-slate-100 text-slate-600 border border-slate-300',
-  ERROR: 'bg-red-200 text-red-900 border border-red-400',
+  PENDING:
+    'bg-amber-100 text-amber-800 border border-amber-300 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700',
+  APPROVED:
+    'bg-green-100 text-green-800 border border-green-300 dark:bg-green-900/30 dark:text-green-300 dark:border-green-700',
+  FORWARDED:
+    'bg-blue-100 text-blue-800 border border-blue-300 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-700',
+  REJECTED:
+    'bg-red-100 text-red-800 border border-red-300 dark:bg-red-900/30 dark:text-red-300 dark:border-red-700',
+  CANCELED:
+    'bg-gray-100 text-gray-600 border border-gray-300 dark:bg-slate-700 dark:text-gray-300 dark:border-slate-600',
+  RECEIVED:
+    'bg-slate-100 text-slate-600 border border-slate-300 dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600',
+  ERROR:
+    'bg-red-200 text-red-900 border border-red-400 dark:bg-red-900/50 dark:text-red-200 dark:border-red-700',
 }
 
 interface StatusBadgeProps {
@@ -16,7 +23,8 @@ interface StatusBadgeProps {
 }
 
 export function StatusBadge({ status, className = '' }: StatusBadgeProps) {
-  const cls = STATUS_CLASSES[status] ?? 'bg-gray-100 text-gray-600'
+  const cls =
+    STATUS_CLASSES[status] ?? 'bg-gray-100 text-gray-600 dark:bg-slate-700 dark:text-gray-300'
   return (
     <span
       className={`text-xs font-semibold px-2 py-0.5 rounded-full whitespace-nowrap shrink-0 ${cls} ${className}`}

--- a/fogwall-dashboard/frontend/src/hooks/useDarkMode.ts
+++ b/fogwall-dashboard/frontend/src/hooks/useDarkMode.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'fogwall-dark-mode'
+
+export function useDarkMode() {
+  const [dark, setDark] = useState<boolean>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored !== null) return stored === 'true'
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  })
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (dark) {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+    localStorage.setItem(STORAGE_KEY, String(dark))
+  }, [dark])
+
+  return { dark, toggle: () => setDark((v) => !v) }
+}

--- a/fogwall-dashboard/frontend/src/index.css
+++ b/fogwall-dashboard/frontend/src/index.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@variant dark (&:where(.dark, .dark *));
 
 html {
   font-size: 18px;

--- a/fogwall-dashboard/frontend/src/pages/Admin.tsx
+++ b/fogwall-dashboard/frontend/src/pages/Admin.tsx
@@ -22,7 +22,9 @@ function TcpBadge({ tcp }: { tcp: TcpResult }) {
   return (
     <span
       className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${
-        ok ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+        ok
+          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+          : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
       }`}
     >
       {ok ? '✓' : '✗'} TCP {ok ? ms(tcp.durationMs) : (tcp.error ?? 'ERROR')}
@@ -36,7 +38,9 @@ function TlsBadge({ tls }: { tls: TlsResult | null | undefined }) {
   return (
     <span
       className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${
-        ok ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+        ok
+          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+          : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
       }`}
     >
       {ok ? '✓' : '✗'} TLS {ok ? ms(tls.durationMs) : (tls.error ?? 'ERROR')}
@@ -52,7 +56,9 @@ function HttpBadge({ http }: { http: HttpResult | null | undefined }) {
   return (
     <span
       className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${
-        ok ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+        ok
+          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+          : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
       }`}
     >
       {ok ? '✓' : '✗'} {label}
@@ -66,7 +72,9 @@ function GitProbeBadge({ label, result }: { label: string; result: GitProbeResul
   return (
     <span
       className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${
-        ok ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+        ok
+          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+          : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
       }`}
     >
       {ok ? '✓' : '✗'} {label} {detail}
@@ -120,7 +128,7 @@ function ConnectivityRow({ result }: { name: string; result: ProviderConnectivit
   const tlsOk = result.tls == null || result.tls.status === 'ok'
 
   return (
-    <div className="border border-gray-200 rounded-lg p-4 space-y-2">
+    <div className="border border-gray-200 rounded-lg p-4 space-y-2 dark:border-slate-700">
       {/* Header row */}
       <div className="flex items-start justify-between gap-2">
         <div className="flex flex-wrap gap-1.5 shrink-0">
@@ -128,7 +136,9 @@ function ConnectivityRow({ result }: { name: string; result: ProviderConnectivit
           <TlsBadge tls={result.tls} />
           <HttpBadge http={result.http} />
         </div>
-        <span className="text-xs text-gray-400 font-mono text-right break-all">{result.uri}</span>
+        <span className="text-xs text-gray-400 font-mono text-right break-all dark:text-gray-500">
+          {result.uri}
+        </span>
       </div>
       {result.gitProbe && (
         <div className="flex flex-wrap gap-1.5">
@@ -139,26 +149,32 @@ function ConnectivityRow({ result }: { name: string; result: ProviderConnectivit
 
       {/* Error details */}
       {!tcpOk && (
-        <div className="text-xs font-mono bg-red-50 text-red-700 rounded px-2 py-1.5 space-y-0.5">
+        <div className="text-xs font-mono bg-red-50 text-red-700 rounded px-2 py-1.5 space-y-0.5 dark:bg-red-900/20 dark:text-red-300">
           <div>
             TCP {result.tcp.host}:{result.tcp.port} → <strong>{result.tcp.error}</strong> (
             {ms(result.tcp.durationMs)})
           </div>
-          {result.tcp.detail && <div className="text-red-500">{result.tcp.detail}</div>}
+          {result.tcp.detail && (
+            <div className="text-red-500 dark:text-red-400">{result.tcp.detail}</div>
+          )}
         </div>
       )}
       {tcpOk && !tlsOk && result.tls && (
-        <div className="text-xs font-mono bg-red-50 text-red-700 rounded px-2 py-1.5 space-y-0.5">
+        <div className="text-xs font-mono bg-red-50 text-red-700 rounded px-2 py-1.5 space-y-0.5 dark:bg-red-900/20 dark:text-red-300">
           <div>
             TLS → <strong>{result.tls.error}</strong> ({ms(result.tls.durationMs)})
           </div>
-          {result.tls.detail && <div className="text-red-500">{result.tls.detail}</div>}
+          {result.tls.detail && (
+            <div className="text-red-500 dark:text-red-400">{result.tls.detail}</div>
+          )}
         </div>
       )}
       {result.http && typeof result.http.status === 'string' && (
-        <div className="text-xs font-mono bg-red-50 text-red-700 rounded px-2 py-1.5">
+        <div className="text-xs font-mono bg-red-50 text-red-700 rounded px-2 py-1.5 dark:bg-red-900/20 dark:text-red-300">
           HTTP → ERROR ({ms(result.http.durationMs)})
-          {result.http.detail && <div className="text-red-500">{result.http.detail}</div>}
+          {result.http.detail && (
+            <div className="text-red-500 dark:text-red-400">{result.http.detail}</div>
+          )}
         </div>
       )}
       {result.gitProbe &&
@@ -170,37 +186,41 @@ function ConnectivityRow({ result }: { name: string; result: ProviderConnectivit
             return (
               <div
                 key={k}
-                className="text-xs font-mono bg-red-50 text-red-700 rounded px-2 py-1.5 space-y-0.5"
+                className="text-xs font-mono bg-red-50 text-red-700 rounded px-2 py-1.5 space-y-0.5 dark:bg-red-900/20 dark:text-red-300"
               >
                 <div>
                   Git {label} → <strong>{r.error}</strong> ({ms(r.durationMs)})
                 </div>
-                {r.detail && <div className="text-red-500">{r.detail}</div>}
-                {r.probeUrl && <div className="text-red-400 break-all">URL: {r.probeUrl}</div>}
+                {r.detail && <div className="text-red-500 dark:text-red-400">{r.detail}</div>}
+                {r.probeUrl && (
+                  <div className="text-red-400 break-all dark:text-red-500">URL: {r.probeUrl}</div>
+                )}
               </div>
             )
           })}
 
       {/* Success details */}
       {tcpOk && tlsOk && result.tls && result.tls.status === 'ok' && (
-        <div className="text-xs text-gray-400 font-mono">
+        <div className="text-xs text-gray-400 font-mono dark:text-gray-500">
           {result.tls.protocol} · {result.tls.cipher}
           {result.tls.peerCn && <span className="ml-2">· CN={result.tls.peerCn}</span>}
         </div>
       )}
       {result.http && typeof result.http.status === 'number' && result.http.location && (
-        <div className="text-xs text-gray-400 font-mono">→ {result.http.location}</div>
+        <div className="text-xs text-gray-400 font-mono dark:text-gray-500">
+          → {result.http.location}
+        </div>
       )}
       {result.gitProbe && (
         <>
           {result.gitProbe.uploadPack.status === 'ok' && result.gitProbe.uploadPack.contentType && (
-            <div className="text-xs text-gray-400 font-mono">
+            <div className="text-xs text-gray-400 font-mono dark:text-gray-500">
               fetch content-type: {result.gitProbe.uploadPack.contentType}
             </div>
           )}
           {result.gitProbe.receivePack.status === 'ok' &&
             result.gitProbe.receivePack.contentType && (
-              <div className="text-xs text-gray-400 font-mono">
+              <div className="text-xs text-gray-400 font-mono dark:text-gray-500">
                 push content-type: {result.gitProbe.receivePack.contentType}
               </div>
             )}
@@ -289,12 +309,14 @@ export function Admin() {
 
   return (
     <div className="max-w-2xl mx-auto px-6 py-8 space-y-6">
-      <h1 className="text-2xl font-semibold text-gray-800">Admin</h1>
+      <h1 className="text-2xl font-semibold text-gray-800 dark:text-gray-200">Admin</h1>
 
-      <section className="bg-white rounded-lg shadow p-6 space-y-4">
+      <section className="bg-white rounded-lg shadow p-6 space-y-4 dark:bg-slate-800">
         <div>
-          <h2 className="text-lg font-medium text-gray-700">Configuration Reload</h2>
-          <p className="text-sm text-gray-500 mt-1">
+          <h2 className="text-lg font-medium text-gray-700 dark:text-gray-300">
+            Configuration Reload
+          </h2>
+          <p className="text-sm text-gray-500 mt-1 dark:text-gray-400">
             Reloads config from the configured source (file or git) without restarting the server.
             Select a section to reload only that portion, or choose <em>All sections</em> to reload
             everything. Provider, server, and database changes still require a restart.
@@ -306,7 +328,7 @@ export function Admin() {
             value={reloadSection}
             onChange={(e) => setReloadSection(e.target.value)}
             disabled={reloadStatus === 'loading'}
-            className="px-3 py-2 border border-gray-300 rounded text-sm text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-slate-400 disabled:opacity-50"
+            className="px-3 py-2 border border-gray-300 rounded text-sm text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-slate-400 disabled:opacity-50 dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200"
           >
             <option value="all">All sections</option>
             <option value="commit">Commit rules</option>
@@ -327,7 +349,10 @@ export function Admin() {
           {reloadMessage && (
             <p
               className={
-                'text-sm ' + (reloadStatus === 'error' ? 'text-red-600' : 'text-green-700')
+                'text-sm ' +
+                (reloadStatus === 'error'
+                  ? 'text-red-600 dark:text-red-400'
+                  : 'text-green-700 dark:text-green-400')
               }
             >
               {reloadMessage}
@@ -336,10 +361,12 @@ export function Admin() {
         </div>
       </section>
 
-      <section className="bg-white rounded-lg shadow p-6 space-y-4">
+      <section className="bg-white rounded-lg shadow p-6 space-y-4 dark:bg-slate-800">
         <div>
-          <h2 className="text-lg font-medium text-gray-700">Provider Connectivity</h2>
-          <p className="text-sm text-gray-500 mt-1">
+          <h2 className="text-lg font-medium text-gray-700 dark:text-gray-300">
+            Provider Connectivity
+          </h2>
+          <p className="text-sm text-gray-500 mt-1 dark:text-gray-400">
             Tests outbound connectivity to each configured upstream provider: TCP handshake, TLS
             negotiation, and HTTP response. Error codes: REFUSED (RST received — port closed or
             firewall REJECT), TIMEOUT (no response — firewall DROP), RESET (connection torn down
@@ -357,13 +384,13 @@ export function Admin() {
             {connStatus === 'loading' ? 'Checking…' : 'Run connectivity check'}
           </button>
           {connCheckedAt && (
-            <span className="text-xs text-gray-400">
+            <span className="text-xs text-gray-400 dark:text-gray-500">
               checked at {new Date(connCheckedAt).toLocaleTimeString()}
             </span>
           )}
         </div>
 
-        {connError && <p className="text-sm text-red-600">{connError}</p>}
+        {connError && <p className="text-sm text-red-600 dark:text-red-400">{connError}</p>}
 
         {connResults && (
           <div className="space-y-2">
@@ -374,10 +401,12 @@ export function Admin() {
         )}
       </section>
 
-      <section className="bg-white rounded-lg shadow p-6 space-y-4">
+      <section className="bg-white rounded-lg shadow p-6 space-y-4 dark:bg-slate-800">
         <div>
-          <h2 className="text-lg font-medium text-gray-700">Targeted Git Probe</h2>
-          <p className="text-sm text-gray-500 mt-1">
+          <h2 className="text-lg font-medium text-gray-700 dark:text-gray-300">
+            Targeted Git Probe
+          </h2>
+          <p className="text-sm text-gray-500 mt-1 dark:text-gray-400">
             Runs the full connectivity check for a single provider, then sends{' '}
             <code className="font-mono">GET /info/refs?service=git-upload-pack</code> with{' '}
             <code className="font-mono">User-Agent: git/2.x.x</code> to a specific repo — the same
@@ -391,11 +420,13 @@ export function Admin() {
         <div className="space-y-3">
           <div className="flex flex-col gap-3">
             <div className="flex flex-col gap-1 sm:w-48">
-              <label className="text-xs font-medium text-gray-600">Provider</label>
+              <label className="text-xs font-medium text-gray-600 dark:text-gray-400">
+                Provider
+              </label>
               <select
                 value={selectedProvider}
                 onChange={(e) => setSelectedProvider(e.target.value)}
-                className="border border-gray-300 rounded px-3 py-2 text-sm text-gray-800 bg-white focus:outline-none focus:ring-2 focus:ring-slate-400"
+                className="border border-gray-300 rounded px-3 py-2 text-sm text-gray-800 bg-white focus:outline-none focus:ring-2 focus:ring-slate-400 dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200"
               >
                 {providerList.map((p) => (
                   <option key={p.name} value={p.name}>
@@ -405,14 +436,14 @@ export function Admin() {
               </select>
             </div>
             <div className="flex flex-col gap-1">
-              <label className="text-xs font-medium text-gray-600">
+              <label className="text-xs font-medium text-gray-600 dark:text-gray-400">
                 Repo path{' '}
-                <span className="font-normal text-gray-400">
+                <span className="font-normal text-gray-400 dark:text-gray-500">
                   (optional — skips git probe if blank)
                 </span>
               </label>
               <div className="flex items-stretch">
-                <span className="inline-flex items-center px-3 rounded-l border border-r-0 border-gray-300 bg-gray-50 text-gray-400 text-xs font-mono select-none">
+                <span className="inline-flex items-center px-3 rounded-l border border-r-0 border-gray-300 bg-gray-50 text-gray-400 text-xs font-mono select-none dark:bg-slate-700 dark:border-slate-600 dark:text-gray-500">
                   {providerList.find((p) => p.name === selectedProvider)?.uri ?? ''}
                 </span>
                 <input
@@ -420,7 +451,7 @@ export function Admin() {
                   placeholder="/owner/repo.git"
                   value={repoPath}
                   onChange={(e) => setRepoPath(e.target.value)}
-                  className="flex-1 border border-gray-300 rounded-r px-3 py-2 text-sm font-mono text-gray-800 focus:outline-none focus:ring-2 focus:ring-slate-400"
+                  className="flex-1 border border-gray-300 rounded-r px-3 py-2 text-sm font-mono text-gray-800 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200"
                 />
               </div>
             </div>
@@ -435,14 +466,14 @@ export function Admin() {
               {targetStatus === 'loading' ? 'Checking…' : 'Run targeted check'}
             </button>
             {targetCheckedAt && (
-              <span className="text-xs text-gray-400">
+              <span className="text-xs text-gray-400 dark:text-gray-500">
                 checked at {new Date(targetCheckedAt).toLocaleTimeString()}
               </span>
             )}
           </div>
         </div>
 
-        {targetError && <p className="text-sm text-red-600">{targetError}</p>}
+        {targetError && <p className="text-sm text-red-600 dark:text-red-400">{targetError}</p>}
 
         {targetResults && (
           <div className="space-y-2">

--- a/fogwall-dashboard/frontend/src/pages/Profile.tsx
+++ b/fogwall-dashboard/frontend/src/pages/Profile.tsx
@@ -17,7 +17,7 @@ function LockedBadge({ source }: { source: string }) {
       : `Managed by your ${source.toUpperCase()} identity provider and cannot be removed`
   return (
     <span
-      className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-600"
+      className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-600 dark:bg-blue-900/30 dark:text-blue-300"
       title={title}
     >
       locked ({source})
@@ -122,17 +122,26 @@ export function Profile() {
   }
 
   if (loading)
-    return <div className="max-w-2xl mx-auto px-4 py-16 text-center text-gray-400">Loading…</div>
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-16 text-center text-gray-400 dark:text-gray-500">
+        Loading…
+      </div>
+    )
   if (error)
-    return <div className="max-w-2xl mx-auto px-4 py-16 text-center text-red-500">{error}</div>
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-16 text-center text-red-500 dark:text-red-400">
+        {error}
+      </div>
+    )
   if (!profile) return null
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-6 space-y-6">
       <div>
-        <h2 className="text-lg font-semibold text-gray-800">Profile</h2>
-        <p className="text-sm text-gray-500 mt-1">
-          Signed in as <span className="font-medium text-gray-700">{profile.username}</span>
+        <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200">Profile</h2>
+        <p className="text-sm text-gray-500 mt-1 dark:text-gray-400">
+          Signed in as{' '}
+          <span className="font-medium text-gray-700 dark:text-gray-300">{profile.username}</span>
         </p>
         <div className="flex flex-wrap gap-1 mt-2">
           {profile.authorities
@@ -141,10 +150,10 @@ export function Profile() {
               const label = a.replace('ROLE_', '')
               const colour =
                 label === 'ADMIN'
-                  ? 'bg-purple-100 text-purple-700'
+                  ? 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300'
                   : label === 'SELF_CERTIFY'
-                    ? 'bg-amber-100 text-amber-700'
-                    : 'bg-gray-100 text-gray-600'
+                    ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300'
+                    : 'bg-gray-100 text-gray-600 dark:bg-slate-700 dark:text-gray-300'
               const isSelfCertify = label === 'SELF_CERTIFY'
               return (
                 <span key={a} className="relative group inline-flex">
@@ -167,7 +176,7 @@ export function Profile() {
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-1 border-b border-gray-200">
+      <div className="flex gap-1 border-b border-gray-200 dark:border-slate-700">
         {(['emails', 'identities', 'permissions'] as const).map((t) => (
           <button
             key={t}
@@ -175,8 +184,8 @@ export function Profile() {
             className={
               'px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ' +
               (tab === t
-                ? 'border-slate-700 text-slate-800'
-                : 'border-transparent text-gray-500 hover:text-gray-700')
+                ? 'border-slate-700 text-slate-800 dark:border-slate-400 dark:text-slate-200'
+                : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300')
             }
           >
             {t === 'emails'
@@ -191,28 +200,30 @@ export function Profile() {
       {/* Emails tab */}
       {tab === 'emails' && (
         <div className="space-y-4">
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-gray-500 dark:text-gray-400">
             Email addresses linked to your commits. The identity verification hook uses these to
             confirm your authorship on push.
           </p>
 
           {profile.emails.length === 0 ? (
-            <p className="text-sm text-gray-400 italic">No email addresses registered.</p>
+            <p className="text-sm text-gray-400 italic dark:text-gray-500">
+              No email addresses registered.
+            </p>
           ) : (
-            <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white">
+            <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white dark:bg-slate-800 dark:border-slate-700 dark:divide-gray-700">
               {profile.emails.map((entry) => (
                 <li
                   key={entry.email}
                   className="flex items-center justify-between px-4 py-3 text-sm"
                 >
                   <span className="flex items-center gap-2">
-                    <span className="text-gray-800">{entry.email}</span>
+                    <span className="text-gray-800 dark:text-gray-200">{entry.email}</span>
                     {entry.locked && <LockedBadge source={entry.source} />}
                   </span>
                   {!entry.locked && (
                     <button
                       onClick={() => handleRemoveEmail(entry)}
-                      className="text-gray-400 hover:text-red-500 transition-colors text-xs"
+                      className="text-gray-400 hover:text-red-500 transition-colors text-xs dark:text-gray-500 dark:hover:text-red-400"
                       title="Remove"
                     >
                       Remove
@@ -223,7 +234,7 @@ export function Profile() {
             </ul>
           )}
 
-          {emailError && <p className="text-sm text-red-600">{emailError}</p>}
+          {emailError && <p className="text-sm text-red-600 dark:text-red-400">{emailError}</p>}
 
           <form onSubmit={handleAddEmail} className="flex gap-2">
             <input
@@ -231,7 +242,7 @@ export function Profile() {
               value={newEmail}
               onChange={(e) => setNewEmail(e.target.value)}
               placeholder="you@example.com"
-              className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none"
+              className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200 dark:placeholder-gray-400"
             />
             <button
               type="submit"
@@ -247,18 +258,20 @@ export function Profile() {
       {/* Permissions tab */}
       {tab === 'permissions' && (
         <div className="space-y-4">
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-gray-500 dark:text-gray-400">
             Repository access permissions granted to your account.
           </p>
           {loading ? (
-            <p className="text-sm text-gray-400">Loading…</p>
+            <p className="text-sm text-gray-400 dark:text-gray-500">Loading…</p>
           ) : permissions.length === 0 ? (
-            <p className="text-sm text-gray-400 italic">No permissions configured.</p>
+            <p className="text-sm text-gray-400 italic dark:text-gray-500">
+              No permissions configured.
+            </p>
           ) : (
-            <div className="rounded-lg border border-gray-200 bg-white overflow-hidden">
+            <div className="rounded-lg border border-gray-200 bg-white overflow-hidden dark:bg-slate-800 dark:border-slate-700">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="border-b border-gray-100 bg-gray-50 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  <tr className="border-b border-gray-100 bg-gray-50 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide dark:bg-slate-700/50 dark:border-slate-700 dark:text-gray-400">
                     <th className="px-4 py-3">Provider</th>
                     <th className="px-4 py-3">Type</th>
                     <th className="px-4 py-3">Path</th>
@@ -266,18 +279,23 @@ export function Profile() {
                     <th className="px-4 py-3">Source</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-100">
+                <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
                   {permissions.map((p) => (
-                    <tr key={p.id} className="hover:bg-gray-50 transition-colors">
+                    <tr
+                      key={p.id}
+                      className="hover:bg-gray-50 transition-colors dark:hover:bg-gray-700/50"
+                    >
                       <td className="px-4 py-3">
-                        <span className="rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+                        <span className="rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-700 dark:text-slate-300">
                           {p.provider}
                         </span>
                       </td>
                       <td className="px-4 py-3">
                         <PathTypeBadge matchType={p.matchType} />
                       </td>
-                      <td className="px-4 py-3 font-mono text-gray-700 text-xs">{p.value}</td>
+                      <td className="px-4 py-3 font-mono text-gray-700 text-xs dark:text-gray-300">
+                        {p.value}
+                      </td>
                       <td className="px-4 py-3">
                         <OperationsBadge operations={p.grant} />
                       </td>
@@ -285,7 +303,7 @@ export function Profile() {
                         {p.source === 'CONFIG' ? (
                           <LockedBadge source="config" />
                         ) : (
-                          <span className="text-xs text-gray-400">local</span>
+                          <span className="text-xs text-gray-400 dark:text-gray-500">local</span>
                         )}
                       </td>
                     </tr>
@@ -300,31 +318,33 @@ export function Profile() {
       {/* SCM Identities tab */}
       {tab === 'identities' && (
         <div className="space-y-4">
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-gray-500 dark:text-gray-400">
             Your usernames on upstream SCM providers. Used to verify that your SCM login matches the
             account pushing code through the proxy.
           </p>
 
           {profile.scmIdentities.length === 0 ? (
-            <p className="text-sm text-gray-400 italic">No SCM identities registered.</p>
+            <p className="text-sm text-gray-400 italic dark:text-gray-500">
+              No SCM identities registered.
+            </p>
           ) : (
-            <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white">
+            <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white dark:bg-slate-800 dark:border-slate-700 dark:divide-gray-700">
               {profile.scmIdentities.map((id) => (
                 <li
                   key={`${id.provider}/${id.username}`}
                   className="flex items-center justify-between px-4 py-3 text-sm"
                 >
                   <span className="flex items-center gap-2">
-                    <span className="rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+                    <span className="rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-700 dark:text-slate-300">
                       {id.provider}
                     </span>
-                    <span className="text-gray-800">{id.username}</span>
+                    <span className="text-gray-800 dark:text-gray-200">{id.username}</span>
                     {id.source === 'config' && <LockedBadge source="config" />}
                   </span>
                   {id.source !== 'config' && (
                     <button
                       onClick={() => handleRemoveIdentity(id)}
-                      className="text-gray-400 hover:text-red-500 transition-colors text-xs"
+                      className="text-gray-400 hover:text-red-500 transition-colors text-xs dark:text-gray-500 dark:hover:text-red-400"
                       title="Remove"
                     >
                       Remove
@@ -335,13 +355,15 @@ export function Profile() {
             </ul>
           )}
 
-          {identityError && <p className="text-sm text-red-600">{identityError}</p>}
+          {identityError && (
+            <p className="text-sm text-red-600 dark:text-red-400">{identityError}</p>
+          )}
 
           <form onSubmit={handleAddIdentity} className="flex gap-2">
             <select
               value={newProvider}
               onChange={(e) => setNewProvider(e.target.value)}
-              className="rounded border border-gray-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none"
+              className="rounded border border-gray-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200"
               disabled={providers.length === 0}
             >
               {providers.map((p) => (
@@ -355,7 +377,7 @@ export function Profile() {
               value={newScmUsername}
               onChange={(e) => setNewScmUsername(e.target.value)}
               placeholder="your-username"
-              className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none"
+              className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200 dark:placeholder-gray-400"
             />
             <button
               type="submit"

--- a/fogwall-dashboard/frontend/src/pages/Providers.tsx
+++ b/fogwall-dashboard/frontend/src/pages/Providers.tsx
@@ -15,16 +15,23 @@ export function Providers() {
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-6 space-y-4">
-      <h2 className="text-lg font-semibold text-gray-800">Active Providers</h2>
+      <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200">Active Providers</h2>
 
-      {loading && <div className="text-center text-gray-400 py-16">Loading…</div>}
+      {loading && (
+        <div className="text-center text-gray-400 dark:text-gray-500 py-16">Loading…</div>
+      )}
 
       {!loading && providers.length === 0 && (
-        <div className="text-center text-gray-400 py-16">No providers configured.</div>
+        <div className="text-center text-gray-400 dark:text-gray-500 py-16">
+          No providers configured.
+        </div>
       )}
 
       {providers.map((p) => (
-        <div key={p.name} className="bg-white rounded-lg shadow border border-gray-200 px-6 py-4">
+        <div
+          key={p.name}
+          className="bg-white rounded-lg shadow border border-gray-200 px-6 py-4 dark:bg-slate-800 dark:border-slate-700"
+        >
           <div className="flex items-center gap-3 mb-3">
             <img
               src={`https://${p.host}/favicon.ico`}
@@ -32,28 +39,32 @@ export function Providers() {
               alt=""
               onError={(e) => (e.currentTarget.style.display = 'none')}
             />
-            <span className="font-semibold text-gray-900">{p.name}</span>
+            <span className="font-semibold text-gray-900 dark:text-gray-100">{p.name}</span>
             <a
               href={p.uri}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-600 hover:underline text-sm font-mono"
+              className="text-blue-600 hover:underline text-sm font-mono dark:text-blue-400"
             >
               {p.uri}
             </a>
           </div>
           <div className="grid grid-cols-2 gap-2 text-sm">
             <div>
-              <span className="text-gray-500 text-xs uppercase tracking-wide">
+              <span className="text-gray-500 text-xs uppercase tracking-wide dark:text-gray-400">
                 Store &amp; Forward (push)
               </span>
-              <div className="font-mono text-xs text-gray-700 mt-0.5">{p.pushPath}/*</div>
+              <div className="font-mono text-xs text-gray-700 mt-0.5 dark:text-gray-300">
+                {p.pushPath}/*
+              </div>
             </div>
             <div>
-              <span className="text-gray-500 text-xs uppercase tracking-wide">
+              <span className="text-gray-500 text-xs uppercase tracking-wide dark:text-gray-400">
                 Transparent Proxy
               </span>
-              <div className="font-mono text-xs text-gray-700 mt-0.5">{p.proxyPath}/*</div>
+              <div className="font-mono text-xs text-gray-700 mt-0.5 dark:text-gray-300">
+                {p.proxyPath}/*
+              </div>
             </div>
           </div>
         </div>

--- a/fogwall-dashboard/frontend/src/pages/PushDetail.tsx
+++ b/fogwall-dashboard/frontend/src/pages/PushDetail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { Diff2HtmlUI } from 'diff2html/lib/ui/js/diff2html-ui-slim'
+import { ColorSchemeType } from 'diff2html/lib/types'
 import 'diff2html/bundles/css/diff2html.min.css'
 import { approvePush, cancelPush, fetchDiff, fetchProviders, fetchPush, rejectPush } from '../api'
 import { StatusBadge } from '../components/StatusBadge'
@@ -50,13 +51,12 @@ const STEP_DISPLAY_NAMES: Record<string, string> = {
 
 function IdentityBadge({ record }: { record: PushRecord }) {
   if (record.resolvedUser) {
-    // Check if identity verification step passed but had email warnings (content is set)
     const idStep = (record.steps ?? []).find((s) => s.stepName === 'identityVerification')
     const hasEmailWarning = idStep?.status === 'PASS' && !!idStep?.content
     if (hasEmailWarning) {
       return (
         <span
-          className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700"
+          className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
           title={idStep?.content ?? undefined}
         >
           ⚠ identity resolved, email unregistered
@@ -64,15 +64,14 @@ function IdentityBadge({ record }: { record: PushRecord }) {
       )
     }
     return (
-      <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+      <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-300">
         ✓ identity resolved
       </span>
     )
   }
-  // Only show "unresolved" if there's actually a push user — not for anonymous/open-mode pushes
   if (record.user) {
     return (
-      <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">
+      <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500 dark:bg-slate-700 dark:text-gray-400">
         identity unresolved
       </span>
     )
@@ -100,18 +99,12 @@ function formatTime(ts: string | number | undefined) {
   }
 }
 
-/**
- * Build a direct link to the commit on the upstream SCM.
- * GitHub / Gitea / Codeberg: {repo}/commit/{sha}
- * GitLab: {repo}/-/commit/{sha}
- */
 function upstreamCommitUrl(upstreamUrl: string, sha: string): string {
   const base = upstreamUrl.replace(/\/$/, '').replace(/\.git$/, '')
   if (/gitlab\./.test(base)) return `${base}/-/commit/${sha}`
   return `${base}/commit/${sha}`
 }
 
-// Steps that represent forwarding/post-receive operations
 const FORWARDING_STEPS = new Set(['ForwardingPostReceiveHook', 'forward', 'ForwardingHook'])
 
 function PushTimeline({ record }: { record: PushRecord }) {
@@ -126,15 +119,13 @@ function PushTimeline({ record }: { record: PushRecord }) {
 
   const events: TimelineEvent[] = []
 
-  // 1. Received
   events.push({
     icon: '↓',
     label: 'Push received',
     time: record.timestamp,
-    color: 'text-gray-500',
+    color: 'text-gray-500 dark:text-gray-400',
   })
 
-  // 2. Validation ran — summarise as a single event using the first/last step timestamp
   const visibleSteps = (record.steps ?? []).filter((s) => !NON_VALIDATION_STEPS.has(s.stepName))
   if (visibleSteps.length > 0) {
     const failed = visibleSteps.filter((s) => s.status === 'FAIL' || s.status === 'BLOCKED')
@@ -147,12 +138,11 @@ function PushTimeline({ record }: { record: PushRecord }) {
           : `Validation passed (${visibleSteps.length} check${visibleSteps.length > 1 ? 's' : ''})`,
       detail: failed.map((s) => stepDisplayName(s.stepName)).join(', ') || undefined,
       time: lastStep?.timestamp,
-      color: failed.length > 0 ? 'text-red-500' : 'text-green-500',
+      color:
+        failed.length > 0 ? 'text-red-500 dark:text-red-400' : 'text-green-500 dark:text-green-400',
     })
   }
 
-  // 3. Pending event — show if currently pending review, or if there was a review
-  //    (attestation present means it went through the approval gate)
   const wasBlocked = record.status === 'PENDING' || record.attestation != null
   if (wasBlocked) {
     events.push({
@@ -160,11 +150,10 @@ function PushTimeline({ record }: { record: PushRecord }) {
       label: 'Pending review',
       detail: record.blockedMessage ?? undefined,
       time: record.timestamp,
-      color: 'text-amber-500',
+      color: 'text-amber-500 dark:text-amber-400',
     })
   }
 
-  // 4. Attestation (review event)
   if (record.attestation) {
     const att = record.attestation
     const typeLabel =
@@ -188,14 +177,13 @@ function PushTimeline({ record }: { record: PushRecord }) {
       time: att.timestamp,
       color:
         att.type === 'APPROVAL'
-          ? 'text-green-600'
+          ? 'text-green-600 dark:text-green-400'
           : att.type === 'REJECTION'
-            ? 'text-red-600'
-            : 'text-gray-400',
+            ? 'text-red-600 dark:text-red-400'
+            : 'text-gray-400 dark:text-gray-500',
     })
   }
 
-  // 5. Forwarded — check for a forwarding step first (S&F), else use record status
   const forwardStep = (record.steps ?? []).find((s) => FORWARDING_STEPS.has(s.stepName))
   if (record.status === 'FORWARDED') {
     const commitLink =
@@ -208,45 +196,56 @@ function PushTimeline({ record }: { record: PushRecord }) {
       detail: record.upstreamUrl ?? undefined,
       link: commitLink,
       time: forwardStep?.timestamp,
-      color: 'text-blue-500',
+      color: 'text-blue-500 dark:text-blue-400',
     })
   }
 
-  // 6. Error
   if (record.status === 'ERROR') {
     events.push({
       icon: '!',
       label: 'Error',
       detail: record.errorMessage ?? undefined,
       time: record.timestamp,
-      color: 'text-red-600',
+      color: 'text-red-600 dark:text-red-400',
     })
   }
 
   return (
-    <div className="bg-white rounded-lg shadow border border-gray-200 px-6 py-4">
-      <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-4">Timeline</h2>
-      <ol className="relative border-l border-gray-200 ml-2 space-y-4">
+    <div className="bg-white rounded-lg shadow border border-gray-200 px-6 py-4 dark:bg-slate-800 dark:border-slate-700">
+      <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-4 dark:text-gray-400">
+        Timeline
+      </h2>
+      <ol className="relative border-l border-gray-200 ml-2 space-y-4 dark:border-slate-700">
         {events.map((ev, i) => (
           <li key={i} className="ml-5">
             <span
-              className={`absolute -left-2.5 flex h-5 w-5 items-center justify-center rounded-full bg-white border border-gray-200 text-xs font-bold ${ev.color}`}
+              className={`absolute -left-2.5 flex h-5 w-5 items-center justify-center rounded-full bg-white border border-gray-200 text-xs font-bold dark:bg-slate-800 dark:border-slate-700 ${ev.color}`}
             >
               {ev.icon}
             </span>
-            <div className="text-sm text-gray-800 font-medium leading-snug">{ev.label}</div>
-            {ev.detail && <div className="text-xs text-gray-500 mt-0.5 font-mono">{ev.detail}</div>}
+            <div className="text-sm text-gray-800 font-medium leading-snug dark:text-gray-200">
+              {ev.label}
+            </div>
+            {ev.detail && (
+              <div className="text-xs text-gray-500 mt-0.5 font-mono dark:text-gray-400">
+                {ev.detail}
+              </div>
+            )}
             {ev.link && (
               <a
                 href={ev.link}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-xs text-blue-600 hover:underline mt-0.5 block"
+                className="text-xs text-blue-600 hover:underline mt-0.5 block dark:text-blue-400"
               >
                 View commit ↗
               </a>
             )}
-            {ev.time && <div className="text-xs text-gray-400 mt-0.5">{formatTime(ev.time)}</div>}
+            {ev.time && (
+              <div className="text-xs text-gray-400 mt-0.5 dark:text-gray-500">
+                {formatTime(ev.time)}
+              </div>
+            )}
           </li>
         ))}
       </ol>
@@ -266,7 +265,7 @@ function AttestationQuestionField({
   onChange: (val: string) => void
 }) {
   const labelEl = (
-    <span className="text-sm text-gray-700">
+    <span className="text-sm text-gray-700 dark:text-gray-300">
       {question.label}
       {question.required && <span className="ml-1 text-red-500">*</span>}
     </span>
@@ -280,7 +279,7 @@ function AttestationQuestionField({
           checked={value === 'true'}
           disabled={disabled}
           onChange={(e) => onChange(e.target.checked ? 'true' : 'false')}
-          className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 disabled:opacity-50"
+          className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 disabled:opacity-50 dark:border-slate-600"
         />
         {labelEl}
       </label>
@@ -295,7 +294,7 @@ function AttestationQuestionField({
           value={value}
           disabled={disabled}
           onChange={(e) => onChange(e.target.value)}
-          className="border border-gray-300 rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:bg-gray-50 disabled:text-gray-400"
+          className="border border-gray-300 rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:bg-gray-50 disabled:text-gray-400 dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200 dark:disabled:bg-gray-800 dark:disabled:text-gray-500"
         >
           <option value="">— select —</option>
           {(question.options ?? []).map((opt) => (
@@ -308,7 +307,6 @@ function AttestationQuestionField({
     )
   }
 
-  // text
   return (
     <div className="flex flex-col gap-1">
       {labelEl}
@@ -318,7 +316,7 @@ function AttestationQuestionField({
         disabled={disabled}
         onChange={(e) => onChange(e.target.value)}
         placeholder={question.tooltip ?? ''}
-        className="border border-gray-300 rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:bg-gray-50 disabled:text-gray-400"
+        className="border border-gray-300 rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:bg-gray-50 disabled:text-gray-400 dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200 dark:disabled:bg-gray-800 dark:disabled:text-gray-500"
       />
     </div>
   )
@@ -329,14 +327,14 @@ function RePushGuidance({ record }: { record: PushRecord }) {
 
   if (record.status === 'APPROVED') {
     return (
-      <div className="bg-blue-50 border border-blue-200 rounded-lg px-6 py-4">
-        <div className="text-sm font-semibold text-blue-800 mb-1">
+      <div className="bg-blue-50 border border-blue-200 rounded-lg px-6 py-4 dark:bg-blue-900/20 dark:border-blue-700">
+        <div className="text-sm font-semibold text-blue-800 mb-1 dark:text-blue-300">
           Push approved — re-push to forward
         </div>
-        <p className="text-sm text-blue-700 mb-3">
+        <p className="text-sm text-blue-700 mb-3 dark:text-blue-400">
           This push has been approved. Push the same commits again to forward them upstream.
         </p>
-        <pre className="text-xs bg-white border border-blue-200 rounded px-3 py-2 font-mono text-blue-900 select-all">
+        <pre className="text-xs bg-white border border-blue-200 rounded px-3 py-2 font-mono text-blue-900 select-all dark:bg-slate-900 dark:border-blue-700 dark:text-blue-300">
           git push origin {branch}
         </pre>
       </div>
@@ -349,9 +347,11 @@ function RePushGuidance({ record }: { record: PushRecord }) {
 
   if (record.status === 'CANCELED') {
     return (
-      <div className="bg-gray-50 border border-gray-200 rounded-lg px-6 py-4">
-        <div className="text-sm font-semibold text-gray-700 mb-1">Push canceled</div>
-        <p className="text-sm text-gray-600 mb-3">
+      <div className="bg-gray-50 border border-gray-200 rounded-lg px-6 py-4 dark:bg-slate-800 dark:border-slate-700">
+        <div className="text-sm font-semibold text-gray-700 mb-1 dark:text-gray-300">
+          Push canceled
+        </div>
+        <p className="text-sm text-gray-600 mb-3 dark:text-gray-400">
           <strong>{reviewer}</strong> canceled this push before review
           {reason ? (
             <>
@@ -362,24 +362,22 @@ function RePushGuidance({ record }: { record: PushRecord }) {
           )}{' '}
           The commits themselves are fine — re-push when ready.
         </p>
-        <pre className="text-xs bg-white border border-gray-200 rounded px-3 py-2 font-mono text-gray-800 select-all">
+        <pre className="text-xs bg-white border border-gray-200 rounded px-3 py-2 font-mono text-gray-800 select-all dark:bg-slate-900 dark:border-slate-700 dark:text-gray-300">
           git push origin {branch}
         </pre>
       </div>
     )
   }
 
-  // Rejection: check if it's a reviewer rejection or validation failure
   const isReviewerRejected = att && att.type === 'REJECTION'
 
   if (isReviewerRejected) {
-    // Reviewer explicitly rejected the push
     return (
-      <div className="bg-red-50 border border-red-200 rounded-lg px-6 py-4">
-        <div className="text-sm font-semibold text-red-800 mb-1">
+      <div className="bg-red-50 border border-red-200 rounded-lg px-6 py-4 dark:bg-red-900/20 dark:border-red-700">
+        <div className="text-sm font-semibold text-red-800 mb-1 dark:text-red-300">
           Push rejected — action required
         </div>
-        <p className="text-sm text-red-700 mb-1">
+        <p className="text-sm text-red-700 mb-1 dark:text-red-400">
           <strong>{reviewer}</strong> rejected this push
           {reason ? (
             <>
@@ -389,10 +387,10 @@ function RePushGuidance({ record }: { record: PushRecord }) {
             '.'
           )}
         </p>
-        <p className="text-sm text-red-700 mb-3">
+        <p className="text-sm text-red-700 mb-3 dark:text-red-400">
           Address the feedback, amend your commits, and push again.
         </p>
-        <pre className="text-xs bg-white border border-red-200 rounded px-3 py-2 font-mono text-red-900 select-all whitespace-pre-wrap">{`# Amend the last commit and re-push
+        <pre className="text-xs bg-white border border-red-200 rounded px-3 py-2 font-mono text-red-900 select-all whitespace-pre-wrap dark:bg-slate-900 dark:border-red-700 dark:text-red-300">{`# Amend the last commit and re-push
 git commit --amend
 git push origin ${branch}
 
@@ -402,17 +400,16 @@ git push origin :${branch}`}</pre>
     )
   }
 
-  // Validation failure (auto-rejected)
   return (
-    <div className="bg-red-50 border border-red-200 rounded-lg px-6 py-4">
-      <div className="text-sm font-semibold text-red-800 mb-1">
+    <div className="bg-red-50 border border-red-200 rounded-lg px-6 py-4 dark:bg-red-900/20 dark:border-red-700">
+      <div className="text-sm font-semibold text-red-800 mb-1 dark:text-red-300">
         Push blocked by validation — action required
       </div>
-      <p className="text-sm text-red-700 mb-3">
+      <p className="text-sm text-red-700 mb-3 dark:text-red-400">
         Your push was blocked by an automated check. Review the validation results above, fix the
         issues in your commits, and re-push.
       </p>
-      <pre className="text-xs bg-white border border-red-200 rounded px-3 py-2 font-mono text-red-900 select-all whitespace-pre-wrap">{`# Fix the issues, amend the last commit, and re-push
+      <pre className="text-xs bg-white border border-red-200 rounded px-3 py-2 font-mono text-red-900 select-all whitespace-pre-wrap dark:bg-slate-900 dark:border-red-700 dark:text-red-300">{`# Fix the issues, amend the last commit, and re-push
 git commit --amend
 git push origin ${branch}
 
@@ -424,11 +421,12 @@ git push origin :${branch}`}</pre>
 
 interface PushDetailProps {
   currentUser: CurrentUser | null
+  dark?: boolean
 }
 
 const DIFF_INLINE_THRESHOLD = 1000
 
-export function PushDetail({ currentUser }: PushDetailProps) {
+export function PushDetail({ currentUser, dark = false }: PushDetailProps) {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const diffRef = useRef<HTMLDivElement>(null)
@@ -446,7 +444,6 @@ export function PushDetail({ currentUser }: PushDetailProps) {
   const [attestationAnswers, setAttestationAnswers] = useState<Record<string, string>>({})
   const [adminOverrideEnabled, setAdminOverrideEnabled] = useState(false)
 
-  // Diff state — loaded separately so it never blocks the main page render
   const [diffContent, setDiffContent] = useState<string | null>(null)
   const [diffLoading, setDiffLoading] = useState(false)
   const [diffLines, setDiffLines] = useState(0)
@@ -454,7 +451,6 @@ export function PushDetail({ currentUser }: PushDetailProps) {
   const [diffHighlight, setDiffHighlight] = useState(true)
   const [diffSideBySide, setDiffSideBySide] = useState(true)
 
-  // Commits pagination
   const COMMITS_PAGE = 20
   const [showAllCommits, setShowAllCommits] = useState(false)
 
@@ -485,7 +481,6 @@ export function PushDetail({ currentUser }: PushDetailProps) {
     if (id) void Promise.resolve().then(() => load(id))
   }, [id])
 
-  // Fetch diff separately after record loads — avoids blocking page render on large diffs
   useEffect(() => {
     if (!id || !record) return
     void Promise.resolve().then(() => {
@@ -500,7 +495,6 @@ export function PushDetail({ currentUser }: PushDetailProps) {
     })
   }, [id, record])
 
-  // Render diff2html inline only when diff is small enough
   useEffect(() => {
     if (!diffContent || diffLines >= DIFF_INLINE_THRESHOLD || !diffRef.current) return
     setDiffRendering(true)
@@ -512,13 +506,14 @@ export function PushDetail({ currentUser }: PushDetailProps) {
           matching: 'lines',
           outputFormat: diffSideBySide ? 'side-by-side' : 'line-by-line',
           highlight: diffHighlight,
+          colorScheme: dark ? ColorSchemeType.DARK : ColorSchemeType.LIGHT,
         })
         ui.draw()
         if (diffHighlight) ui.highlightCode()
       } catch {
         if (diffRef.current) {
           diffRef.current.innerHTML =
-            '<pre class="text-xs text-gray-700 whitespace-pre-wrap overflow-x-auto">' +
+            '<pre class="text-xs text-gray-700 dark:text-gray-300 whitespace-pre-wrap overflow-x-auto">' +
             diffContent.replace(/</g, '&lt;') +
             '</pre>'
         }
@@ -527,7 +522,7 @@ export function PushDetail({ currentUser }: PushDetailProps) {
       }
     }, 16)
     return () => clearTimeout(timer)
-  }, [diffContent, diffLines, diffHighlight, diffSideBySide])
+  }, [diffContent, diffLines, diffHighlight, diffSideBySide, dark])
 
   const validationSteps: Step[] = (record?.steps ?? [])
     .filter((s) => !NON_VALIDATION_STEPS.has(s.stepName))
@@ -591,59 +586,62 @@ export function PushDetail({ currentUser }: PushDetailProps) {
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
-      <button onClick={() => navigate('/')} className="text-sm text-blue-600 hover:underline">
+      <button
+        onClick={() => navigate('/')}
+        className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+      >
         ← Back to push records
       </button>
 
-      {loading && <div className="text-center text-gray-400 py-16">Loading…</div>}
-      {error && <div className="text-red-600 py-8 text-center">{error}</div>}
+      {loading && (
+        <div className="text-center text-gray-400 py-16 dark:text-gray-500">Loading…</div>
+      )}
+      {error && <div className="text-red-600 py-8 text-center dark:text-red-400">{error}</div>}
 
       {record && !loading && (
         <>
           {/* Header card */}
-          <div className="bg-white rounded-lg shadow border border-gray-200 px-6 py-4">
+          <div className="bg-white rounded-lg shadow border border-gray-200 px-6 py-4 dark:bg-slate-800 dark:border-slate-700">
             <div className="flex items-start gap-4">
               <StatusBadge status={record.status} className="mt-1" />
 
-              {/* Left: commit details */}
               <div className="flex-1 min-w-0 space-y-0.5">
-                <div className="font-mono text-sm text-gray-900 truncate">
+                <div className="font-mono text-sm text-gray-900 truncate dark:text-gray-100">
                   {record.upstreamUrl ??
                     record.url ??
                     (record.project ?? '') + '/' + (record.repoName ?? '')}
                 </div>
-                <div className="text-xs text-gray-500 font-mono">{record.branch}</div>
-                <div className="text-xs font-mono text-gray-400 break-all">{record.commitTo}</div>
+                <div className="text-xs text-gray-500 font-mono dark:text-gray-400">
+                  {record.branch}
+                </div>
+                <div className="text-xs font-mono text-gray-400 break-all dark:text-gray-500">
+                  {record.commitTo}
+                </div>
                 {record.message && (
-                  <div className="text-xs text-gray-600 italic pt-0.5">{record.message}</div>
+                  <div className="text-xs text-gray-600 italic pt-0.5 dark:text-gray-400">
+                    {record.message}
+                  </div>
                 )}
               </div>
 
-              {/* Right: identity + timestamp */}
-              <div className="text-right text-xs text-gray-500 shrink-0 space-y-1">
-                {/* Git author (forgeable — labelled) */}
+              <div className="text-right text-xs text-gray-500 shrink-0 space-y-1 dark:text-gray-400">
                 {record.author && (
                   <div>
-                    <span className="text-gray-400">author: </span>
-                    <span className="text-gray-600">{record.author}</span>
+                    <span className="text-gray-400 dark:text-gray-500">author: </span>
+                    <span className="text-gray-600 dark:text-gray-300">{record.author}</span>
                   </div>
                 )}
-                {/* Git committer — only if different from author */}
                 {record.committer && record.committer !== record.author && (
                   <div>
-                    <span className="text-gray-400">committer: </span>
-                    <span className="text-gray-600">{record.committer}</span>
+                    <span className="text-gray-400 dark:text-gray-500">committer: </span>
+                    <span className="text-gray-600 dark:text-gray-300">{record.committer}</span>
                   </div>
                 )}
-                {/* Authenticated push identity */}
                 {(() => {
                   try {
                     const upstreamHost = record.upstreamUrl
                       ? new URL(record.upstreamUrl).hostname
                       : null
-                    // scmUsername  = real provider handle (coopernetes) — use for link
-                    // resolvedUser = proxy account (admin) — show when it differs from scmUsername
-                    // user         = raw HTTP Basic username — only show in open/unresolved mode
                     const displayHandle =
                       record.scmUsername ?? (record.resolvedUser ? null : record.user)
                     if (!displayHandle && !record.resolvedUser) return null
@@ -651,7 +649,7 @@ export function PushDetail({ currentUser }: PushDetailProps) {
                       <div className="space-y-0.5">
                         {displayHandle && (
                           <div className="flex items-center justify-end gap-1">
-                            <span className="text-gray-400">pusher</span>
+                            <span className="text-gray-400 dark:text-gray-500">pusher</span>
                             {upstreamHost && record.scmUsername && (
                               <img
                                 src={`https://${upstreamHost}/favicon.ico`}
@@ -666,17 +664,21 @@ export function PushDetail({ currentUser }: PushDetailProps) {
                                 href={`https://${upstreamHost}/${record.scmUsername}`}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="text-blue-600 hover:underline font-medium"
+                                className="text-blue-600 hover:underline font-medium dark:text-blue-400"
                               >
                                 {record.scmUsername}
                               </a>
                             ) : (
-                              <span className="text-gray-600">{displayHandle}</span>
+                              <span className="text-gray-600 dark:text-gray-300">
+                                {displayHandle}
+                              </span>
                             )}
                           </div>
                         )}
                         {record.resolvedUser && record.resolvedUser !== record.scmUsername && (
-                          <div className="text-gray-400">user: {record.resolvedUser}</div>
+                          <div className="text-gray-400 dark:text-gray-500">
+                            user: {record.resolvedUser}
+                          </div>
                         )}
                       </div>
                     )
@@ -686,17 +688,19 @@ export function PushDetail({ currentUser }: PushDetailProps) {
                   return null
                 })()}
                 <IdentityBadge record={record} />
-                <div className="text-gray-400">{formatTime(record.timestamp)}</div>
+                <div className="text-gray-400 dark:text-gray-500">
+                  {formatTime(record.timestamp)}
+                </div>
               </div>
             </div>
             {record.blockedMessage && (
-              <div className="mt-3 flex gap-2 text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+              <div className="mt-3 flex gap-2 text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded px-3 py-2 dark:bg-amber-900/20 dark:border-amber-700 dark:text-amber-300">
                 <span>⚠️</span>
                 <span>{record.blockedMessage}</span>
               </div>
             )}
             {record.attestation && (
-              <div className="mt-3 text-sm text-gray-500 border-t border-gray-100 pt-2">
+              <div className="mt-3 text-sm text-gray-500 border-t border-gray-100 pt-2 dark:text-gray-400 dark:border-slate-700">
                 Reviewed by <strong>{record.attestation.reviewerUsername}</strong>
                 {record.attestation.reviewerEmail && ` (${record.attestation.reviewerEmail})`}
                 {record.attestation.reason && ` · "${record.attestation.reason}"`}
@@ -709,37 +713,42 @@ export function PushDetail({ currentUser }: PushDetailProps) {
 
           {/* Commits */}
           {record.commits && record.commits.length > 0 && (
-            <div className="bg-white rounded-lg shadow border border-gray-200 px-6 py-4">
-              <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
+            <div className="bg-white rounded-lg shadow border border-gray-200 px-6 py-4 dark:bg-slate-800 dark:border-slate-700">
+              <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3 dark:text-gray-400">
                 Commits ({record.commits.length})
               </h2>
               <div className="space-y-2">
                 {(showAllCommits ? record.commits : record.commits.slice(0, COMMITS_PAGE)).map(
                   (c) => (
-                    <div key={c.sha} className="border border-gray-100 rounded p-3 space-y-1">
-                      <div className="font-mono text-xs text-gray-400">{c.sha}</div>
-                      <div className="text-sm text-gray-800 whitespace-pre-wrap">
+                    <div
+                      key={c.sha}
+                      className="border border-gray-100 rounded p-3 space-y-1 dark:border-slate-700"
+                    >
+                      <div className="font-mono text-xs text-gray-400 dark:text-gray-500">
+                        {c.sha}
+                      </div>
+                      <div className="text-sm text-gray-800 whitespace-pre-wrap dark:text-gray-200">
                         {(c.message ?? '').split('\n')[0].trim()}
                       </div>
-                      <div className="text-xs text-gray-500">
+                      <div className="text-xs text-gray-500 dark:text-gray-400">
                         <span className="font-medium">Author: </span>
                         {c.authorName} &lt;{c.authorEmail}&gt;
                       </div>
                       {c.committerName &&
                         (c.committerName !== c.authorName ||
                           c.committerEmail !== c.authorEmail) && (
-                          <div className="text-xs text-gray-500">
+                          <div className="text-xs text-gray-500 dark:text-gray-400">
                             <span className="font-medium">Committer: </span>
                             {c.committerName} &lt;{c.committerEmail}&gt;
                           </div>
                         )}
                       {c.signedOffBy && c.signedOffBy.length > 0 && (
-                        <div className="text-xs text-gray-500">
+                        <div className="text-xs text-gray-500 dark:text-gray-400">
                           <span className="font-medium">Signed-off-by: </span>
                           {c.signedOffBy.map((sob) => (
                             <span
                               key={sob}
-                              className="ml-1 bg-green-50 text-green-700 border border-green-200 rounded px-1"
+                              className="ml-1 bg-green-50 text-green-700 border border-green-200 rounded px-1 dark:bg-green-900/20 dark:text-green-300 dark:border-green-700"
                             >
                               {sob}
                             </span>
@@ -753,7 +762,7 @@ export function PushDetail({ currentUser }: PushDetailProps) {
               {record.commits.length > COMMITS_PAGE && (
                 <button
                   onClick={() => setShowAllCommits((v) => !v)}
-                  className="mt-3 text-xs text-slate-500 hover:text-slate-700 transition-colors"
+                  className="mt-3 text-xs text-slate-500 hover:text-slate-700 transition-colors dark:text-slate-400 dark:hover:text-slate-300"
                 >
                   {showAllCommits
                     ? '▲ Show fewer'
@@ -765,8 +774,8 @@ export function PushDetail({ currentUser }: PushDetailProps) {
 
           {/* Validation steps */}
           {validationSteps.length > 0 && (
-            <div className="bg-white rounded-lg shadow border border-gray-200 px-6 py-4">
-              <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
+            <div className="bg-white rounded-lg shadow border border-gray-200 px-6 py-4 dark:bg-slate-800 dark:border-slate-700">
+              <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3 dark:text-gray-400">
                 Validation steps
               </h2>
               <div className="space-y-1">
@@ -783,31 +792,31 @@ export function PushDetail({ currentUser }: PushDetailProps) {
                         <span
                           className={
                             s.status === 'PASS'
-                              ? 'text-green-500'
+                              ? 'text-green-500 dark:text-green-400'
                               : isFailed
-                                ? 'text-red-500'
+                                ? 'text-red-500 dark:text-red-400'
                                 : isSkipped
-                                  ? 'text-yellow-500'
-                                  : 'text-gray-400'
+                                  ? 'text-yellow-500 dark:text-yellow-400'
+                                  : 'text-gray-400 dark:text-gray-500'
                           }
                         >
                           {s.status === 'PASS' ? '✓' : isFailed ? '✗' : isSkipped ? '⚠' : '–'}
                         </span>
-                        <span className="text-sm text-gray-700 w-56 shrink-0">
+                        <span className="text-sm text-gray-700 w-56 shrink-0 dark:text-gray-300">
                           {stepDisplayName(s.stepName)}
                         </span>
-                        <span className="text-gray-500 text-xs truncate flex-1">
+                        <span className="text-gray-500 text-xs truncate flex-1 dark:text-gray-400">
                           {s.errorMessage ?? s.blockedMessage ?? (isSkipped ? 'skipped' : '')}
                         </span>
                         {(isFailed || isSkipped) &&
                           (s.content || s.errorMessage || s.blockedMessage) && (
-                            <span className="text-xs text-gray-400 shrink-0">
+                            <span className="text-xs text-gray-400 shrink-0 dark:text-gray-500">
                               {isOpen ? '▲ hide' : '▼ details'}
                             </span>
                           )}
                       </div>
                       {isOpen && (s.content || s.errorMessage || s.blockedMessage) && (
-                        <pre className="mt-2 ml-6 text-xs bg-gray-50 border border-gray-200 rounded p-3 whitespace-pre-wrap font-mono text-gray-800 overflow-x-auto">
+                        <pre className="mt-2 ml-6 text-xs bg-gray-50 border border-gray-200 rounded p-3 whitespace-pre-wrap font-mono text-gray-800 overflow-x-auto dark:bg-slate-900 dark:border-slate-700 dark:text-gray-200">
                           {[s.errorMessage ?? s.blockedMessage, s.content]
                             .filter(Boolean)
                             .join('\n\n')}
@@ -821,46 +830,60 @@ export function PushDetail({ currentUser }: PushDetailProps) {
           )}
 
           {/* Diff */}
-          <div className="bg-white rounded-lg shadow border border-gray-200 px-6 py-4">
+          <div className="bg-white rounded-lg shadow border border-gray-200 px-6 py-4 dark:bg-slate-800 dark:border-slate-700">
             <div className="flex items-center gap-3 mb-3">
-              <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide">Diff</h2>
+              <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide dark:text-gray-400">
+                Diff
+              </h2>
               {!diffLoading && diffContent && diffLines < DIFF_INLINE_THRESHOLD && (
                 <div className="flex items-center gap-2 ml-auto">
                   {diffRendering && (
-                    <span className="text-xs text-gray-400 italic">Rendering…</span>
+                    <span className="text-xs text-gray-400 italic dark:text-gray-500">
+                      Rendering…
+                    </span>
                   )}
                   <button
                     onClick={() => setDiffSideBySide((v) => !v)}
-                    className={`px-2.5 py-1 rounded text-xs transition-colors ${diffSideBySide ? 'bg-slate-600 text-white' : 'bg-gray-100 text-gray-500 hover:bg-gray-200'}`}
+                    className={`px-2.5 py-1 rounded text-xs transition-colors ${
+                      diffSideBySide
+                        ? 'bg-slate-600 text-white'
+                        : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-slate-700 dark:text-gray-400 dark:hover:bg-gray-600'
+                    }`}
                   >
                     Side-by-side
                   </button>
                   <button
                     onClick={() => setDiffHighlight((v) => !v)}
-                    className={`px-2.5 py-1 rounded text-xs transition-colors ${diffHighlight ? 'bg-slate-600 text-white' : 'bg-gray-100 text-gray-500 hover:bg-gray-200'}`}
+                    className={`px-2.5 py-1 rounded text-xs transition-colors ${
+                      diffHighlight
+                        ? 'bg-slate-600 text-white'
+                        : 'bg-gray-100 text-gray-500 hover:bg-gray-200 dark:bg-slate-700 dark:text-gray-400 dark:hover:bg-gray-600'
+                    }`}
                   >
                     Syntax highlight
                   </button>
                   <Link
                     to={`/push/${id}/diff`}
-                    className="px-2.5 py-1 rounded text-xs text-slate-500 hover:text-slate-700 bg-gray-100 hover:bg-gray-200 transition-colors"
+                    className="px-2.5 py-1 rounded text-xs text-slate-500 hover:text-slate-700 bg-gray-100 hover:bg-gray-200 transition-colors dark:bg-slate-700 dark:text-gray-400 dark:hover:text-gray-300 dark:hover:bg-gray-600"
                   >
                     Full page →
                   </Link>
                 </div>
               )}
             </div>
-            {diffLoading && <div className="text-gray-400 text-sm">Loading diff…</div>}
+            {diffLoading && (
+              <div className="text-gray-400 text-sm dark:text-gray-500">Loading diff…</div>
+            )}
             {!diffLoading && !diffContent && (
-              <div className="text-gray-400 text-sm">No diff available.</div>
+              <div className="text-gray-400 text-sm dark:text-gray-500">No diff available.</div>
             )}
             {!diffLoading && diffContent && diffLines >= DIFF_INLINE_THRESHOLD && (
-              <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 flex items-center justify-between gap-4">
+              <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 flex items-center justify-between gap-4 dark:bg-amber-900/20 dark:border-amber-700">
                 <div>
-                  <p className="text-sm font-medium text-amber-800">
+                  <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
                     This diff is large ({diffLines.toLocaleString()} lines)
                   </p>
-                  <p className="text-xs text-amber-600 mt-0.5">
+                  <p className="text-xs text-amber-600 mt-0.5 dark:text-amber-400">
                     Rendering it inline would degrade page performance.
                   </p>
                 </div>
@@ -886,16 +909,11 @@ export function PushDetail({ currentUser }: PushDetailProps) {
           {record.status === 'PENDING' &&
             (() => {
               const isAdmin = currentUser?.authorities?.includes('ROLE_ADMIN') ?? false
-              // canCurrentUserSelfCertify is computed server-side and requires BOTH the
-              // ROLE_SELF_CERTIFY authority AND a SELF_CERTIFY repo permission row for this push's
-              // path. A user with the role but no per-repo permission gets `false` here.
               const canSelfCertify = record.canCurrentUserSelfCertify ?? false
               const isPusher =
                 !!currentUser?.username &&
                 !!record.resolvedUser &&
                 currentUser.username === record.resolvedUser
-              // Admins are treated the same as regular users for their own pushes: they need
-              // self-certify permissions or must explicitly activate the admin override.
               const isSelfReview = isPusher && !canSelfCertify
               const canCancel = isAdmin || isPusher
               const attestationsComplete = attestationQuestions
@@ -907,11 +925,11 @@ export function PushDetail({ currentUser }: PushDetailProps) {
                   return true
                 })
               return (
-                <div className="bg-white rounded-lg shadow border border-gray-200 px-6 py-5">
-                  <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
+                <div className="bg-white rounded-lg shadow border border-gray-200 px-6 py-5 dark:bg-slate-800 dark:border-slate-700">
+                  <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3 dark:text-gray-400">
                     Review
                   </h2>
-                  <div className="text-xs text-gray-400 mb-3">
+                  <div className="text-xs text-gray-400 mb-3 dark:text-gray-500">
                     Reviewing as{' '}
                     <strong>
                       {currentUser
@@ -920,13 +938,13 @@ export function PushDetail({ currentUser }: PushDetailProps) {
                         : '…'}
                     </strong>
                     {isAdmin && (
-                      <span className="ml-2 inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+                      <span className="ml-2 inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
                         admin
                       </span>
                     )}
                   </div>
                   {isSelfReview && !adminOverrideEnabled && (
-                    <div className="flex gap-2 text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded px-3 py-2 mb-3">
+                    <div className="flex gap-2 text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded px-3 py-2 mb-3 dark:bg-amber-900/20 dark:border-amber-700 dark:text-amber-300">
                       <span>⚠</span>
                       <span>
                         Self-approval is not permitted — you pushed these commits. Another reviewer
@@ -935,8 +953,8 @@ export function PushDetail({ currentUser }: PushDetailProps) {
                     </div>
                   )}
                   {canSelfCertify && isPusher && (
-                    <div className="flex gap-2 text-sm text-blue-800 bg-blue-50 border border-blue-200 rounded px-3 py-2 mb-3">
-                      <span>{'\u2139\uFE0F'}</span>
+                    <div className="flex gap-2 text-sm text-blue-800 bg-blue-50 border border-blue-200 rounded px-3 py-2 mb-3 dark:bg-blue-900/20 dark:border-blue-700 dark:text-blue-300">
+                      <span>{'ℹ️'}</span>
                       <span>
                         You are self-certifying your own push. This approval will be permanently
                         recorded in the audit log.
@@ -946,13 +964,13 @@ export function PushDetail({ currentUser }: PushDetailProps) {
                   {isAdmin && isPusher && !canSelfCertify && !adminOverrideEnabled && (
                     <button
                       onClick={() => setAdminOverrideEnabled(true)}
-                      className="w-full text-left text-xs text-gray-500 hover:text-gray-700 underline mb-3"
+                      className="w-full text-left text-xs text-gray-500 hover:text-gray-700 underline mb-3 dark:text-gray-400 dark:hover:text-gray-300"
                     >
                       Enable admin override
                     </button>
                   )}
                   {isAdmin && isPusher && adminOverrideEnabled && (
-                    <div className="flex gap-2 text-sm text-red-800 bg-red-50 border border-red-200 rounded px-3 py-2 mb-3">
+                    <div className="flex gap-2 text-sm text-red-800 bg-red-50 border border-red-200 rounded px-3 py-2 mb-3 dark:bg-red-900/20 dark:border-red-700 dark:text-red-300">
                       <span>⚠</span>
                       <span>
                         <strong>WARNING:</strong> You are about to approve your own push as an admin
@@ -963,7 +981,7 @@ export function PushDetail({ currentUser }: PushDetailProps) {
                   )}
                   {attestationQuestions.length > 0 && (
                     <div className="mb-4 space-y-3">
-                      <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                      <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide dark:text-gray-400">
                         Attestation
                       </div>
                       {attestationQuestions.map((q) => (
@@ -987,9 +1005,11 @@ export function PushDetail({ currentUser }: PushDetailProps) {
                       'Reason (required for both approve and reject)\nDescribe the basis for your decision...'
                     }
                     disabled={isSelfReview && !adminOverrideEnabled}
-                    className="w-full border border-gray-300 rounded px-3 py-2 text-sm mb-3 resize-none focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:bg-gray-50 disabled:text-gray-400"
+                    className="w-full border border-gray-300 rounded px-3 py-2 text-sm mb-3 resize-none focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:bg-gray-50 disabled:text-gray-400 dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200 dark:placeholder-gray-400 dark:disabled:bg-gray-800 dark:disabled:text-gray-500"
                   />
-                  {actionError && <div className="text-red-600 text-sm mb-3">{actionError}</div>}
+                  {actionError && (
+                    <div className="text-red-600 text-sm mb-3 dark:text-red-400">{actionError}</div>
+                  )}
                   <div className="flex gap-3">
                     <button
                       onClick={handleApprove}
@@ -1020,7 +1040,7 @@ export function PushDetail({ currentUser }: PushDetailProps) {
                       <button
                         onClick={handleCancel}
                         disabled={saving || canceling}
-                        className="ml-auto px-4 py-2 text-sm font-medium rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-50"
+                        className="ml-auto px-4 py-2 text-sm font-medium rounded border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-50 dark:border-slate-600 dark:text-gray-400 dark:hover:bg-gray-700"
                       >
                         {canceling ? 'Canceling…' : 'Cancel push'}
                       </button>

--- a/fogwall-dashboard/frontend/src/pages/PushDiff.tsx
+++ b/fogwall-dashboard/frontend/src/pages/PushDiff.tsx
@@ -1,4 +1,5 @@
 import { Diff2HtmlUI } from 'diff2html/lib/ui/js/diff2html-ui-slim'
+import { ColorSchemeType } from 'diff2html/lib/types'
 import 'diff2html/bundles/css/diff2html.min.css'
 import { useEffect, useRef, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
@@ -35,7 +36,7 @@ function ToggleButton({
   )
 }
 
-export function PushDiff() {
+export function PushDiff({ dark = false }: { dark?: boolean }) {
   const { id } = useParams<{ id: string }>()
   const diffRef = useRef<HTMLDivElement>(null)
 
@@ -84,6 +85,7 @@ export function PushDiff() {
           matching: 'none',
           outputFormat: sideBySide ? 'side-by-side' : 'line-by-line',
           highlight,
+          colorScheme: dark ? ColorSchemeType.DARK : ColorSchemeType.LIGHT,
         })
         ui.draw()
         if (highlight) ui.highlightCode()
@@ -99,10 +101,10 @@ export function PushDiff() {
       }
     }, 16)
     return () => clearTimeout(timer)
-  }, [diffContent, highlight, sideBySide])
+  }, [diffContent, highlight, sideBySide, dark])
 
   return (
-    <div className="min-h-screen flex flex-col bg-white">
+    <div className="min-h-screen flex flex-col bg-white dark:bg-slate-900">
       {/* Header */}
       <div className="bg-slate-800 text-white px-6 py-3 flex items-center gap-4 text-sm shrink-0 flex-wrap">
         <Link
@@ -145,12 +147,14 @@ export function PushDiff() {
       {/* Diff body */}
       <div className="flex-1 overflow-auto">
         {loading && (
-          <div className="flex items-center justify-center h-64 text-gray-400 text-sm">
+          <div className="flex items-center justify-center h-64 text-gray-400 text-sm dark:text-gray-500">
             Loading diff…
           </div>
         )}
         {error && (
-          <div className="flex items-center justify-center h-64 text-red-500 text-sm">{error}</div>
+          <div className="flex items-center justify-center h-64 text-red-500 text-sm dark:text-red-400">
+            {error}
+          </div>
         )}
         {!loading && !error && (
           <div className="p-4">

--- a/fogwall-dashboard/frontend/src/pages/PushList.tsx
+++ b/fogwall-dashboard/frontend/src/pages/PushList.tsx
@@ -16,13 +16,20 @@ const STATUSES: PushStatus[] = [
 ]
 
 const STATUS_COLORS: Record<string, string> = {
-  PENDING: 'bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100',
-  APPROVED: 'bg-green-50 text-green-700 border-green-200 hover:bg-green-100',
-  FORWARDED: 'bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100',
-  REJECTED: 'bg-red-50 text-red-700 border-red-200 hover:bg-red-100',
-  RECEIVED: 'bg-slate-50 text-slate-700 border-slate-200 hover:bg-slate-100',
-  CANCELED: 'bg-gray-50 text-gray-500 border-gray-200 hover:bg-gray-100',
-  ERROR: 'bg-rose-50 text-rose-800 border-rose-200 hover:bg-rose-100',
+  PENDING:
+    'bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100 dark:bg-amber-900/20 dark:text-amber-300 dark:border-amber-700 dark:hover:bg-amber-900/40',
+  APPROVED:
+    'bg-green-50 text-green-700 border-green-200 hover:bg-green-100 dark:bg-green-900/20 dark:text-green-300 dark:border-green-700 dark:hover:bg-green-900/40',
+  FORWARDED:
+    'bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100 dark:bg-blue-900/20 dark:text-blue-300 dark:border-blue-700 dark:hover:bg-blue-900/40',
+  REJECTED:
+    'bg-red-50 text-red-700 border-red-200 hover:bg-red-100 dark:bg-red-900/20 dark:text-red-300 dark:border-red-700 dark:hover:bg-red-900/40',
+  RECEIVED:
+    'bg-slate-50 text-slate-700 border-slate-200 hover:bg-slate-100 dark:bg-slate-700/40 dark:text-slate-300 dark:border-slate-600 dark:hover:bg-slate-700/60',
+  CANCELED:
+    'bg-gray-50 text-gray-500 border-gray-200 hover:bg-gray-100 dark:bg-slate-700/40 dark:text-gray-400 dark:border-slate-600 dark:hover:bg-gray-700/60',
+  ERROR:
+    'bg-rose-50 text-rose-800 border-rose-200 hover:bg-rose-100 dark:bg-rose-900/20 dark:text-rose-300 dark:border-rose-700 dark:hover:bg-rose-900/40',
 }
 
 function formatTime(ts: string | number | undefined) {
@@ -197,8 +204,8 @@ export function PushList({ currentUser, bulkReviewEnabled = false }: PushListPro
           }}
           className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
             filterStatus === ''
-              ? 'bg-gray-900 text-white border-gray-900'
-              : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+              ? 'bg-gray-900 text-white border-gray-900 dark:bg-slate-100 dark:text-gray-900 dark:border-slate-100'
+              : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50 dark:bg-slate-800 dark:text-gray-300 dark:border-slate-600 dark:hover:bg-gray-700'
           }`}
         >
           All
@@ -212,8 +219,9 @@ export function PushList({ currentUser, bulkReviewEnabled = false }: PushListPro
             }}
             className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
               filterStatus === s
-                ? 'bg-gray-900 text-white border-gray-900'
-                : (STATUS_COLORS[s] ?? 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50')
+                ? 'bg-gray-900 text-white border-gray-900 dark:bg-slate-100 dark:text-gray-900 dark:border-slate-100'
+                : (STATUS_COLORS[s] ??
+                  'bg-white text-gray-600 border-gray-300 hover:bg-gray-50 dark:bg-slate-800 dark:text-gray-300 dark:border-slate-600 dark:hover:bg-gray-700')
             }`}
           >
             {s.charAt(0) + s.slice(1).toLowerCase()}
@@ -224,8 +232,8 @@ export function PushList({ currentUser, bulkReviewEnabled = false }: PushListPro
 
       {/* Bulk action bar — shown when items are selected */}
       {selectionEnabled && selectedIds.size > 0 && (
-        <div className="max-w-7xl mx-auto px-4 py-3 flex gap-3 flex-wrap items-center bg-amber-50 border-y border-amber-200">
-          <span className="text-sm font-medium text-amber-800">
+        <div className="max-w-7xl mx-auto px-4 py-3 flex gap-3 flex-wrap items-center bg-amber-50 border-y border-amber-200 dark:bg-amber-900/20 dark:border-amber-700">
+          <span className="text-sm font-medium text-amber-800 dark:text-amber-300">
             {selectedIds.size} push{selectedIds.size !== 1 ? 'es' : ''} selected
           </span>
           <input
@@ -233,7 +241,7 @@ export function PushList({ currentUser, bulkReviewEnabled = false }: PushListPro
             onChange={(e) => setBulkReason(e.target.value)}
             type="text"
             placeholder="Reason (required)..."
-            className="flex-1 min-w-40 border border-amber-300 rounded px-3 py-1.5 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-amber-300"
+            className="flex-1 min-w-40 border border-amber-300 rounded px-3 py-1.5 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-amber-300 dark:bg-slate-700 dark:border-amber-700 dark:text-gray-200 dark:placeholder-gray-400 dark:focus:ring-amber-600"
           />
           <button
             onClick={handleBulkApprove}
@@ -255,18 +263,20 @@ export function PushList({ currentUser, bulkReviewEnabled = false }: PushListPro
               setBulkReason('')
               setBulkError('')
             }}
-            className="text-sm text-amber-700 hover:underline ml-auto"
+            className="text-sm text-amber-700 hover:underline ml-auto dark:text-amber-400"
           >
             Clear
           </button>
-          {bulkError && <div className="w-full text-sm text-red-600">{bulkError}</div>}
+          {bulkError && (
+            <div className="w-full text-sm text-red-600 dark:text-red-400">{bulkError}</div>
+          )}
         </div>
       )}
 
       {/* Filter bar */}
-      <div className="max-w-7xl mx-auto px-4 py-3 flex gap-3 flex-wrap items-center border-b border-gray-100">
+      <div className="max-w-7xl mx-auto px-4 py-3 flex gap-3 flex-wrap items-center border-b border-gray-100 dark:border-slate-700">
         {selectionEnabled && (
-          <label className="flex items-center gap-1.5 text-sm text-gray-500 cursor-pointer select-none">
+          <label className="flex items-center gap-1.5 text-sm text-gray-500 cursor-pointer select-none dark:text-gray-400">
             <input
               type="checkbox"
               checked={
@@ -274,7 +284,7 @@ export function PushList({ currentUser, bulkReviewEnabled = false }: PushListPro
                 selectedIds.size === pushes.filter((p) => p.status === 'PENDING').length
               }
               onChange={toggleSelectAll}
-              className="rounded border-gray-300"
+              className="rounded border-gray-300 dark:border-slate-600"
             />
             <span className="text-xs">All</span>
           </label>
@@ -284,7 +294,7 @@ export function PushList({ currentUser, bulkReviewEnabled = false }: PushListPro
           onChange={(e) => handleRepoChange(e.target.value)}
           type="text"
           placeholder="Filter by project or repo..."
-          className="border border-gray-300 rounded px-3 py-1.5 text-sm bg-white shadow-sm w-52"
+          className="border border-gray-300 rounded px-3 py-1.5 text-sm bg-white shadow-sm w-52 dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200 dark:placeholder-gray-400"
         />
 
         {currentUser && (
@@ -296,7 +306,7 @@ export function PushList({ currentUser, bulkReviewEnabled = false }: PushListPro
             className={`px-3 py-1.5 text-sm rounded border transition-colors ${
               myPushesOnly
                 ? 'bg-blue-600 text-white border-blue-600'
-                : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+                : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50 dark:bg-slate-800 dark:text-gray-300 dark:border-slate-600 dark:hover:bg-gray-700'
             }`}
           >
             My pushes
@@ -308,13 +318,13 @@ export function PushList({ currentUser, bulkReviewEnabled = false }: PushListPro
             setNewestFirst((v) => !v)
             setPage(0)
           }}
-          className="px-3 py-1.5 text-sm rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 transition-colors"
+          className="px-3 py-1.5 text-sm rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-50 transition-colors dark:bg-slate-800 dark:text-gray-300 dark:border-slate-600 dark:hover:bg-gray-700"
           title={newestFirst ? 'Currently: newest first' : 'Currently: oldest first'}
         >
           {newestFirst ? '↓ Newest first' : '↑ Oldest first'}
         </button>
 
-        <div className="ml-auto flex items-center gap-4 text-sm text-gray-400">
+        <div className="ml-auto flex items-center gap-4 text-sm text-gray-400 dark:text-gray-500">
           <span>
             {pushes.length} record{pushes.length !== 1 ? 's' : ''}
             {page > 0 ? ` (page ${page + 1})` : ''}
@@ -322,7 +332,7 @@ export function PushList({ currentUser, bulkReviewEnabled = false }: PushListPro
           {lastRefresh && <span>refreshed {lastRefresh}</span>}
           <button
             onClick={() => load(filterStatus, filterRepo, myPushesOnly, newestFirst, page)}
-            className="text-blue-600 hover:underline"
+            className="text-blue-600 hover:underline dark:text-blue-400"
           >
             &#8635; Refresh
           </button>
@@ -332,16 +342,18 @@ export function PushList({ currentUser, bulkReviewEnabled = false }: PushListPro
       {/* List */}
       <div className="max-w-7xl mx-auto px-4 space-y-2 py-4 pb-12">
         {pushes.length === 0 && (
-          <div className="text-center text-gray-400 py-16">No push records found.</div>
+          <div className="text-center text-gray-400 dark:text-gray-500 py-16">
+            No push records found.
+          </div>
         )}
         {pushes.map((push) => (
           <div
             key={push.id}
             onClick={() => navigate(`/push/${push.id}`)}
-            className={`bg-white rounded-lg shadow border transition-colors cursor-pointer ${
+            className={`bg-white rounded-lg shadow border transition-colors cursor-pointer dark:bg-slate-800 ${
               selectedIds.has(push.id)
-                ? 'border-amber-300 bg-amber-50'
-                : 'border-gray-200 hover:border-blue-300'
+                ? 'border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-900/20'
+                : 'border-gray-200 hover:border-blue-300 dark:border-slate-700 dark:hover:border-blue-500'
             }`}
           >
             <div className="flex items-center gap-4 px-5 py-3">
@@ -351,36 +363,40 @@ export function PushList({ currentUser, bulkReviewEnabled = false }: PushListPro
                   checked={selectedIds.has(push.id)}
                   onClick={(e) => toggleSelect(push.id, e)}
                   onChange={() => {}}
-                  className="rounded border-gray-300 shrink-0"
+                  className="rounded border-gray-300 shrink-0 dark:border-slate-600"
                 />
               )}
               <StatusBadge status={push.status} />
               <div className="flex-1 min-w-0 space-y-0.5">
-                <div className="font-mono text-sm text-gray-900 truncate">
+                <div className="font-mono text-sm text-gray-900 truncate dark:text-gray-100">
                   {push.upstreamUrl ??
                     push.url ??
                     (push.project ?? '') + '/' + (push.repoName ?? 'unknown')}
                 </div>
-                <div className="text-xs text-gray-500 truncate">{push.branch ?? '—'}</div>
-                <div className="font-mono text-xs text-gray-400 break-all">
+                <div className="text-xs text-gray-500 truncate dark:text-gray-400">
+                  {push.branch ?? '—'}
+                </div>
+                <div className="font-mono text-xs text-gray-400 break-all dark:text-gray-500">
                   {push.commitTo ?? '—'}
                 </div>
               </div>
-              <div className="text-right text-sm text-gray-500 shrink-0">
+              <div className="text-right text-sm text-gray-500 shrink-0 dark:text-gray-400">
                 <div>{push.author ?? push.user ?? '—'}</div>
                 {push.resolvedUser ? (
-                  <span className="inline-flex items-center gap-0.5 text-xs text-green-600 font-medium">
+                  <span className="inline-flex items-center gap-0.5 text-xs text-green-600 font-medium dark:text-green-400">
                     ● identity resolved
                   </span>
                 ) : push.user ? (
-                  <span className="inline-flex items-center gap-0.5 text-xs text-gray-400 font-medium">
+                  <span className="inline-flex items-center gap-0.5 text-xs text-gray-400 font-medium dark:text-gray-500">
                     ● identity unresolved
                   </span>
                 ) : null}
-                <div className="text-xs text-gray-400 mt-0.5">{formatTime(push.timestamp)}</div>
+                <div className="text-xs text-gray-400 mt-0.5 dark:text-gray-500">
+                  {formatTime(push.timestamp)}
+                </div>
               </div>
               <svg
-                className="w-4 h-4 text-gray-300 shrink-0"
+                className="w-4 h-4 text-gray-300 shrink-0 dark:text-gray-600"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -403,15 +419,17 @@ export function PushList({ currentUser, bulkReviewEnabled = false }: PushListPro
           <button
             onClick={() => setPage((p) => Math.max(0, p - 1))}
             disabled={page === 0}
-            className="px-4 py-2 text-sm rounded border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-40"
+            className="px-4 py-2 text-sm rounded border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-40 dark:bg-slate-800 dark:border-slate-600 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             ← Previous
           </button>
-          <span className="px-4 py-2 text-sm text-gray-500">Page {page + 1}</span>
+          <span className="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">
+            Page {page + 1}
+          </span>
           <button
             onClick={() => setPage((p) => p + 1)}
             disabled={!hasMore}
-            className="px-4 py-2 text-sm rounded border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-40"
+            className="px-4 py-2 text-sm rounded border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-40 dark:bg-slate-800 dark:border-slate-600 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             Next →
           </button>

--- a/fogwall-dashboard/frontend/src/pages/Repos.tsx
+++ b/fogwall-dashboard/frontend/src/pages/Repos.tsx
@@ -49,7 +49,7 @@ function CloneButton({ cloneUrl }: { cloneUrl: string }) {
     <div className="relative" ref={ref}>
       <button
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded border border-green-600 text-green-700 bg-green-50 hover:bg-green-100 transition-colors"
+        className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded border border-green-600 text-green-700 bg-green-50 hover:bg-green-100 transition-colors dark:border-green-700 dark:text-green-400 dark:bg-green-900/20 dark:hover:bg-green-900/40"
       >
         <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor">
           <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h7A2.5 2.5 0 0 1 14 2.5v10.528c0 .3-.05.654-.272.moorings M4.5 1A1.5 1.5 0 0 0 3 2.5v9.539l1.446-1.085a.749.749 0 0 1 .85-.006L7 12.266l1.704-1.318a.749.749 0 0 1 .85.006L11 12.039V2.5A1.5 1.5 0 0 0 9.5 1Z" />
@@ -61,21 +61,31 @@ function CloneButton({ cloneUrl }: { cloneUrl: string }) {
       </button>
 
       {open && (
-        <div className="absolute right-0 mt-1 w-80 bg-white border border-gray-200 rounded-lg shadow-lg z-10 p-4">
+        <div className="absolute right-0 mt-1 w-80 bg-white border border-gray-200 rounded-lg shadow-lg z-10 p-4 dark:bg-slate-800 dark:border-slate-700">
           <div className="flex items-center gap-1.5 mb-2">
-            <svg className="w-3.5 h-3.5 text-gray-500" viewBox="0 0 16 16" fill="currentColor">
+            <svg
+              className="w-3.5 h-3.5 text-gray-500 dark:text-gray-400"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+            >
               <path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25Zm1.75-.25a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V2.75a.25.25 0 0 0-.25-.25ZM7.25 8a.75.75 0 0 1-.22.53l-2.25 2.25a.75.75 0 1 1-1.06-1.06L5.44 8 3.72 6.28a.75.75 0 1 1 1.06-1.06l2.25 2.25c.141.14.22.331.22.53Zm1.5 1.5h3a.75.75 0 0 1 0 1.5h-3a.75.75 0 0 1 0-1.5Z" />
             </svg>
-            <span className="text-xs font-semibold text-gray-700">Clone via proxy</span>
+            <span className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+              Clone via proxy
+            </span>
           </div>
-          <div className="flex items-center gap-2 px-2 py-1.5 border border-gray-300 rounded font-mono text-xs text-gray-700 bg-gray-50">
+          <div className="flex items-center gap-2 px-2 py-1.5 border border-gray-300 rounded font-mono text-xs text-gray-700 bg-gray-50 dark:bg-slate-700 dark:border-slate-600 dark:text-gray-300">
             <span className="flex-1 truncate">{cloneUrl}</span>
             <button
               onClick={copy}
-              className="shrink-0 text-gray-400 hover:text-gray-700 transition-colors"
+              className="shrink-0 text-gray-400 hover:text-gray-700 transition-colors dark:text-gray-500 dark:hover:text-gray-300"
             >
               {copied ? (
-                <svg className="w-4 h-4 text-green-600" viewBox="0 0 16 16" fill="currentColor">
+                <svg
+                  className="w-4 h-4 text-green-600 dark:text-green-400"
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                >
                   <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z" />
                 </svg>
               ) : (
@@ -86,7 +96,9 @@ function CloneButton({ cloneUrl }: { cloneUrl: string }) {
               )}
             </button>
           </div>
-          <p className="mt-2 text-xs text-gray-400">Use Git or run this in your terminal 👍</p>
+          <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+            Use Git or run this in your terminal 👍
+          </p>
         </div>
       )}
     </div>
@@ -199,23 +211,26 @@ function AddRuleModal({
     }
   }
 
+  const inputClass =
+    'w-full border border-gray-300 rounded px-3 py-1.5 text-sm dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200'
+  const labelClass = 'block text-sm font-medium text-gray-700 mb-1 dark:text-gray-300'
+
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-md p-6 space-y-4">
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 dark:bg-black/60">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-md p-6 space-y-4 dark:bg-slate-800">
         <div className="flex items-center justify-between">
-          <h3 className="text-lg font-semibold text-gray-800">Add Rule</h3>
+          <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200">Add Rule</h3>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 text-xl leading-none"
+            className="text-gray-400 hover:text-gray-600 text-xl leading-none dark:text-gray-500 dark:hover:text-gray-300"
           >
             ×
           </button>
         </div>
 
         <div className="space-y-3">
-          {/* Rule type */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Rule type</label>
+            <label className={labelClass}>Rule type</label>
             <div className="flex gap-3">
               {(['ALLOW', 'DENY'] as const).map((a) => (
                 <label key={a} className="flex items-center gap-1.5 cursor-pointer">
@@ -227,7 +242,11 @@ function AddRuleModal({
                     className="accent-blue-600"
                   />
                   <span
-                    className={`text-sm font-medium ${a === 'ALLOW' ? 'text-green-700' : 'text-red-700'}`}
+                    className={`text-sm font-medium ${
+                      a === 'ALLOW'
+                        ? 'text-green-700 dark:text-green-400'
+                        : 'text-red-700 dark:text-red-400'
+                    }`}
                   >
                     {a}
                   </span>
@@ -236,13 +255,12 @@ function AddRuleModal({
             </div>
           </div>
 
-          {/* Match target */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Match by</label>
+            <label className={labelClass}>Match by</label>
             <select
               value={form.targetType}
               onChange={(e) => set('targetType', e.target.value as TargetType)}
-              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+              className={inputClass}
             >
               <option value="slug">Slug (/owner/repo)</option>
               <option value="owner">Owner / org</option>
@@ -250,13 +268,12 @@ function AddRuleModal({
             </select>
           </div>
 
-          {/* Pattern type + Pattern */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Match type</label>
+            <label className={labelClass}>Match type</label>
             <select
               value={form.patternType}
               onChange={(e) => handlePatternTypeChange(e.target.value as PatternType)}
-              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+              className={inputClass}
             >
               <option value="LITERAL">Literal — exact match</option>
               <option value="GLOB">Glob — wildcard (* / **)</option>
@@ -264,7 +281,7 @@ function AddRuleModal({
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Pattern</label>
+            <label className={labelClass}>Pattern</label>
             <input
               type="text"
               value={form.pattern}
@@ -288,13 +305,17 @@ function AddRuleModal({
                         ? 'myorg'
                         : 'myrepo'
               }
-              className={`w-full border rounded px-3 py-1.5 text-sm font-mono ${
-                regexError ? 'border-amber-400' : 'border-gray-300'
+              className={`w-full border rounded px-3 py-1.5 text-sm font-mono dark:bg-slate-700 dark:text-gray-200 ${
+                regexError
+                  ? 'border-amber-400 dark:border-amber-600'
+                  : 'border-gray-300 dark:border-slate-600'
               }`}
             />
-            {regexError && <p className="mt-1 text-xs text-amber-600">⚠ {regexError}</p>}
+            {regexError && (
+              <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">⚠ {regexError}</p>
+            )}
             {form.targetType === 'slug' && (
-              <p className="mt-1 text-xs text-gray-400">
+              <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
                 Slug rules match the full URL path — must start with{' '}
                 <code className="font-mono">/</code>, e.g.{' '}
                 <code className="font-mono">/myorg/myrepo</code>.
@@ -302,13 +323,12 @@ function AddRuleModal({
             )}
           </div>
 
-          {/* Provider */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Provider</label>
+            <label className={labelClass}>Provider</label>
             <select
               value={form.provider}
               onChange={(e) => set('provider', e.target.value)}
-              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+              className={inputClass}
             >
               <option value="">— All providers (applies to any) —</option>
               {providers.map((p) => (
@@ -319,13 +339,12 @@ function AddRuleModal({
             </select>
           </div>
 
-          {/* Operation */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Operation</label>
+            <label className={labelClass}>Operation</label>
             <select
               value={form.operation}
               onChange={(e) => set('operation', e.target.value as AddRuleForm['operation'])}
-              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+              className={inputClass}
             >
               <option value="BOTH">Push &amp; Fetch</option>
               <option value="PUSH">Push only</option>
@@ -333,29 +352,28 @@ function AddRuleModal({
             </select>
           </div>
 
-          {/* Rule order */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Priority order</label>
+            <label className={labelClass}>Priority order</label>
             <input
               type="number"
               value={form.ruleOrder}
               onChange={(e) => set('ruleOrder', Number(e.target.value))}
               min={1}
-              className="w-full border border-gray-300 rounded px-3 py-1.5 text-sm"
+              className={inputClass}
             />
-            <p className="mt-1 text-xs text-gray-400">
+            <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
               Lower numbers are evaluated first. Default is 100. Deny rules always override allow
               rules regardless of order.
             </p>
           </div>
         </div>
 
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
 
         <div className="flex justify-end gap-2 pt-1">
           <button
             onClick={onClose}
-            className="px-4 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50"
+            className="px-4 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 dark:border-slate-600 dark:text-gray-300 dark:hover:bg-gray-700"
           >
             Cancel
           </button>
@@ -417,11 +435,11 @@ export function Repos() {
       )}
 
       <div className="flex items-baseline gap-3">
-        <h2 className="text-lg font-semibold text-gray-800">Repositories</h2>
+        <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200">Repositories</h2>
       </div>
 
       {/* Tabs */}
-      <div className="flex items-center justify-between border-b border-gray-200">
+      <div className="flex items-center justify-between border-b border-gray-200 dark:border-slate-700">
         <div className="flex gap-2">
           {(['active', 'rules'] as Tab[]).map((t) => (
             <button
@@ -429,8 +447,8 @@ export function Repos() {
               onClick={() => setTab(t)}
               className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
                 tab === t
-                  ? 'border-blue-600 text-blue-700'
-                  : 'border-transparent text-gray-500 hover:text-gray-700'
+                  ? 'border-blue-600 text-blue-700 dark:text-blue-400'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'
               }`}
             >
               {t === 'active' ? 'Active' : 'Rules'}
@@ -447,13 +465,13 @@ export function Repos() {
         )}
       </div>
 
-      {loading && <div className="text-sm text-gray-400">Loading…</div>}
+      {loading && <div className="text-sm text-gray-400 dark:text-gray-500">Loading…</div>}
 
       {/* Active repos tab */}
       {!loading && tab === 'active' && (
         <>
           {activeRepos.length === 0 ? (
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-400 dark:text-gray-500">
               No repo activity recorded yet. Push or fetch through the proxy to populate this view.
             </p>
           ) : (
@@ -461,30 +479,36 @@ export function Repos() {
               {activeRepos.map((repo) => (
                 <div
                   key={`${repo.provider}/${repo.owner}/${repo.repoName}`}
-                  className="bg-white rounded-lg shadow border border-gray-200 px-6 py-4 flex items-center justify-between"
+                  className="bg-white rounded-lg shadow border border-gray-200 px-6 py-4 flex items-center justify-between dark:bg-slate-800 dark:border-slate-700"
                 >
                   <div>
-                    <div className="text-xs text-gray-400 mb-0.5">
+                    <div className="text-xs text-gray-400 mb-0.5 dark:text-gray-500">
                       {providers.find((p) => p.id === repo.provider)?.name ?? repo.provider}
                     </div>
-                    <div className="font-semibold text-gray-800">
+                    <div className="font-semibold text-gray-800 dark:text-gray-200">
                       {repo.owner}/{repo.repoName}
                     </div>
                   </div>
                   <div className="flex items-center gap-6">
-                    <div className="flex gap-6 text-sm text-gray-600">
+                    <div className="flex gap-6 text-sm text-gray-600 dark:text-gray-400">
                       <div className="text-center">
-                        <div className="font-semibold text-gray-900">{repo.pushCount}</div>
-                        <div className="text-xs text-gray-400">pushes</div>
+                        <div className="font-semibold text-gray-900 dark:text-gray-100">
+                          {repo.pushCount}
+                        </div>
+                        <div className="text-xs text-gray-400 dark:text-gray-500">pushes</div>
                       </div>
                       <div className="text-center">
-                        <div className="font-semibold text-gray-900">{repo.fetchCount}</div>
-                        <div className="text-xs text-gray-400">fetches</div>
+                        <div className="font-semibold text-gray-900 dark:text-gray-100">
+                          {repo.fetchCount}
+                        </div>
+                        <div className="text-xs text-gray-400 dark:text-gray-500">fetches</div>
                       </div>
                       {repo.blockedFetchCount > 0 && (
                         <div className="text-center">
-                          <div className="font-semibold text-red-600">{repo.blockedFetchCount}</div>
-                          <div className="text-xs text-red-400">blocked</div>
+                          <div className="font-semibold text-red-600 dark:text-red-400">
+                            {repo.blockedFetchCount}
+                          </div>
+                          <div className="text-xs text-red-400 dark:text-red-500">blocked</div>
                         </div>
                       )}
                     </div>
@@ -503,17 +527,17 @@ export function Repos() {
       {!loading && tab === 'rules' && (
         <>
           {rules.length === 0 ? (
-            <p className="text-sm text-gray-400">No rules configured.</p>
+            <p className="text-sm text-gray-400 dark:text-gray-500">No rules configured.</p>
           ) : (
             <div className="space-y-2">
               {rules.map((rule) => (
                 <div
                   key={rule.id}
-                  className="bg-white rounded-lg border border-gray-200 px-5 py-3 flex items-center justify-between"
+                  className="bg-white rounded-lg border border-gray-200 px-5 py-3 flex items-center justify-between dark:bg-slate-800 dark:border-slate-700"
                 >
                   <div className="flex items-center gap-3 min-w-0">
                     <span
-                      className="text-xs w-8 text-center text-gray-400 font-mono shrink-0"
+                      className="text-xs w-8 text-center text-gray-400 font-mono shrink-0 dark:text-gray-500"
                       title="Priority order — lower runs first"
                     >
                       #{rule.ruleOrder}
@@ -521,29 +545,29 @@ export function Repos() {
                     <span
                       className={`text-xs px-2 py-0.5 rounded-full font-medium shrink-0 ${
                         rule.access === 'ALLOW'
-                          ? 'bg-green-100 text-green-800 border border-green-300'
-                          : 'bg-red-100 text-red-800 border border-red-300'
+                          ? 'bg-green-100 text-green-800 border border-green-300 dark:bg-green-900/30 dark:text-green-300 dark:border-green-700'
+                          : 'bg-red-100 text-red-800 border border-red-300 dark:bg-red-900/30 dark:text-red-300 dark:border-red-700'
                       }`}
                     >
                       {rule.access}
                     </span>
                     <div className="flex flex-col min-w-0">
                       <div className="flex items-center gap-1.5">
-                        <span className="text-xs text-gray-400 shrink-0">
+                        <span className="text-xs text-gray-400 shrink-0 dark:text-gray-500">
                           {(rule.target ?? 'SLUG').toLowerCase()}:
                         </span>
-                        <span className="font-mono text-sm text-gray-800 truncate">
+                        <span className="font-mono text-sm text-gray-800 truncate dark:text-gray-200">
                           {rule.value ?? '*'}
                         </span>
                       </div>
                       <div className="flex items-center gap-2 mt-0.5">
-                        <span className="text-xs text-gray-400">
+                        <span className="text-xs text-gray-400 dark:text-gray-500">
                           {(rule.matchType ?? 'GLOB').toLowerCase()}
                         </span>
-                        <span className="text-xs text-gray-300">·</span>
-                        <span className="text-xs text-gray-400">
+                        <span className="text-xs text-gray-300 dark:text-gray-600">·</span>
+                        <span className="text-xs text-gray-400 dark:text-gray-500">
                           provider:{' '}
-                          <span className="text-gray-600">
+                          <span className="text-gray-600 dark:text-gray-300">
                             {rule.provider
                               ? (providers.find((p) => p.id === rule.provider)?.name ??
                                 rule.provider)
@@ -551,14 +575,16 @@ export function Repos() {
                           </span>
                         </span>
                         {rule.description && (
-                          <span className="text-xs text-gray-400">— {rule.description}</span>
+                          <span className="text-xs text-gray-400 dark:text-gray-500">
+                            — {rule.description}
+                          </span>
                         )}
                       </div>
                     </div>
                   </div>
                   <div className="flex flex-col items-end gap-1 shrink-0">
                     <span
-                      className="text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-600 font-mono border border-gray-200 cursor-help"
+                      className="text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-600 font-mono border border-gray-200 cursor-help dark:bg-slate-700 dark:text-gray-300 dark:border-slate-600"
                       title={
                         rule.operation === 'FETCH'
                           ? 'git clone / git fetch'
@@ -569,14 +595,16 @@ export function Repos() {
                     >
                       {rule.operation === 'BOTH' ? 'PUSH & FETCH' : rule.operation}
                     </span>
-                    <span className="text-xs text-gray-400">
+                    <span className="text-xs text-gray-400 dark:text-gray-500">
                       {rule.source === 'CONFIG' ? 'config' : 'local'}
                     </span>
-                    {!rule.enabled && <span className="text-xs text-amber-500">disabled</span>}
+                    {!rule.enabled && (
+                      <span className="text-xs text-amber-500 dark:text-amber-400">disabled</span>
+                    )}
                     {rule.source === 'DB' && (
                       <button
                         onClick={() => deleteRule(rule.id)}
-                        className="text-xs text-red-500 hover:text-red-700"
+                        className="text-xs text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
                       >
                         Delete
                       </button>

--- a/fogwall-dashboard/frontend/src/pages/UserDetail.tsx
+++ b/fogwall-dashboard/frontend/src/pages/UserDetail.tsx
@@ -33,11 +33,9 @@ interface UserDetailProps {
 
 type Tab = 'overview' | 'pushes' | 'permissions'
 
-// ── Sub-components ───────────────────────────────────────────────────────────
-
 function LockedBadge({ source }: { source: string }) {
   return (
-    <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-600">
+    <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-600 dark:bg-blue-900/30 dark:text-blue-300">
       locked ({source})
     </span>
   )
@@ -45,11 +43,23 @@ function LockedBadge({ source }: { source: string }) {
 
 function VerifiedBadge() {
   return (
-    <span className="inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-600">
+    <span className="inline-flex items-center rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-600 dark:bg-green-900/30 dark:text-green-300">
       verified
     </span>
   )
 }
+
+const modalClass =
+  'fixed inset-0 z-50 flex items-center justify-center bg-black/40 dark:bg-black/60'
+const modalPanelClass = 'w-full max-w-sm rounded-lg bg-white p-6 shadow-xl dark:bg-slate-800'
+const modalTitleClass = 'text-base font-semibold text-gray-800 mb-4 dark:text-gray-200'
+const labelClass = 'block text-xs font-medium text-gray-600 mb-1 dark:text-gray-400'
+const inputClass =
+  'w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200'
+const cancelBtnClass =
+  'px-3 py-1.5 rounded border border-gray-200 text-xs text-gray-600 hover:bg-gray-50 dark:border-slate-600 dark:text-gray-400 dark:hover:bg-gray-700'
+const submitBtnClass =
+  'px-3 py-1.5 rounded bg-slate-700 text-white text-xs hover:bg-slate-800 disabled:opacity-50'
 
 function AddEmailModal({
   username,
@@ -80,9 +90,9 @@ function AddEmailModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
-        <h3 className="text-base font-semibold text-gray-800 mb-4">Add Email</h3>
+    <div className={modalClass}>
+      <div className={modalPanelClass}>
+        <h3 className={modalTitleClass}>Add Email</h3>
         <form onSubmit={handleSubmit} className="space-y-3">
           <input
             required
@@ -90,22 +100,14 @@ function AddEmailModal({
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="user@example.com"
-            className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none"
+            className={inputClass}
           />
-          {error && <p className="text-xs text-red-500">{error}</p>}
+          {error && <p className="text-xs text-red-500 dark:text-red-400">{error}</p>}
           <div className="flex justify-end gap-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-3 py-1.5 rounded border border-gray-200 text-xs text-gray-600 hover:bg-gray-50"
-            >
+            <button type="button" onClick={onClose} className={cancelBtnClass}>
               Cancel
             </button>
-            <button
-              type="submit"
-              disabled={submitting}
-              className="px-3 py-1.5 rounded bg-slate-700 text-white text-xs hover:bg-slate-800 disabled:opacity-50"
-            >
+            <button type="submit" disabled={submitting} className={submitBtnClass}>
               {submitting ? 'Adding…' : 'Add'}
             </button>
           </div>
@@ -155,18 +157,18 @@ function AddScmIdentityModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
-        <h3 className="text-base font-semibold text-gray-800 mb-4">Add SCM Identity</h3>
+    <div className={modalClass}>
+      <div className={modalPanelClass}>
+        <h3 className={modalTitleClass}>Add SCM Identity</h3>
         <form onSubmit={handleSubmit} className="space-y-3">
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Provider</label>
+            <label className={labelClass}>Provider</label>
             <select
               required
               value={provider}
               onChange={(e) => setProvider(e.target.value)}
               disabled={providers.length === 0}
-              className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none disabled:bg-gray-50 disabled:text-gray-400"
+              className={`${inputClass} disabled:opacity-50`}
             >
               {providers.length === 0 && <option value="">Loading…</option>}
               {providers.map((p) => (
@@ -177,29 +179,21 @@ function AddScmIdentityModal({
             </select>
           </div>
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">SCM Username</label>
+            <label className={labelClass}>SCM Username</label>
             <input
               required
               value={scmUsername}
               onChange={(e) => setScmUsername(e.target.value)}
               placeholder="github-handle"
-              className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none"
+              className={inputClass}
             />
           </div>
-          {error && <p className="text-xs text-red-500">{error}</p>}
+          {error && <p className="text-xs text-red-500 dark:text-red-400">{error}</p>}
           <div className="flex justify-end gap-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-3 py-1.5 rounded border border-gray-200 text-xs text-gray-600 hover:bg-gray-50"
-            >
+            <button type="button" onClick={onClose} className={cancelBtnClass}>
               Cancel
             </button>
-            <button
-              type="submit"
-              disabled={submitting}
-              className="px-3 py-1.5 rounded bg-slate-700 text-white text-xs hover:bg-slate-800 disabled:opacity-50"
-            >
+            <button type="submit" disabled={submitting} className={submitBtnClass}>
               {submitting ? 'Adding…' : 'Add'}
             </button>
           </div>
@@ -235,17 +229,16 @@ function ResetPasswordModal({ username, onClose }: { username: string; onClose: 
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
-        <h3 className="text-base font-semibold text-gray-800 mb-4">Reset Password — {username}</h3>
+    <div className={modalClass}>
+      <div className={modalPanelClass}>
+        <h3 className={modalTitleClass}>Reset Password — {username}</h3>
         {done ? (
           <div className="space-y-3">
-            <p className="text-sm text-green-600">Password updated successfully.</p>
+            <p className="text-sm text-green-600 dark:text-green-400">
+              Password updated successfully.
+            </p>
             <div className="flex justify-end">
-              <button
-                onClick={onClose}
-                className="px-3 py-1.5 rounded bg-slate-700 text-white text-xs"
-              >
+              <button onClick={onClose} className={submitBtnClass}>
                 Close
               </button>
             </div>
@@ -253,41 +246,31 @@ function ResetPasswordModal({ username, onClose }: { username: string; onClose: 
         ) : (
           <form onSubmit={handleSubmit} className="space-y-3">
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">New Password</label>
+              <label className={labelClass}>New Password</label>
               <input
                 required
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none"
+                className={inputClass}
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">
-                Confirm Password
-              </label>
+              <label className={labelClass}>Confirm Password</label>
               <input
                 required
                 type="password"
                 value={confirm}
                 onChange={(e) => setConfirm(e.target.value)}
-                className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none"
+                className={inputClass}
               />
             </div>
-            {error && <p className="text-xs text-red-500">{error}</p>}
+            {error && <p className="text-xs text-red-500 dark:text-red-400">{error}</p>}
             <div className="flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={onClose}
-                className="px-3 py-1.5 rounded border border-gray-200 text-xs text-gray-600 hover:bg-gray-50"
-              >
+              <button type="button" onClick={onClose} className={cancelBtnClass}>
                 Cancel
               </button>
-              <button
-                type="submit"
-                disabled={submitting}
-                className="px-3 py-1.5 rounded bg-slate-700 text-white text-xs hover:bg-slate-800 disabled:opacity-50"
-              >
+              <button type="submit" disabled={submitting} className={submitBtnClass}>
                 {submitting ? 'Saving…' : 'Update Password'}
               </button>
             </div>
@@ -359,6 +342,9 @@ function OverviewTab({
     }
   }
 
+  const listClass =
+    'divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white dark:bg-slate-800 dark:border-slate-700 dark:divide-gray-700'
+
   return (
     <div className="space-y-6">
       {showAddEmail && (
@@ -382,24 +368,28 @@ function OverviewTab({
       {/* Emails */}
       <section className="space-y-2">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-semibold text-gray-700">Email Addresses</h3>
+          <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+            Email Addresses
+          </h3>
           {isAdmin && (
             <button
               onClick={() => setShowAddEmail(true)}
-              className="text-xs text-slate-600 hover:text-slate-800"
+              className="text-xs text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
             >
               + Add
             </button>
           )}
         </div>
         {user.emails.length === 0 ? (
-          <p className="text-sm text-gray-400 italic">No email addresses registered.</p>
+          <p className="text-sm text-gray-400 italic dark:text-gray-500">
+            No email addresses registered.
+          </p>
         ) : (
-          <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white">
+          <ul className={listClass}>
             {user.emails.map((entry: EmailEntry) => (
               <li key={entry.email} className="flex items-center justify-between px-4 py-3 text-sm">
                 <span className="flex items-center gap-2">
-                  <span className="text-gray-800">{entry.email}</span>
+                  <span className="text-gray-800 dark:text-gray-200">{entry.email}</span>
                   {entry.verified && <VerifiedBadge />}
                   {entry.locked && <LockedBadge source={entry.source} />}
                 </span>
@@ -407,7 +397,7 @@ function OverviewTab({
                   <button
                     onClick={() => handleRemoveEmail(entry.email)}
                     disabled={deletingEmail === entry.email}
-                    className="text-red-400 text-xs hover:text-red-600 disabled:opacity-40"
+                    className="text-red-400 text-xs hover:text-red-600 disabled:opacity-40 dark:text-red-500 dark:hover:text-red-300"
                   >
                     {deletingEmail === entry.email ? '…' : 'Remove'}
                   </button>
@@ -421,30 +411,32 @@ function OverviewTab({
       {/* SCM Identities */}
       <section className="space-y-2">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-semibold text-gray-700">SCM Identities</h3>
+          <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">SCM Identities</h3>
           {isAdmin && (
             <button
               onClick={() => setShowAddScm(true)}
-              className="text-xs text-slate-600 hover:text-slate-800"
+              className="text-xs text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
             >
               + Add
             </button>
           )}
         </div>
         {user.scmIdentities.length === 0 ? (
-          <p className="text-sm text-gray-400 italic">No SCM identities registered.</p>
+          <p className="text-sm text-gray-400 italic dark:text-gray-500">
+            No SCM identities registered.
+          </p>
         ) : (
-          <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white">
+          <ul className={listClass}>
             {user.scmIdentities.map((id: ScmIdentity) => (
               <li
                 key={`${id.provider}/${id.username}`}
                 className="flex items-center justify-between px-4 py-3 text-sm"
               >
                 <span className="flex items-center gap-2">
-                  <span className="rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+                  <span className="rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-700 dark:text-slate-300">
                     {id.provider}
                   </span>
-                  <span className="text-gray-800">{id.username}</span>
+                  <span className="text-gray-800 dark:text-gray-200">{id.username}</span>
                   {id.verified && <VerifiedBadge />}
                   {id.source === 'config' && <LockedBadge source="config" />}
                 </span>
@@ -452,7 +444,7 @@ function OverviewTab({
                   <button
                     onClick={() => handleRemoveScm(id.provider, id.username)}
                     disabled={deletingScm === `${id.provider}/${id.username}`}
-                    className="text-red-400 text-xs hover:text-red-600 disabled:opacity-40"
+                    className="text-red-400 text-xs hover:text-red-600 disabled:opacity-40 dark:text-red-500 dark:hover:text-red-300"
                   >
                     {deletingScm === `${id.provider}/${id.username}` ? '…' : 'Remove'}
                   </button>
@@ -465,31 +457,37 @@ function OverviewTab({
 
       {/* Push summary */}
       <section className="space-y-2">
-        <h3 className="text-sm font-semibold text-gray-700">Push Summary</h3>
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">Push Summary</h3>
         <div className="flex flex-wrap gap-3">
           {Object.entries(user.pushCounts).length === 0 ? (
-            <p className="text-sm text-gray-400 italic">No push activity recorded.</p>
+            <p className="text-sm text-gray-400 italic dark:text-gray-500">
+              No push activity recorded.
+            </p>
           ) : (
             Object.entries(user.pushCounts).map(([status, count]) => (
               <div key={status} className="flex items-center gap-2">
                 <StatusBadge status={status} />
-                <span className="text-sm font-semibold text-gray-700">{String(count)}</span>
+                <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+                  {String(count)}
+                </span>
               </div>
             ))
           )}
         </div>
       </section>
 
-      {actionError && <p className="text-xs text-red-500">{actionError}</p>}
+      {actionError && <p className="text-xs text-red-500 dark:text-red-400">{actionError}</p>}
 
       {isAdmin && (
-        <section className="border-t border-gray-100 pt-4">
-          <h3 className="text-sm font-semibold text-gray-700 mb-2">Account Actions</h3>
+        <section className="border-t border-gray-100 pt-4 dark:border-slate-700">
+          <h3 className="text-sm font-semibold text-gray-700 mb-2 dark:text-gray-300">
+            Account Actions
+          </h3>
           <div className="flex gap-2">
             {isLocalAuth && (
               <button
                 onClick={() => setShowResetPw(true)}
-                className="px-3 py-1.5 rounded border border-gray-200 text-xs text-gray-600 hover:bg-gray-50"
+                className="px-3 py-1.5 rounded border border-gray-200 text-xs text-gray-600 hover:bg-gray-50 dark:border-slate-600 dark:text-gray-400 dark:hover:bg-gray-700"
               >
                 Reset Password
               </button>
@@ -497,7 +495,7 @@ function OverviewTab({
             <button
               onClick={handleDelete}
               disabled={deleting}
-              className="px-3 py-1.5 rounded border border-red-200 text-xs text-red-600 hover:bg-red-50 disabled:opacity-40"
+              className="px-3 py-1.5 rounded border border-red-200 text-xs text-red-600 hover:bg-red-50 disabled:opacity-40 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/20"
             >
               {deleting ? 'Deleting…' : 'Delete User & Permissions'}
             </button>
@@ -521,41 +519,42 @@ function PushesTab({ username }: { username: string }) {
       .finally(() => setLoading(false))
   }, [username])
 
-  if (loading) return <div className="py-8 text-center text-gray-400 text-sm">Loading…</div>
+  if (loading)
+    return <div className="py-8 text-center text-gray-400 text-sm dark:text-gray-500">Loading…</div>
 
   if (pushes.length === 0)
     return (
-      <p className="text-sm text-gray-400 italic py-8 text-center">
+      <p className="text-sm text-gray-400 italic py-8 text-center dark:text-gray-500">
         No push records found for this user.
       </p>
     )
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white overflow-hidden">
+    <div className="rounded-lg border border-gray-200 bg-white overflow-hidden dark:bg-slate-800 dark:border-slate-700">
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-gray-100 bg-gray-50 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
+          <tr className="border-b border-gray-100 bg-gray-50 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide dark:bg-slate-700/50 dark:border-slate-700 dark:text-gray-400">
             <th className="px-4 py-3">Status</th>
             <th className="px-4 py-3">Repository</th>
             <th className="px-4 py-3">Branch</th>
             <th className="px-4 py-3">Time</th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-100">
+        <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
           {pushes.map((p) => (
             <tr
               key={p.id}
-              className="hover:bg-gray-50 cursor-pointer transition-colors"
+              className="hover:bg-gray-50 cursor-pointer transition-colors dark:hover:bg-gray-700/50"
               onClick={() => navigate(`/push/${p.id}`)}
             >
               <td className="px-4 py-3">
                 <StatusBadge status={p.status} />
               </td>
-              <td className="px-4 py-3 text-gray-700">
+              <td className="px-4 py-3 text-gray-700 dark:text-gray-300">
                 {p.project && p.repoName ? `${p.project}/${p.repoName}` : (p.repoName ?? '—')}
               </td>
-              <td className="px-4 py-3 text-gray-500">{p.branch ?? '—'}</td>
-              <td className="px-4 py-3 text-gray-400">
+              <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{p.branch ?? '—'}</td>
+              <td className="px-4 py-3 text-gray-400 dark:text-gray-500">
                 {p.timestamp ? new Date(p.timestamp).toLocaleString() : '—'}
               </td>
             </tr>
@@ -642,18 +641,18 @@ function AddPermissionModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
-        <h3 className="text-base font-semibold text-gray-800 mb-4">Add Permission</h3>
+    <div className={modalClass}>
+      <div className={modalPanelClass}>
+        <h3 className={modalTitleClass}>Add Permission</h3>
         <form onSubmit={handleSubmit} className="space-y-3">
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Provider</label>
+            <label className={labelClass}>Provider</label>
             <select
               required
               value={provider}
               onChange={(e) => setProvider(e.target.value)}
               disabled={providers.length === 0}
-              className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none disabled:bg-gray-50 disabled:text-gray-400"
+              className={`${inputClass} disabled:opacity-50`}
             >
               {providers.length === 0 && <option value="">Loading…</option>}
               {providers.map((p) => (
@@ -664,22 +663,28 @@ function AddPermissionModal({
             </select>
           </div>
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Path</label>
+            <label className={labelClass}>Path</label>
             <input
               required
               value={path}
               onChange={(e) => handlePathChange(e.target.value)}
               placeholder="/owner/repo"
-              className={`w-full rounded border px-3 py-1.5 text-sm font-mono focus:outline-none ${regexError ? 'border-amber-400 focus:border-amber-500' : 'border-gray-300 focus:border-slate-500'}`}
+              className={`w-full rounded border px-3 py-1.5 text-sm font-mono focus:outline-none dark:bg-slate-700 dark:text-gray-200 ${
+                regexError
+                  ? 'border-amber-400 focus:border-amber-500 dark:border-amber-600'
+                  : 'border-gray-300 focus:border-slate-500 dark:border-slate-600'
+              }`}
             />
-            {regexError && <p className="mt-1 text-xs text-amber-600">⚠ {regexError}</p>}
+            {regexError && (
+              <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">⚠ {regexError}</p>
+            )}
           </div>
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Path Type</label>
+            <label className={labelClass}>Path Type</label>
             <select
               value={pathType}
               onChange={(e) => handlePathTypeChange(e.target.value as typeof pathType)}
-              className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none"
+              className={inputClass}
             >
               <option value="LITERAL">Literal — exact match</option>
               <option value="GLOB">Glob — wildcard (* / **)</option>
@@ -687,11 +692,11 @@ function AddPermissionModal({
             </select>
           </div>
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Grant</label>
+            <label className={labelClass}>Grant</label>
             <select
               value={grant}
               onChange={(e) => setGrant(e.target.value as typeof grant)}
-              className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none"
+              className={inputClass}
             >
               <option value="PUSH_AND_REVIEW">Push and review</option>
               <option value="PUSH">Push only</option>
@@ -699,20 +704,12 @@ function AddPermissionModal({
               <option value="SELF_CERTIFY">Self-certify</option>
             </select>
           </div>
-          {error && <p className="text-xs text-red-500">{error}</p>}
+          {error && <p className="text-xs text-red-500 dark:text-red-400">{error}</p>}
           <div className="flex justify-end gap-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-3 py-1.5 rounded border border-gray-200 text-xs text-gray-600 hover:bg-gray-50"
-            >
+            <button type="button" onClick={onClose} className={cancelBtnClass}>
               Cancel
             </button>
-            <button
-              type="submit"
-              disabled={submitting}
-              className="px-3 py-1.5 rounded bg-slate-700 text-white text-xs hover:bg-slate-800 disabled:opacity-50"
-            >
+            <button type="submit" disabled={submitting} className={submitBtnClass}>
               {submitting ? 'Adding…' : 'Add'}
             </button>
           </div>
@@ -754,7 +751,8 @@ function PermissionsTab({ username, isAdmin }: { username: string; isAdmin: bool
     }
   }
 
-  if (loading) return <div className="py-8 text-center text-gray-400 text-sm">Loading…</div>
+  if (loading)
+    return <div className="py-8 text-center text-gray-400 text-sm dark:text-gray-500">Loading…</div>
 
   return (
     <div className="space-y-4">
@@ -767,14 +765,14 @@ function PermissionsTab({ username, isAdmin }: { username: string; isAdmin: bool
       )}
 
       {permissions.length === 0 ? (
-        <p className="text-sm text-gray-400 italic py-4">
+        <p className="text-sm text-gray-400 italic py-4 dark:text-gray-500">
           No permissions configured for this user.
         </p>
       ) : (
-        <div className="rounded-lg border border-gray-200 bg-white overflow-hidden">
+        <div className="rounded-lg border border-gray-200 bg-white overflow-hidden dark:bg-slate-800 dark:border-slate-700">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-gray-100 bg-gray-50 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
+              <tr className="border-b border-gray-100 bg-gray-50 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide dark:bg-slate-700/50 dark:border-slate-700 dark:text-gray-400">
                 <th className="px-4 py-3">Provider</th>
                 <th className="px-4 py-3">Type</th>
                 <th className="px-4 py-3">Path</th>
@@ -783,18 +781,23 @@ function PermissionsTab({ username, isAdmin }: { username: string; isAdmin: bool
                 {isAdmin && <th className="px-4 py-3" />}
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-100">
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
               {permissions.map((p) => (
-                <tr key={p.id} className="hover:bg-gray-50 transition-colors">
+                <tr
+                  key={p.id}
+                  className="hover:bg-gray-50 transition-colors dark:hover:bg-gray-700/50"
+                >
                   <td className="px-4 py-3">
-                    <span className="rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+                    <span className="rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-700 dark:text-slate-300">
                       {p.provider}
                     </span>
                   </td>
                   <td className="px-4 py-3">
                     <PathTypeBadge matchType={p.matchType} />
                   </td>
-                  <td className="px-4 py-3 font-mono text-gray-700 text-xs">{p.value}</td>
+                  <td className="px-4 py-3 font-mono text-gray-700 text-xs dark:text-gray-300">
+                    {p.value}
+                  </td>
                   <td className="px-4 py-3">
                     <OperationsBadge operations={p.grant} />
                   </td>
@@ -802,7 +805,7 @@ function PermissionsTab({ username, isAdmin }: { username: string; isAdmin: bool
                     {p.source === 'CONFIG' ? (
                       <LockedBadge source="config" />
                     ) : (
-                      <span className="text-xs text-gray-400">local</span>
+                      <span className="text-xs text-gray-400 dark:text-gray-500">local</span>
                     )}
                   </td>
                   {isAdmin && (
@@ -811,7 +814,7 @@ function PermissionsTab({ username, isAdmin }: { username: string; isAdmin: bool
                         <button
                           onClick={() => handleDelete(p.id)}
                           disabled={deletingId === p.id}
-                          className="text-red-400 text-xs hover:text-red-600 disabled:opacity-40"
+                          className="text-red-400 text-xs hover:text-red-600 disabled:opacity-40 dark:text-red-500 dark:hover:text-red-300"
                         >
                           {deletingId === p.id ? '…' : 'Remove'}
                         </button>
@@ -825,7 +828,7 @@ function PermissionsTab({ username, isAdmin }: { username: string; isAdmin: bool
         </div>
       )}
 
-      {actionError && <p className="text-xs text-red-500">{actionError}</p>}
+      {actionError && <p className="text-xs text-red-500 dark:text-red-400">{actionError}</p>}
 
       {isAdmin && (
         <button
@@ -837,17 +840,23 @@ function PermissionsTab({ username, isAdmin }: { username: string; isAdmin: bool
       )}
 
       <div className="pt-2 space-y-2">
-        <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide">Coming soon</p>
+        <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide dark:text-gray-500">
+          Coming soon
+        </p>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-3 space-y-1 opacity-70">
-            <p className="text-sm font-medium text-gray-500">Time-bound permissions</p>
-            <p className="text-xs text-gray-400">
+          <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-3 space-y-1 opacity-70 dark:bg-slate-800 dark:border-slate-700">
+            <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
+              Time-bound permissions
+            </p>
+            <p className="text-xs text-gray-400 dark:text-gray-500">
               Grant access valid only within a date range, e.g. valid 2025-01-01 → 2025-12-31.
             </p>
           </div>
-          <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-3 space-y-1 opacity-70">
-            <p className="text-sm font-medium text-gray-500">Just-in-time permissions</p>
-            <p className="text-xs text-gray-400">
+          <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-3 space-y-1 opacity-70 dark:bg-slate-800 dark:border-slate-700">
+            <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
+              Just-in-time permissions
+            </p>
+            <p className="text-xs text-gray-400 dark:text-gray-500">
               Self-service, short-lived access requests with automatic expiry and audit trail.
             </p>
           </div>
@@ -856,8 +865,6 @@ function PermissionsTab({ username, isAdmin }: { username: string; isAdmin: bool
     </div>
   )
 }
-
-// ── Main component ───────────────────────────────────────────────────────────
 
 export function UserDetail({ authProvider, currentUser }: UserDetailProps) {
   const { username } = useParams<{ username: string }>()
@@ -883,10 +890,14 @@ export function UserDetail({ authProvider, currentUser }: UserDetailProps) {
   }, [loadUser])
 
   if (loading)
-    return <div className="max-w-3xl mx-auto px-4 py-16 text-center text-gray-400">Loading…</div>
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-16 text-center text-gray-400 dark:text-gray-500">
+        Loading…
+      </div>
+    )
   if (error || !user)
     return (
-      <div className="max-w-3xl mx-auto px-4 py-16 text-center text-red-500">
+      <div className="max-w-3xl mx-auto px-4 py-16 text-center text-red-500 dark:text-red-400">
         {error ?? 'User not found'}
       </div>
     )
@@ -903,21 +914,21 @@ export function UserDetail({ authProvider, currentUser }: UserDetailProps) {
       <div className="flex items-center gap-3">
         <button
           onClick={() => navigate('/users')}
-          className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+          className="text-xs text-gray-400 hover:text-gray-600 transition-colors dark:text-gray-500 dark:hover:text-gray-300"
         >
           ← Users
         </button>
-        <span className="text-gray-300">/</span>
-        <h2 className="text-lg font-semibold text-gray-800">{user.username}</h2>
+        <span className="text-gray-300 dark:text-gray-600">/</span>
+        <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200">{user.username}</h2>
         {!isLocalAuth && (
-          <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500">
+          <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500 dark:bg-slate-700 dark:text-slate-400">
             {authProvider}
           </span>
         )}
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-1 border-b border-gray-200">
+      <div className="flex gap-1 border-b border-gray-200 dark:border-slate-700">
         {tabs.map((t) => (
           <button
             key={t.id}
@@ -925,8 +936,8 @@ export function UserDetail({ authProvider, currentUser }: UserDetailProps) {
             className={
               'px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ' +
               (tab === t.id
-                ? 'border-slate-700 text-slate-800'
-                : 'border-transparent text-gray-500 hover:text-gray-700')
+                ? 'border-slate-700 text-slate-800 dark:border-slate-400 dark:text-slate-200'
+                : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300')
             }
           >
             {t.label}

--- a/fogwall-dashboard/frontend/src/pages/Users.tsx
+++ b/fogwall-dashboard/frontend/src/pages/Users.tsx
@@ -17,25 +17,29 @@ const PUSH_STAT_CONFIG: {
     status: 'FORWARDED',
     label: 'Forwarded',
     icon: '✓',
-    classes: 'bg-blue-50 text-blue-700 border-blue-200',
+    classes:
+      'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-900/20 dark:text-blue-300 dark:border-blue-700',
   },
   {
     status: 'APPROVED',
     label: 'Approved',
     icon: '✓',
-    classes: 'bg-green-50 text-green-700 border-green-200',
+    classes:
+      'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/20 dark:text-green-300 dark:border-green-700',
   },
   {
     status: 'PENDING',
     label: 'Pending',
     icon: '⊘',
-    classes: 'bg-amber-50 text-amber-700 border-amber-200',
+    classes:
+      'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-900/20 dark:text-amber-300 dark:border-amber-700',
   },
   {
     status: 'REJECTED',
     label: 'Rejected',
     icon: '✗',
-    classes: 'bg-red-50 text-red-700 border-red-200',
+    classes:
+      'bg-red-50 text-red-700 border-red-200 dark:bg-red-900/20 dark:text-red-300 dark:border-red-700',
   },
 ]
 
@@ -87,41 +91,45 @@ function AddUserModal({ onClose, onCreated }: { onClose: () => void; onCreated: 
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-      <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
-        <h3 className="text-base font-semibold text-gray-800 mb-4">Add User</h3>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 dark:bg-black/60">
+      <div className="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl dark:bg-slate-800">
+        <h3 className="text-base font-semibold text-gray-800 mb-4 dark:text-gray-200">Add User</h3>
         <form onSubmit={handleSubmit} className="space-y-3">
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Username</label>
+            <label className="block text-xs font-medium text-gray-600 mb-1 dark:text-gray-400">
+              Username
+            </label>
             <input
               required
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-              className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none"
+              className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200"
             />
           </div>
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Password</label>
+            <label className="block text-xs font-medium text-gray-600 mb-1 dark:text-gray-400">
+              Password
+            </label>
             <input
               required
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none"
+              className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200"
             />
           </div>
           <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">
-              Email <span className="text-gray-400">(optional)</span>
+            <label className="block text-xs font-medium text-gray-600 mb-1 dark:text-gray-400">
+              Email <span className="text-gray-400 dark:text-gray-500">(optional)</span>
             </label>
             <input
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none"
+              className="w-full rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-slate-500 focus:outline-none dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200"
             />
           </div>
-          <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+          <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer dark:text-gray-300">
             <input
               type="checkbox"
               checked={isAdmin}
@@ -130,12 +138,12 @@ function AddUserModal({ onClose, onCreated }: { onClose: () => void; onCreated: 
             />
             Grant admin role
           </label>
-          {error && <p className="text-xs text-red-500">{error}</p>}
+          {error && <p className="text-xs text-red-500 dark:text-red-400">{error}</p>}
           <div className="flex justify-end gap-2 pt-2">
             <button
               type="button"
               onClick={onClose}
-              className="px-3 py-1.5 rounded border border-gray-200 text-xs text-gray-600 hover:bg-gray-50"
+              className="px-3 py-1.5 rounded border border-gray-200 text-xs text-gray-600 hover:bg-gray-50 dark:border-slate-600 dark:text-gray-400 dark:hover:bg-gray-700"
             >
               Cancel
             </button>
@@ -181,9 +189,17 @@ export function Users({ authProvider }: UsersProps) {
   )
 
   if (loading)
-    return <div className="max-w-5xl mx-auto px-4 py-16 text-center text-gray-400">Loading…</div>
+    return (
+      <div className="max-w-5xl mx-auto px-4 py-16 text-center text-gray-400 dark:text-gray-500">
+        Loading…
+      </div>
+    )
   if (error)
-    return <div className="max-w-5xl mx-auto px-4 py-16 text-center text-red-500">{error}</div>
+    return (
+      <div className="max-w-5xl mx-auto px-4 py-16 text-center text-red-500 dark:text-red-400">
+        {error}
+      </div>
+    )
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-6 space-y-4">
@@ -191,7 +207,7 @@ export function Users({ authProvider }: UsersProps) {
         <AddUserModal onClose={() => setShowAddModal(false)} onCreated={loadUsers} />
       )}
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-gray-800">Users</h2>
+        <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200">Users</h2>
         {isLocalAuth && (
           <button
             onClick={() => setShowAddModal(true)}
@@ -207,16 +223,18 @@ export function Users({ authProvider }: UsersProps) {
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         placeholder="Search by username or email…"
-        className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none"
+        className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200 dark:placeholder-gray-400"
       />
 
       {filtered.length === 0 ? (
-        <p className="text-sm text-gray-400 italic py-8 text-center">No users found.</p>
+        <p className="text-sm text-gray-400 italic py-8 text-center dark:text-gray-500">
+          No users found.
+        </p>
       ) : (
-        <div className="rounded-lg border border-gray-200 bg-white overflow-hidden">
+        <div className="rounded-lg border border-gray-200 bg-white overflow-hidden dark:bg-slate-800 dark:border-slate-700">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-gray-100 bg-gray-50 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
+              <tr className="border-b border-gray-100 bg-gray-50 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide dark:bg-slate-700/50 dark:border-slate-700 dark:text-gray-400">
                 <th className="px-4 py-3">Username</th>
                 <th className="px-4 py-3">Email</th>
                 <th className="px-4 py-3">SCM Identities</th>
@@ -224,26 +242,32 @@ export function Users({ authProvider }: UsersProps) {
                 <th className="px-4 py-3"></th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-100">
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
               {filtered.map((u) => (
                 <tr
                   key={u.username}
-                  className="hover:bg-gray-50 cursor-pointer transition-colors"
+                  className="hover:bg-gray-50 cursor-pointer transition-colors dark:hover:bg-gray-700/50"
                   onClick={() => navigate(`/users/${encodeURIComponent(u.username)}`)}
                 >
-                  <td className="px-4 py-3 font-medium text-gray-800">{u.username}</td>
-                  <td className="px-4 py-3 text-gray-500">
-                    {u.primaryEmail ?? <span className="italic text-gray-300">none</span>}
+                  <td className="px-4 py-3 font-medium text-gray-800 dark:text-gray-200">
+                    {u.username}
+                  </td>
+                  <td className="px-4 py-3 text-gray-500 dark:text-gray-400">
+                    {u.primaryEmail ?? (
+                      <span className="italic text-gray-300 dark:text-gray-600">none</span>
+                    )}
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex flex-wrap gap-1">
                       {u.scmProviders.length === 0 ? (
-                        <span className="italic text-gray-300 text-xs">none</span>
+                        <span className="italic text-gray-300 text-xs dark:text-gray-600">
+                          none
+                        </span>
                       ) : (
                         u.scmProviders.map((p) => (
                           <span
                             key={p}
-                            className="rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600"
+                            className="rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-700 dark:text-slate-300"
                           >
                             {p}
                           </span>
@@ -265,7 +289,7 @@ export function Users({ authProvider }: UsersProps) {
                     </div>
                   </td>
                   <td className="px-4 py-3 text-right">
-                    <span className="text-gray-400 text-xs">›</span>
+                    <span className="text-gray-400 text-xs dark:text-gray-500">›</span>
                   </td>
                 </tr>
               ))}

--- a/fogwall-dashboard/src/main/resources/static/login.html
+++ b/fogwall-dashboard/src/main/resources/static/login.html
@@ -5,9 +5,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>fogwall · sign in</title>
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-    <style>html { font-size: 18px; }</style>
+    <style type="text/tailwindcss">
+      @variant dark (&:where(.dark, .dark *));
+      html { font-size: 18px; }
+    </style>
+    <script>
+      (function () {
+        var stored = localStorage.getItem('fogwall-dark-mode');
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (stored === 'true' || (stored === null && prefersDark)) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
   </head>
-  <body class="bg-gray-100 min-h-screen flex flex-col">
+  <body class="bg-gray-100 dark:bg-gray-900 min-h-screen flex flex-col">
     <header class="bg-slate-800 text-white px-6 py-4 shadow flex items-center justify-between">
       <div class="flex items-center gap-2">
         <svg class="h-8 w-auto" viewBox="0 0 28 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
@@ -29,19 +41,19 @@
     </header>
 
     <main class="flex-1 flex items-center justify-center px-4 py-12">
-      <div class="bg-white rounded-lg shadow border border-gray-200 w-full max-w-sm px-8 py-8">
-        <h2 class="text-lg font-semibold text-gray-800 mb-6">Sign in</h2>
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 w-full max-w-sm px-8 py-8">
+        <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-6">Sign in</h2>
 
-        <div id="msg-logout" class="hidden mb-4 text-sm text-green-700 bg-green-50 border border-green-200 rounded px-3 py-2">
+        <div id="msg-logout" class="hidden mb-4 text-sm text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 rounded px-3 py-2">
           You have been signed out.
         </div>
-        <div id="msg-error" class="hidden mb-4 text-sm text-red-700 bg-red-50 border border-red-200 rounded px-3 py-2">
+        <div id="msg-error" class="hidden mb-4 text-sm text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded px-3 py-2">
           Sign in failed. Check your credentials or contact your administrator.
         </div>
 
         <form id="login-form" method="post" action="/login" class="space-y-4">
           <div>
-            <label for="username" class="block text-sm font-medium text-gray-700 mb-1">Username</label>
+            <label for="username" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Username</label>
             <input
               id="username"
               name="username"
@@ -49,18 +61,18 @@
               autocomplete="username"
               required
               autofocus
-              class="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300"
+              class="w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-700"
             />
           </div>
           <div>
-            <label for="password" class="block text-sm font-medium text-gray-700 mb-1">Password</label>
+            <label for="password" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Password</label>
             <input
               id="password"
               name="password"
               type="password"
               autocomplete="current-password"
               required
-              class="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300"
+              class="w-full border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-700"
             />
           </div>
           <button


### PR DESCRIPTION
## Summary

- Adds a system-preference-aware dark mode toggle to the dashboard nav bar (sun/moon icon)
- User preference persists in `localStorage` under `fogwall-dark-mode`, defaulting to the OS colour scheme on first visit
- diff2html `colorScheme` wired to `ColorSchemeType.DARK/LIGHT` so diffs re-render correctly on toggle
- Structural dark backgrounds use `slate-` instead of neutral `gray-` for a cleaner blue-tinted palette

## Changes

- `useDarkMode` hook — toggles `dark` class on `<html>`, persists to localStorage
- Tailwind v4 `@variant dark` directive enables class-based dark mode
- All pages, components, and `login.html` have `dark:` variants applied
- `dark` prop threaded to `PushDetail` and `PushDiff` for diff2html colour scheme

closes #46