### PR TITLE
chore: group codeql dependabot updates and normalize labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,16 @@ updates:
       interval: "weekly"
       day: "monday"
     labels:
-      - "dependencies"
+      - "dependencies:actions"
+    groups:
+      codeql-actions:
+        patterns:
+          - "github/codeql-action*"
+      github-actions:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: "gradle"
     directory: "/"
@@ -14,8 +23,7 @@ updates:
       interval: "weekly"
       day: "monday"
     labels:
-      - "dependencies"
-      - "java"
+      - "dependencies:java"
     groups:
       java-dependencies:
         patterns:
@@ -27,8 +35,7 @@ updates:
       interval: "weekly"
       day: "monday"
     labels:
-      - "dependencies"
-      - "frontend"
+      - "dependencies:frontend"
     groups:
       frontend-npm-dependencies:
         patterns:
@@ -40,5 +47,4 @@ updates:
       interval: "weekly"
       day: "monday"
     labels:
-      - "dependencies"
-      - "docker"
+      - "dependencies:docker"


### PR DESCRIPTION
## What

- **Group CodeQL actions** into a dedicated `codeql-actions` Dependabot group so the interdependent `init`/`analyze` bumps land in a single PR (they are incompatible when bumped separately).
- **Group remaining GitHub Actions** into one weekly `github-actions` group, excluding CodeQL via `exclude-patterns`.
- **Normalize labels** to a single `dependencies:{type}` label per ecosystem, matching the existing `area:{domain}` convention.

## Label changes (already applied to the repo)

Created: `dependencies:actions`, `dependencies:java`, `dependencies:frontend`, `dependencies:docker`
Deleted: `dependencies`, `java`, `frontend`, `docker`

## Rollout note

Grouping takes effect on the next Dependabot run against `main` after merge. Existing individual PRs (including the two conflicting CodeQL bumps) will be closed as superseded and replaced by consolidated group PRs. Use Insights → Dependency graph → Dependabot → "Check for updates" to trigger immediately instead of waiting for the Monday schedule.