### PR TITLE
docs: clarify credential flow and transparent proxy streaming constraint

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,8 +62,12 @@ The developer's git client is talking to a forwarding proxy, not a JGit endpoint
 cycle. A temporary local clone is still used to unpack the pack data and walk the commit range for validation, but the
 push is forwarded via HTTP proxy rather than a JGit `push` command.
 
-This mode cannot stream incremental feedback, but it does still clone the upstream repo locally for pack inspection —
-see below.
+This mode cannot stream incremental feedback. The reason is structural: an HTTP response is a single buffered reply.
+The filter chain runs to completion inside one request/response cycle — there is no mechanism to flush partial output to
+the git client mid-chain. Validation filters accumulate their results; `ValidationSummaryFilter` and
+`PushFinalizerFilter` collect everything and write one response at the end. Store-and-forward avoids this constraint
+entirely because JGit's `ReceivePack` owns the connection and can call `sendMessage()` at any point, streaming sideband
+packets to the client as each hook completes.
 
 ### Choosing a mode
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -328,9 +328,12 @@ The transparent proxy mode replicates what finos/git-proxy does today: intercept
 store-and-forward mode — where the proxy owns the full pack lifecycle via JGit — opens up use cases that are not
 possible with a pass-through HTTP proxy:
 
-- **Deferred forwarding** — the developer's push is received and acknowledged immediately. The pack and credentials are
-  parked locally while an approval process runs (hours, days). Forwarding happens asynchronously once approved. This
-  eliminates the problem of holding a git client session open during a long review window.
+- **Deferred forwarding** — the developer's push is received and acknowledged immediately. The pack is stored locally
+  while an approval process runs (hours, days); forwarding happens asynchronously once approved. This eliminates the
+  problem of holding a git client session open during a long review window. Note: the current implementation forwards
+  within the same session using the client's in-memory credentials (see
+  [Credential flow](internals/JGIT_INFRASTRUCTURE.md#credential-flow)); true async deferred forwarding would require a
+  separate credential design and is tracked as a backlog item.
 
 - **Multi-upstream push** — a single received pack can be forwarded to more than one upstream remote, keeping shared
   repositories (CI workflows, shared libraries) in sync across separate Git hosts without requiring the developer to


### PR DESCRIPTION
## Summary

Two targeted corrections to `docs/ARCHITECTURE.md`:

- **Credential handling in deferred forwarding**: the previous wording said "pack and credentials are parked locally," implying the current implementation persists credentials to disk. It does not — credentials exist in memory for the duration of the request only, as documented in the existing [Credential flow](docs/internals/JGIT_INFRASTRUCTURE.md#credential-flow) section. The description now correctly distinguishes current in-session behaviour from what a future async deferred forwarding design would require, and links to the existing documentation.

- **Why transparent proxy cannot stream incremental feedback**: the mode comparison said it "cannot stream incremental feedback" without explaining why. Added a brief explanation: the HTTP buffering constraint is structural — the filter chain runs to completion inside one request/response cycle with no mechanism to flush partial output mid-chain. This applies equally to any transparent HTTP proxy implementation (including Express-based ones). Store-and-forward avoids this because JGit's `ReceivePack` owns the connection as a git server and can write sideband packets at will.

## Test plan

- [ ] Docs render correctly on GitHub
- [ ] Links to `JGIT_INFRASTRUCTURE.md#credential-flow` resolve