### PR TITLE
chore: bump version to 1.2.1

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,7 +13,7 @@ fi
 
 echo "[pre-commit] Running spotlessApply..."
 ./gradlew spotlessApply --quiet
-git diff --name-only | xargs -r git add
+git diff --name-only -- '*.java' | xargs -r git add
 echo "[pre-commit] Spotless: OK"
 
 echo "[pre-commit] Running Prettier..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,12 @@ on:
   pull_request:
     branches: ["main"]
 
+# On main, give every commit its own concurrency group (via SHA) so runs never cancel
+# each other — each landed commit goes through the full CI in parallel. On PR/other refs,
+# superseded runs are cancelled on new pushes to save resources.
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build-and-test:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,9 +16,12 @@ on:
 permissions:
   contents: read
 
+# On main, give every commit its own concurrency group (via SHA) so build+scan runs never
+# cancel each other — each landed commit is fully built and scanned in parallel. Tags never
+# cancel (release builds). PR/other refs cancel superseded runs on new pushes.
 concurrency:
-  group: docker-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+  group: docker-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main' }}
 
 jobs:
   build-and-push:

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ ext {
 
 allprojects {
     group = 'com.rbc.fogwall'
-    version = '1.2.0'
+    version = '1.2.1'
     
     repositories {
         mavenCentral()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,12 +62,12 @@ The developer's git client is talking to a forwarding proxy, not a JGit endpoint
 cycle. A temporary local clone is still used to unpack the pack data and walk the commit range for validation, but the
 push is forwarded via HTTP proxy rather than a JGit `push` command.
 
-This mode cannot stream incremental feedback. The reason is structural: an HTTP response is a single buffered reply.
-The filter chain runs to completion inside one request/response cycle — there is no mechanism to flush partial output to
-the git client mid-chain. Validation filters accumulate their results; `ValidationSummaryFilter` and
-`PushFinalizerFilter` collect everything and write one response at the end. Store-and-forward avoids this constraint
-entirely because JGit's `ReceivePack` owns the connection and can call `sendMessage()` at any point, streaming sideband
-packets to the client as each hook completes.
+This mode cannot stream incremental feedback. The reason is structural: an HTTP response is a single buffered reply. The
+filter chain runs to completion inside one request/response cycle — there is no mechanism to flush partial output to the
+git client mid-chain. Validation filters accumulate their results; `ValidationSummaryFilter` and `PushFinalizerFilter`
+collect everything and write one response at the end. Store-and-forward avoids this constraint entirely because JGit's
+`ReceivePack` owns the connection and can call `sendMessage()` at any point, streaming sideband packets to the client as
+each hook completes.
 
 ### Choosing a mode
 

--- a/fogwall-dashboard/frontend/src/types.ts
+++ b/fogwall-dashboard/frontend/src/types.ts
@@ -1,11 +1,5 @@
 export type PushStatus =
-  | 'PENDING'
-  | 'APPROVED'
-  | 'FORWARDED'
-  | 'REJECTED'
-  | 'CANCELED'
-  | 'RECEIVED'
-  | 'ERROR'
+  'PENDING' | 'APPROVED' | 'FORWARDED' | 'REJECTED' | 'CANCELED' | 'RECEIVED' | 'ERROR'
 
 export interface Step {
   id: string


### PR DESCRIPTION
## Summary

- Bumps version to **1.2.1**
- Fixes CI and Docker build/publish concurrency: each commit on `main` now gets its own concurrency group (keyed by SHA) so back-to-back merges no longer cancel the prior commit's run — every landed commit goes through the full CI and Docker build+scan in parallel
- Fixes pre-commit hook: spotless `git add` now scoped to `*.java` only, so prettier-formatted JS/TS/MD files are no longer accidentally staged by the spotless step

## Once merged

Run `/release-tag 1.2.1` to create and push the tag.