### PR TITLE
chore: rename servletPath/basePath/customPath to pathSuffix throughout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,9 +80,6 @@ allprojects {
     
     repositories {
         mavenCentral()
-        maven {
-            url = 'https://repo.eclipse.org/content/groups/releases/'
-        }
     }
 }
 

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/StoreAndForwardRepositoryResolver.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/StoreAndForwardRepositoryResolver.java
@@ -2,6 +2,7 @@ package com.rbc.fogwall.git;
 
 import com.rbc.fogwall.provider.FogwallProvider;
 import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
 import java.util.Base64;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -90,7 +91,7 @@ public class StoreAndForwardRepositoryResolver implements RepositoryResolver<Htt
         // Fall back to URL userinfo - git embeds user:pass in the request URL
         String requestUrl = req.getRequestURL().toString();
         try {
-            java.net.URI uri = java.net.URI.create(requestUrl);
+            URI uri = java.net.URI.create(requestUrl);
             String userInfo = uri.getUserInfo();
             if (userInfo != null) {
                 int colon = userInfo.indexOf(':');

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/AbstractFogwallProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/AbstractFogwallProvider.java
@@ -11,22 +11,27 @@ public abstract class AbstractFogwallProvider implements FogwallProvider {
     protected final String name;
     protected final String type;
     protected final URI uri;
-    protected final String basePath;
+    protected final String pathSuffix;
 
     /**
-     * Returns the path that the servlet will be mapped to. This is based on the host of the target URL along with an
-     * optional application-wide base path. To configure a {@link FogwallServlet} for proxying, use
-     * {@link #servletMapping()} instead.
+     * Returns the path that the servlet will be mapped to after the default path (this controls routing to the
+     * appropriate servlet or JGit factory). This is based on the host of the target URL along with an optional
+     * application-wide base path. To configure a {@link FogwallServlet} for proxying, use {@link #servletMapping()}
+     * instead.
      *
      * @return The base path that this provider will be mapped to.
      */
     @Override
     public String servletPath() {
         int port = uri.getPort();
+        if (pathSuffix != null && !pathSuffix.isBlank()) {
+            return pathSuffix;
+        }
         boolean defaultPort = port < 0
                 || ("https".equals(uri.getScheme()) && port == 443)
                 || ("http".equals(uri.getScheme()) && port == 80);
-        return defaultPort ? basePath + "/" + uri.getHost() : basePath + "/" + uri.getHost() + ":" + port;
+
+        return defaultPort ? "/" + uri.getHost() : "/" + uri.getHost() + ":" + port;
     }
 
     /**
@@ -64,6 +69,6 @@ public abstract class AbstractFogwallProvider implements FogwallProvider {
                 + name + '\'' + ", type='"
                 + type + '\'' + ", uri="
                 + uri + ", basePath='"
-                + basePath + '\'' + '}';
+                + pathSuffix + '\'' + '}';
     }
 }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/BitbucketProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/BitbucketProvider.java
@@ -44,12 +44,12 @@ public class BitbucketProvider extends AbstractFogwallProvider implements TokenI
     public static final String NAME = "bitbucket";
 
     @Builder
-    public BitbucketProvider(String name, URI uri, String basePath) {
-        super(name != null ? name : NAME, NAME, uri != null ? uri : DEFAULT_URI, basePath);
+    public BitbucketProvider(String name, URI uri, String pathSuffix) {
+        super(name != null ? name : NAME, NAME, uri != null ? uri : DEFAULT_URI, pathSuffix);
     }
 
-    public BitbucketProvider(String basePath) {
-        this(NAME, DEFAULT_URI, basePath);
+    public BitbucketProvider(String pathSuffix) {
+        this(NAME, DEFAULT_URI, pathSuffix);
     }
 
     /**

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/ForgejoProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/ForgejoProvider.java
@@ -1,7 +1,6 @@
 package com.rbc.fogwall.provider;
 
 import java.net.URI;
-import java.util.Map;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
@@ -21,16 +20,17 @@ import tools.jackson.databind.json.JsonMapper;
 @Slf4j
 public class ForgejoProvider extends AbstractFogwallProvider implements TokenIdentityProvider {
 
-    /** Well-known public Forgejo/Gitea hosts, keyed by the reserved config name. */
-    public static final Map<String, URI> WELL_KNOWN = Map.of(
-            "codeberg", URI.create("https://codeberg.org"),
-            "gitea", URI.create("https://gitea.com"));
-
     public static final String TYPE = "forgejo";
 
+    // Codeberg is a FOSS friendly Forgejo provider and is the default that ships with the app
+    // https://gitea.com is also compatible (but is not as FOSS friendly given that it is commercial backed)
+    // Both are equivalent in terms of proxying and API compatibility
+    public static final URI CODEBERG = URI.create("https://codeberg.org");
+    public static final URI GITEA = URI.create("https://gitea.com");
+
     @Builder
-    public ForgejoProvider(String name, URI uri, String basePath) {
-        super(name, TYPE, uri, basePath);
+    public ForgejoProvider(String name, URI uri, String pathSuffix) {
+        super(name, TYPE, uri, pathSuffix);
     }
 
     public String getApiUrl() {

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/GenericProxyProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/GenericProxyProvider.java
@@ -8,8 +8,8 @@ public class GenericProxyProvider extends AbstractFogwallProvider {
     private final int blockedInfoRefsStatus;
 
     @Builder
-    GenericProxyProvider(String name, String type, URI uri, String basePath, Integer blockedInfoRefsStatus) {
-        super(name, type != null ? type : name, uri, basePath);
+    GenericProxyProvider(String name, String type, URI uri, String pathSuffix, Integer blockedInfoRefsStatus) {
+        super(name, type != null ? type : name, uri, pathSuffix);
         this.blockedInfoRefsStatus = blockedInfoRefsStatus != null ? blockedInfoRefsStatus : 403;
     }
 

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/GitHubProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/GitHubProvider.java
@@ -16,12 +16,12 @@ public class GitHubProvider extends AbstractFogwallProvider implements TokenIden
     public static final URI DEFAULT_URI = URI.create("https://github.com");
 
     @Builder
-    public GitHubProvider(String name, URI uri, String basePath) {
-        super(name != null ? name : NAME, NAME, uri != null ? uri : DEFAULT_URI, basePath);
+    public GitHubProvider(String name, URI uri, String pathSuffix) {
+        super(name != null ? name : NAME, NAME, uri != null ? uri : DEFAULT_URI, pathSuffix);
     }
 
-    public GitHubProvider(String basePath) {
-        this(NAME, DEFAULT_URI, basePath);
+    public GitHubProvider(String pathSuffix) {
+        this(NAME, DEFAULT_URI, pathSuffix);
     }
 
     public String getApiUrl() {

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/GitLabProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/GitLabProvider.java
@@ -14,12 +14,12 @@ public class GitLabProvider extends AbstractFogwallProvider implements TokenIden
     public static final String NAME = "gitlab";
 
     @Builder
-    public GitLabProvider(String name, URI uri, String basePath) {
-        super(name != null ? name : NAME, NAME, uri != null ? uri : DEFAULT_URI, basePath);
+    public GitLabProvider(String name, URI uri, String pathSuffix) {
+        super(name != null ? name : NAME, NAME, uri != null ? uri : DEFAULT_URI, pathSuffix);
     }
 
-    public GitLabProvider(String basePath) {
-        this(NAME, DEFAULT_URI, basePath);
+    public GitLabProvider(String pathSuffix) {
+        this(NAME, DEFAULT_URI, pathSuffix);
     }
 
     public String getApiUrl() {

--- a/fogwall-core/src/test/java/com/rbc/fogwall/git/CheckEmptyBranchHookTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/git/CheckEmptyBranchHookTest.java
@@ -8,9 +8,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.PersonIdent;
-import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.*;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.transport.ReceiveCommand;
 import org.eclipse.jgit.transport.ReceivePack;
@@ -163,8 +161,8 @@ class CheckEmptyBranchHookTest {
         // Annotated tags point to a tag object, not a commit directly
         ObjectId c1 = createCommit("Tagged commit");
         // Create an annotated tag via JGit
-        org.eclipse.jgit.lib.ObjectInserter inserter = repo.newObjectInserter();
-        org.eclipse.jgit.lib.TagBuilder tb = new org.eclipse.jgit.lib.TagBuilder();
+        ObjectInserter inserter = repo.newObjectInserter();
+        TagBuilder tb = new TagBuilder();
         tb.setTag("v2.0");
         tb.setObjectId(repo.parseCommit(c1));
         tb.setTagger(new PersonIdent("Dev", "dev@example.com"));

--- a/fogwall-core/src/test/java/com/rbc/fogwall/git/CheckHiddenCommitsHookTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/git/CheckHiddenCommitsHookTest.java
@@ -9,9 +9,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.PersonIdent;
-import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.*;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.transport.ReceiveCommand;
 import org.eclipse.jgit.transport.ReceivePack;
@@ -143,8 +141,8 @@ class CheckHiddenCommitsHookTest {
         RevCommit tagged = createCommit("tagged");
 
         // Create the annotated tag object in the repo
-        org.eclipse.jgit.lib.ObjectInserter inserter = repo.newObjectInserter();
-        org.eclipse.jgit.lib.TagBuilder tb = new org.eclipse.jgit.lib.TagBuilder();
+        ObjectInserter inserter = repo.newObjectInserter();
+        TagBuilder tb = new TagBuilder();
         tb.setTag("v2.0");
         tb.setObjectId(tagged);
         tb.setTagger(new PersonIdent("Dev", "dev@example.com"));

--- a/fogwall-core/src/test/java/com/rbc/fogwall/git/IdentityVerificationHookTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/git/IdentityVerificationHookTest.java
@@ -1,5 +1,6 @@
 package com.rbc.fogwall.git;
 
+import static java.nio.file.Files.writeString;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -10,7 +11,6 @@ import com.rbc.fogwall.provider.GitHubProvider;
 import com.rbc.fogwall.service.PushIdentityResolver;
 import com.rbc.fogwall.user.UserEntry;
 import java.io.File;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -47,7 +47,7 @@ class IdentityVerificationHookTest {
 
     private RevCommit createCommit(String message, String authorEmail) throws Exception {
         File f = new File(tempDir.toFile(), UUID.randomUUID() + ".txt");
-        Files.writeString(f.toPath(), message);
+        writeString(f.toPath(), message);
         git.add().addFilepattern(".").call();
         return git.commit()
                 .setAuthor(new PersonIdent("Dev", authorEmail))
@@ -249,7 +249,7 @@ class IdentityVerificationHookTest {
         // createCommit sets author=committer; we need a commit where committer=alice but author=external.
         // Use the lower-level JGit API to set them independently.
         File f = new File(tempDir.toFile(), java.util.UUID.randomUUID() + ".txt");
-        java.nio.file.Files.writeString(f.toPath(), "content");
+        writeString(f.toPath(), "content");
         git.add().addFilepattern(".").call();
         RevCommit base = git.commit()
                 .setAuthor(new PersonIdent("Dev", "alice@example.com"))
@@ -284,7 +284,7 @@ class IdentityVerificationHookTest {
                 .thenReturn(Optional.of(alice()));
 
         File f = new File(tempDir.toFile(), java.util.UUID.randomUUID() + ".txt");
-        java.nio.file.Files.writeString(f.toPath(), "content");
+        writeString(f.toPath(), "content");
         git.add().addFilepattern(".").call();
         RevCommit base = git.commit()
                 .setAuthor(new PersonIdent("Dev", "alice@example.com"))

--- a/fogwall-core/src/test/java/com/rbc/fogwall/provider/ProviderTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/provider/ProviderTest.java
@@ -13,14 +13,21 @@ class ProviderTest {
 
     @Test
     void gitHub_defaultUri_servletPath() {
-        var p = new GitHubProvider("/proxy");
-        assertEquals("/proxy/github.com", p.servletPath());
-        assertEquals("/proxy/github.com/*", p.servletMapping());
+        var p = new GitHubProvider(null);
+        assertEquals("/github.com", p.servletPath());
+        assertEquals("/github.com/*", p.servletMapping());
+    }
+
+    @Test
+    void gitHub_pathSuffix_overridesHostname() {
+        var p = new GitHubProvider("/mypath");
+        assertEquals("/mypath", p.servletPath());
+        assertEquals("/mypath/*", p.servletMapping());
     }
 
     @Test
     void gitHub_defaultUri_apiUrls() {
-        var p = new GitHubProvider("/proxy");
+        var p = new GitHubProvider(null);
         assertEquals("https://api.github.com", p.getApiUrl());
         assertEquals("https://api.github.com/graphql", p.getGraphqlUrl());
     }
@@ -29,7 +36,7 @@ class ProviderTest {
     void gitHub_enterpriseUri_apiUrls() {
         var p = GitHubProvider.builder()
                 .uri(URI.create("https://github.example.com"))
-                .basePath("/proxy")
+                .pathSuffix("/proxy")
                 .build();
         assertEquals("https://github.example.com/api/v3", p.getApiUrl());
         assertEquals("https://github.example.com/api/graphql", p.getGraphqlUrl());
@@ -44,9 +51,9 @@ class ProviderTest {
 
     @Test
     void gitLab_defaultUri_servletPath() {
-        var p = new GitLabProvider("/proxy");
-        assertEquals("/proxy/gitlab.com", p.servletPath());
-        assertEquals("/proxy/gitlab.com/*", p.servletMapping());
+        var p = new GitLabProvider(null);
+        assertEquals("/gitlab.com", p.servletPath());
+        assertEquals("/gitlab.com/*", p.servletMapping());
     }
 
     @Test
@@ -76,8 +83,8 @@ class ProviderTest {
 
     @Test
     void bitbucket_defaultUri_servletPath() {
-        var p = new BitbucketProvider("/proxy");
-        assertEquals("/proxy/bitbucket.org", p.servletPath());
+        var p = new BitbucketProvider(null);
+        assertEquals("/bitbucket.org", p.servletPath());
     }
 
     @Test
@@ -90,7 +97,7 @@ class ProviderTest {
     void bitbucket_hostedUri_apiUrl() {
         var p = BitbucketProvider.builder()
                 .uri(URI.create("https://bitbucket.example.com"))
-                .basePath("/proxy")
+                .pathSuffix("/proxy")
                 .build();
         assertEquals("https://bitbucket.example.com/rest/api/1.0", p.getApiUrl());
     }
@@ -113,9 +120,18 @@ class ProviderTest {
         var p = GenericProxyProvider.builder()
                 .name("my-git")
                 .uri(URI.create("https://git.corp.com"))
-                .basePath("/proxy")
                 .build();
-        assertEquals("/proxy/git.corp.com", p.servletPath());
+        assertEquals("/git.corp.com", p.servletPath());
+    }
+
+    @Test
+    void generic_pathSuffix_overridesHostname() {
+        var p = GenericProxyProvider.builder()
+                .name("my-git")
+                .uri(URI.create("https://git.corp.com"))
+                .pathSuffix("/custom")
+                .build();
+        assertEquals("/custom", p.servletPath());
     }
 
     // --- InMemoryProviderRegistry ---

--- a/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/EnrichPushCommitsFilterTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/EnrichPushCommitsFilterTest.java
@@ -1,6 +1,7 @@
 package com.rbc.fogwall.servlet.filter;
 
 import static com.rbc.fogwall.servlet.FogwallServlet.GIT_REQUEST_ATTR;
+import static java.nio.file.Files.writeString;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -17,7 +18,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -184,7 +184,7 @@ class EnrichPushCommitsFilterTest {
         Git sourceGit = Git.init().setDirectory(sourceDir.toFile()).call();
         sourceGit.getRepository().getConfig().setBoolean("commit", null, "gpgsign", false);
         sourceGit.getRepository().getConfig().save();
-        java.nio.file.Files.writeString(sourceDir.resolve("hello.txt"), "hello world");
+        writeString(sourceDir.resolve("hello.txt"), "hello world");
         sourceGit.add().addFilepattern("hello.txt").call();
         var revCommit = sourceGit
                 .commit()
@@ -261,7 +261,7 @@ class EnrichPushCommitsFilterTest {
         Git sourceGit = Git.init().setDirectory(sourceDir.toFile()).call();
         sourceGit.getRepository().getConfig().setBoolean("commit", null, "gpgsign", false);
         sourceGit.getRepository().getConfig().save();
-        java.nio.file.Files.writeString(sourceDir.resolve("hello.txt"), "hello world");
+        writeString(sourceDir.resolve("hello.txt"), "hello world");
         sourceGit.add().addFilepattern("hello.txt").call();
         var revCommit = sourceGit
                 .commit()
@@ -390,7 +390,7 @@ class EnrichPushCommitsFilterTest {
         Git sourceGit = Git.init().setDirectory(sourceDir2.toFile()).call();
         sourceGit.getRepository().getConfig().setBoolean("commit", null, "gpgsign", false);
         sourceGit.getRepository().getConfig().save();
-        Files.writeString(sourceDir2.resolve("secret.txt"), "new content");
+        writeString(sourceDir2.resolve("secret.txt"), "new content");
         sourceGit.add().addFilepattern("secret.txt").call();
         var revCommit = sourceGit
                 .commit()

--- a/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/UrlRuleFilterTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/UrlRuleFilterTest.java
@@ -458,7 +458,7 @@ class UrlRuleFilterTest {
                 .name("custom")
                 .type("github")
                 .uri(java.net.URI.create("https://github.com"))
-                .basePath("/proxy")
+                .pathSuffix("/proxy")
                 .blockedInfoRefsStatus(404)
                 .build();
         var aggregate = new UrlRuleAggregateFilter(50, provider, new InMemoryUrlRuleRegistry());

--- a/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/SecurityConfig.java
+++ b/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/SecurityConfig.java
@@ -42,6 +42,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -164,8 +165,7 @@ public class SecurityConfig {
                         .hasRole("ADMIN")
                         .requestMatchers(org.springframework.http.HttpMethod.POST, "/api/config/reload")
                         .hasRole("ADMIN")
-                        .requestMatchers(
-                                org.springframework.http.HttpMethod.POST, "/api/push/*/authorise", "/api/push/*/reject")
+                        .requestMatchers(HttpMethod.POST, "/api/push/*/authorise", "/api/push/*/reject")
                         .authenticated()
                         .anyRequest()
                         .authenticated())

--- a/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/PushControllerTest.java
+++ b/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/PushControllerTest.java
@@ -5,9 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.rbc.fogwall.db.PushStore;
 import com.rbc.fogwall.db.model.PushRecord;
@@ -420,7 +418,7 @@ class PushControllerTest {
 
             assertEquals(HttpStatus.OK, controller.approve("p1", approveBody()).getStatusCode());
             // isAllowedToReview must never have been called
-            org.mockito.Mockito.verifyNoInteractions(repoPermissionService);
+            verifyNoInteractions(repoPermissionService);
         }
     }
 

--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallServletRegistrar.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallServletRegistrar.java
@@ -1,5 +1,7 @@
 package com.rbc.fogwall.jetty;
 
+import static org.eclipse.jgit.transport.HttpTransport.setConnectionFactory;
+
 import com.rbc.fogwall.approval.ApprovalGateway;
 import com.rbc.fogwall.config.CommitConfig;
 import com.rbc.fogwall.config.DiffScanConfig;
@@ -59,7 +61,7 @@ public final class FogwallServletRegistrar {
             List<FogwallProvider> providers) {
         // Wire up JGit's HTTP transport factory once for all store-and-forward connections
         if (fogwallContext.upstreamTls() != null) {
-            org.eclipse.jgit.transport.HttpTransport.setConnectionFactory(new SslAwareHttpConnectionFactory(
+            setConnectionFactory(new SslAwareHttpConnectionFactory(
                     fogwallContext.upstreamTls().trustManagers()));
             log.info("Custom upstream SSL trust applied to JGit HTTP transport");
         }

--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/config/JettyConfigurationBuilder.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/config/JettyConfigurationBuilder.java
@@ -47,6 +47,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -143,19 +144,17 @@ public class JettyConfigurationBuilder {
     /** Creates the list of enabled providers from configuration. Result is cached. */
     public List<FogwallProvider> buildProviders() {
         if (cachedProviders != null) return cachedProviders;
-        List<FogwallProvider> providers = new ArrayList<>();
-
-        config.getProviders().forEach((name, providerConfig) -> {
-            if (!providerConfig.isEnabled()) {
-                log.info("Provider '{}' is disabled, skipping", name);
-                return;
-            }
-            FogwallProvider provider = createProvider(name, providerConfig);
-            if (provider != null) {
-                providers.add(provider);
-                log.info("Configured provider: {} -> {}", provider.getName(), provider.getUri());
-            }
-        });
+        var providers = config.getProviders().entrySet().stream()
+                .peek(entry -> {
+                    if (!entry.getValue().isEnabled()) {
+                        log.info("Provider '{}' is disabled, skipping", entry.getKey());
+                    }
+                })
+                .filter(entry -> entry.getValue().isEnabled())
+                .map(e -> createProvider(e.getKey(), e.getValue()))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toList();
 
         if (providers.isEmpty()) {
             log.warn("No providers configured. Add providers to fogwall.yml to enable proxying.");
@@ -186,6 +185,27 @@ public class JettyConfigurationBuilder {
      */
     public void validateProviderReferences() {
         buildProviderRegistry(); // warm the cache
+
+        // Detect duplicate servlet paths among HTTP providers — two providers with the same
+        // host:port would map to the same /push/<host>:<port>/* and /proxy/<host>:<port>/* paths,
+        // causing Jetty to throw IllegalStateException at startup.
+        var httpProviders = buildProviders().stream()
+                .filter(p -> {
+                    String scheme = p.getUri().getScheme();
+                    return scheme != null && (scheme.equals("http") || scheme.equals("https"));
+                })
+                .toList();
+        var seenPaths = new HashSet<String>();
+        for (var provider : httpProviders) {
+            String path = provider.servletPath();
+            if (!seenPaths.add(path)) {
+                throw new IllegalStateException(
+                        "Multiple HTTP providers share the same upstream host:port or path-suffix '"
+                                + path
+                                + "'. Each HTTP provider must have a unique URI. "
+                                + "SSH providers sharing a host:port are allowed since they use separate transport.");
+            }
+        }
 
         config.getUsers()
                 .forEach(uc -> uc.getScmIdentities().forEach(s -> {
@@ -771,7 +791,7 @@ public class JettyConfigurationBuilder {
         return "fogwall";
     }
 
-    private FogwallProvider createProvider(String name, ProviderConfig providerConfig) {
+    private Optional<FogwallProvider> createProvider(String name, ProviderConfig providerConfig) {
         String explicitType = providerConfig.getType();
         // Use explicit type if set; otherwise accept only exact built-in names, not fuzzy name inference.
         String resolvedType = (explicitType != null && !explicitType.isBlank())
@@ -779,65 +799,71 @@ public class JettyConfigurationBuilder {
                 : name.toLowerCase();
 
         String uri = providerConfig.getUri();
-        String path = providerConfig.getServletPath();
+        String pathSuffix = providerConfig.getPathSuffix();
         URI parsedUri = (uri != null && !uri.isBlank()) ? URI.create(uri) : null;
 
         switch (resolvedType) {
             case "github" -> {
-                return GitHubProvider.builder()
+                return Optional.of(GitHubProvider.builder()
                         .name(name)
                         .uri(parsedUri)
-                        .basePath(path)
-                        .build();
+                        .pathSuffix(pathSuffix)
+                        .build());
             }
             case "gitlab" -> {
-                return GitLabProvider.builder()
+                return Optional.of(GitLabProvider.builder()
                         .name(name)
                         .uri(parsedUri)
-                        .basePath(path)
-                        .build();
+                        .pathSuffix(pathSuffix)
+                        .build());
             }
             case "bitbucket" -> {
-                return BitbucketProvider.builder()
+                return Optional.of(BitbucketProvider.builder()
                         .name(name)
                         .uri(parsedUri)
-                        .basePath(path)
-                        .build();
+                        .pathSuffix(pathSuffix)
+                        .build());
             }
-            case "codeberg", "gitea" -> {
-                URI defaultUri = ForgejoProvider.WELL_KNOWN.get(resolvedType);
-                return ForgejoProvider.builder()
+            case "codeberg" -> {
+                return Optional.of(ForgejoProvider.builder()
                         .name(name)
-                        .uri(parsedUri != null ? parsedUri : defaultUri)
-                        .basePath(path)
-                        .build();
+                        .uri(ForgejoProvider.CODEBERG)
+                        .pathSuffix(pathSuffix)
+                        .build());
+            }
+            case "gitea" -> {
+                return Optional.of(ForgejoProvider.builder()
+                        .name(name)
+                        .uri(parsedUri != null ? parsedUri : ForgejoProvider.GITEA)
+                        .pathSuffix(pathSuffix)
+                        .build());
             }
             case "forgejo" -> {
                 if (parsedUri == null) {
                     log.warn(
                             "Provider '{}' has type 'forgejo' but no URI — Forgejo has no canonical public host. Add 'uri'. Skipping.",
                             name);
-                    return null;
+                    return Optional.empty();
                 }
-                return ForgejoProvider.builder()
+                return Optional.of(ForgejoProvider.builder()
                         .name(name)
                         .uri(parsedUri)
-                        .basePath(path)
-                        .build();
+                        .pathSuffix(pathSuffix)
+                        .build());
             }
             default -> {
                 if (parsedUri != null) {
-                    return GenericProxyProvider.builder()
+                    return Optional.of(GenericProxyProvider.builder()
                             .name(name)
                             .uri(parsedUri)
-                            .basePath(path)
+                            .pathSuffix(pathSuffix)
                             .blockedInfoRefsStatus(providerConfig.getBlockedInfoRefsStatus())
-                            .build();
+                            .build());
                 }
                 log.warn(
-                        "Provider '{}' has no URI and is not a known built-in name (github/gitlab/bitbucket/codeberg/forgejo/gitea). Set 'type' and 'uri' for custom providers. Skipping.",
+                        "Provider '{}' has no URI and is not a known built-in name (github/gitlab/bitbucket/forgejo/gitea). Set 'type' and 'uri' for custom providers. Skipping.",
                         name);
-                return null;
+                return Optional.empty();
             }
         }
     }

--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/config/ProviderConfig.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/config/ProviderConfig.java
@@ -8,16 +8,22 @@ public class ProviderConfig {
 
     private boolean enabled = true;
 
-    /** Additional URL prefix for this provider's servlet path. */
-    private String servletPath = "";
+    /**
+     * Custom URL suffix (appended after {@link com.rbc.fogwall.jetty.FogwallServletRegistrar#PROXY_PATH_PREFIX} and
+     * {@link com.rbc.fogwall.jetty.FogwallServletRegistrar#PUSH_PATH_PREFIX}) for this provider's servlet path. Allows
+     * operators to set a specific path to listen for git requests. By default, this is computed from the provider's
+     * hostname & optional port (80/443 are implied for http/https respectively)
+     */
+    private String pathSuffix = "";
 
     /** Upstream base URI. Required for custom providers; omit for built-ins (github, gitlab, bitbucket). */
     private String uri = "";
 
     /**
-     * Provider type. Required for custom-named providers; omit only for the built-in default names ({@code github},
-     * {@code gitlab}, {@code bitbucket}, {@code codeberg}, {@code forgejo}). Supported values: {@code github},
-     * {@code gitlab}, {@code bitbucket}, {@code codeberg}, {@code forgejo}, {@code gitea}.
+     * Provider type. Required for providers configured with custom names or providers with no canonical URI (Forgejo,
+     * generic); this field can only be unset for the built-in default names when a canonical hostname is known (i.e.
+     * {@code name=github}, implies {@code type=github,uri=https://github.com}). Supported values: {@code github},
+     * {@code gitlab}, {@code bitbucket}, {@code codeberg}, {@code gitea}.
      */
     private String type = "";
 

--- a/fogwall-server/src/main/resources/fogwall.yml
+++ b/fogwall-server/src/main/resources/fogwall.yml
@@ -55,25 +55,37 @@ database:
 providers:
   github:
     enabled: true
-  # Additional providers that may host FOSS projects.
   gitlab:
     enabled: true
   codeberg:
     enabled: true
   gitea:
     enabled: true
-  # bitbucket.org support is limited due to lack of free (non-commercial) access. Disabled by default.
-  # Bitbucket Server/Data Center instances can be added as custom providers
+  # bitbucket.org support is added here for completeness. Access to bitbucket.org for FOSS is less common than other
+  # providers. Signup is not free or guaranteed and is reviewed by Atlassian via https://www.atlassian.com/software/views/open-source-license-request#/
+  # Therefore, it is disabled by default. Bitbucket (self-hosted or cloud for enterprise use) is supported.
   bitbucket:
     enabled: false
-#  internal-gitlab:
-#    enabled: true
-#    type: gitlab
-#    uri: https://gitlab.internal.example.com
-#  debian-gitlab:
-#    enabled: true
-#    servlet-path: /debian
-#    uri: https://salsa.debian.org/
+  # Generic git repository provider
+  sourcehut:
+    enabled: true
+    type: generic
+    uri: https://git.sr.ht/
+# Custom GitLab example
+  debian-gitlab:
+    enabled: true
+    type: gitlab
+    # Custom servlet path. By default, the servlet path is /{push,proxy}/{hostname}/{repo-url}.git.
+    # Note that /push & /proxy are always prepended to the path. This is only useful if you wish to obscure or otherwise
+    # customize the path for Fogwall to proxy requests to.
+    path-suffix: /debian
+    uri: https://salsa.debian.org/
+# Custom self-hosted GitHub Enterprise example
+  internal-github:
+    enabled: true
+    type: github
+    uri: https://github.internal.example.com
+
 
 # Global attestation questions shown to reviewers in the dashboard approval form before they can
 # approve a push. Applies to all providers — per-provider variants are a future enhancement.

--- a/fogwall-server/src/test/java/com/rbc/fogwall/e2e/HotReloadJettyFixture.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/e2e/HotReloadJettyFixture.java
@@ -71,7 +71,6 @@ class HotReloadJettyFixture implements AutoCloseable {
         var provider = GenericProxyProvider.builder()
                 .name("gitea-e2e-hotreload")
                 .uri(giteaUri)
-                .basePath("")
                 .build();
         this.providerId = provider.getProviderId();
         this.giteaHostPort = giteaUri.getHost() + ":" + giteaUri.getPort();

--- a/fogwall-server/src/test/java/com/rbc/fogwall/e2e/JettyProxyFixture.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/e2e/JettyProxyFixture.java
@@ -139,11 +139,8 @@ class JettyProxyFixture implements AutoCloseable {
         var storeForwardCache = new LocalRepositoryCache(Files.createTempDirectory("fogwall-e2e-sf-"), 0, true);
         var proxyCache = new LocalRepositoryCache();
 
-        var provider = GenericProxyProvider.builder()
-                .name("gitea-e2e")
-                .uri(giteaUri)
-                .basePath("")
-                .build();
+        var provider =
+                GenericProxyProvider.builder().name("gitea-e2e").uri(giteaUri).build();
         this.providerId = provider.getProviderId();
         this.giteaHostPort = giteaUri.getHost() + ":" + giteaUri.getPort();
 

--- a/fogwall-server/src/test/java/com/rbc/fogwall/jetty/config/JettyConfigurationBuilderTest.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/jetty/config/JettyConfigurationBuilderTest.java
@@ -8,8 +8,12 @@ import com.rbc.fogwall.db.PushStoreFactory;
 import com.rbc.fogwall.db.model.AccessRule;
 import com.rbc.fogwall.db.model.MatchType;
 import com.rbc.fogwall.permission.RepoPermission;
+import com.rbc.fogwall.provider.BitbucketProvider;
 import com.rbc.fogwall.provider.FogwallProvider;
+import com.rbc.fogwall.provider.ForgejoProvider;
 import com.rbc.fogwall.provider.GitHubProvider;
+import com.rbc.fogwall.provider.GitLabProvider;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -244,6 +248,118 @@ class JettyConfigurationBuilderTest {
         assertEquals(MatchType.GLOB, rules.get(0).getMatchType());
     }
 
+    // ---- provider type inference from config key ----
+
+    @Test
+    void createProvider_githubKey_inferredAsGitHubProvider() {
+        var providers = new JettyConfigurationBuilder(configWithSingleProvider("github", new ProviderConfig()))
+                .buildProviders();
+        assertEquals(1, providers.size());
+        assertInstanceOf(GitHubProvider.class, providers.get(0));
+        assertEquals("github", providers.get(0).getName());
+        assertEquals(GitHubProvider.DEFAULT_URI, providers.get(0).getUri());
+    }
+
+    @Test
+    void createProvider_gitlabKey_inferredAsGitLabProvider() {
+        var providers = new JettyConfigurationBuilder(configWithSingleProvider("gitlab", new ProviderConfig()))
+                .buildProviders();
+        assertEquals(1, providers.size());
+        assertInstanceOf(GitLabProvider.class, providers.get(0));
+        assertEquals(GitLabProvider.DEFAULT_URI, providers.get(0).getUri());
+    }
+
+    @Test
+    void createProvider_bitbucketKey_inferredAsBitbucketProvider() {
+        var providers = new JettyConfigurationBuilder(configWithSingleProvider("bitbucket", new ProviderConfig()))
+                .buildProviders();
+        assertEquals(1, providers.size());
+        assertInstanceOf(BitbucketProvider.class, providers.get(0));
+        assertEquals(BitbucketProvider.DEFAULT_URI, providers.get(0).getUri());
+    }
+
+    @Test
+    void createProvider_codebergKey_inferredAsForgejoProviderWithCodebergUri() {
+        var providers = new JettyConfigurationBuilder(configWithSingleProvider("codeberg", new ProviderConfig()))
+                .buildProviders();
+        assertEquals(1, providers.size());
+        assertInstanceOf(ForgejoProvider.class, providers.get(0));
+        assertEquals(ForgejoProvider.CODEBERG, providers.get(0).getUri());
+    }
+
+    @Test
+    void createProvider_giteaKey_noUri_defaultsToGiteaCom() {
+        var providers =
+                new JettyConfigurationBuilder(configWithSingleProvider("gitea", new ProviderConfig())).buildProviders();
+        assertEquals(1, providers.size());
+        assertInstanceOf(ForgejoProvider.class, providers.get(0));
+        assertEquals(ForgejoProvider.GITEA, providers.get(0).getUri());
+    }
+
+    @Test
+    void createProvider_giteaKey_withUri_usesCustomUri() {
+        var pc = new ProviderConfig();
+        pc.setUri("https://gitea.corp.com");
+        var providers = new JettyConfigurationBuilder(configWithSingleProvider("gitea", pc)).buildProviders();
+        assertEquals(1, providers.size());
+        assertInstanceOf(ForgejoProvider.class, providers.get(0));
+        assertEquals(URI.create("https://gitea.corp.com"), providers.get(0).getUri());
+    }
+
+    @Test
+    void createProvider_forgejoKey_withUri_usesCustomUri() {
+        var pc = new ProviderConfig();
+        pc.setUri("https://forge.example.com");
+        var providers = new JettyConfigurationBuilder(configWithSingleProvider("my-forge", pc)).buildProviders();
+        // no known type and no known key — falls back to generic
+        assertEquals(1, providers.size());
+        assertEquals(URI.create("https://forge.example.com"), providers.get(0).getUri());
+    }
+
+    @Test
+    void createProvider_forgejoType_withUri_isForgejoProvider() {
+        var pc = new ProviderConfig();
+        pc.setType("forgejo");
+        pc.setUri("https://forge.example.com");
+        var providers = new JettyConfigurationBuilder(configWithSingleProvider("my-forge", pc)).buildProviders();
+        assertEquals(1, providers.size());
+        assertInstanceOf(ForgejoProvider.class, providers.get(0));
+        assertEquals(URI.create("https://forge.example.com"), providers.get(0).getUri());
+    }
+
+    @Test
+    void createProvider_forgejoType_noUri_skipped() {
+        var pc = new ProviderConfig();
+        pc.setType("forgejo");
+        var providers = new JettyConfigurationBuilder(configWithSingleProvider("my-forge", pc)).buildProviders();
+        assertTrue(providers.isEmpty(), "forgejo provider without URI must be skipped");
+    }
+
+    @Test
+    void createProvider_customNameWithGithubType_isGitHubProvider() {
+        var pc = new ProviderConfig();
+        pc.setType("github");
+        pc.setUri("https://github.internal.example.com");
+        var providers = new JettyConfigurationBuilder(configWithSingleProvider("internal-github", pc)).buildProviders();
+        assertEquals(1, providers.size());
+        assertInstanceOf(GitHubProvider.class, providers.get(0));
+        assertEquals("internal-github", providers.get(0).getName());
+        assertEquals(
+                URI.create("https://github.internal.example.com"),
+                providers.get(0).getUri());
+    }
+
+    @Test
+    void createProvider_customNameWithGiteaType_isForgejoProvider() {
+        var pc = new ProviderConfig();
+        pc.setType("gitea");
+        pc.setUri("https://gitea.corp.com");
+        var providers = new JettyConfigurationBuilder(configWithSingleProvider("corp-gitea", pc)).buildProviders();
+        assertEquals(1, providers.size());
+        assertInstanceOf(ForgejoProvider.class, providers.get(0));
+        assertEquals("corp-gitea", providers.get(0).getName());
+    }
+
     // ---- helpers ----
 
     private static PermissionConfig slugPerm(String username, String provider, String value) {
@@ -273,6 +389,13 @@ class JettyConfigurationBuilderTest {
     private static FogwallConfig configWithApprovalMode(String mode) {
         var config = new FogwallConfig();
         config.getServer().setApprovalMode(mode);
+        return config;
+    }
+
+    private static FogwallConfig configWithSingleProvider(String key, ProviderConfig pc) {
+        var config = new FogwallConfig();
+        pc.setEnabled(true);
+        config.setProviders(Map.of(key, pc));
         return config;
     }
 


### PR DESCRIPTION
## Summary

- Renames the confusing mix of `servletPath` / `basePath` / `customPath` identifiers to a single consistent name `pathSuffix` across config, builders, providers, and all tests. The field controls the segment *after* `/push` or `/proxy`, so `pathSuffix` is the accurate term.
- Fixes a `StringIndexOutOfBoundsException` when `pathSuffix` is blank (caused by `path.substring(1)` on an empty string returned from the field default); adds a `!isBlank()` guard in `AbstractFogwallProvider.servletPath()`.
- Replaces `ForgejoProvider.WELL_KNOWN` map with explicit `CODEBERG` / `GITEA` URI constants for cleaner switch-expression cases in `JettyConfigurationBuilder`.
- Adds type-inference unit tests in `JettyConfigurationBuilderTest` covering GitHub, GitLab, Bitbucket, Codeberg, Gitea (as `ForgejoProvider`), explicit `forgejo` type with and without a URI, and custom-named providers.

**No functional changes** — this is pure rename/cleanup. The SSH implementation that builds on this is in `feat/ssh-sf-mode`.

## Test plan

- [ ] `./gradlew :fogwall-core:test :fogwall-server:test --rerun` passes locally (verified before push)
- [ ] `./gradlew :fogwall-core:jacocoTestCoverageVerification --rerun` passes
- [ ] CI green