### PR TITLE
feat: double-underscore env var convention for hyphenated config keys

### DIFF
--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/config/FogwallConfigLoader.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/config/FogwallConfigLoader.java
@@ -33,13 +33,24 @@ import org.github.gestalt.config.source.MapConfigSourceBuilder;
  *   <li>{@code FOGWALL_CONFIG_PROFILES=docker-default,ldap} — Docker + LDAP auth
  * </ul>
  *
- * <p>Environment variable naming: strip the {@code FOGWALL_} prefix, lowercase, replace {@code _} with {@code .} to get
- * the config path. Examples:
+ * <p>Environment variable naming: two conventions are supported.
+ *
+ * <p><b>Legacy (single-underscore) convention</b> — strip the {@code FOGWALL_} prefix, lowercase, replace {@code _}
+ * with {@code .}. Works for paths that contain no hyphens:
  *
  * <ul>
  *   <li>{@code FOGWALL_SERVER_PORT=9090} → {@code server.port}
  *   <li>{@code FOGWALL_DATABASE_TYPE=postgres} → {@code database.type}
  *   <li>{@code FOGWALL_PROVIDERS_GITHUB_ENABLED=false} → {@code providers.github.enabled}
+ * </ul>
+ *
+ * <p><b>Double-underscore convention</b> — activated when the variable name contains {@code __}. {@code __} maps to
+ * {@code .} (path separator) and {@code _} maps to {@code -} (hyphen within a segment). Use this for hyphenated keys or
+ * hyphenated provider IDs:
+ *
+ * <ul>
+ *   <li>{@code FOGWALL_PROVIDERS__GITEA_SSH__API_TOKEN} → {@code providers.gitea-ssh.api-token}
+ *   <li>{@code FOGWALL_PROVIDERS__GITHUB__ENABLED=false} → {@code providers.github.enabled}
  * </ul>
  */
 @Slf4j
@@ -158,12 +169,21 @@ public final class FogwallConfigLoader {
         Map<String, String> overrides = new HashMap<>();
         System.getenv().forEach((varName, varValue) -> {
             if (varName.startsWith(ENV_PREFIX) && !varName.equals(PROFILES_ENV_VAR)) {
-                String configPath =
-                        varName.substring(ENV_PREFIX.length()).toLowerCase().replace('_', '.');
+                String configPath = envVarToConfigPath(varName);
                 overrides.put(configPath, varValue);
                 log.debug("Env override: {} → {}", varName, configPath);
             }
         });
         return overrides;
+    }
+
+    static String envVarToConfigPath(String varName) {
+        String stripped = varName.substring(ENV_PREFIX.length()).toLowerCase();
+        if (stripped.contains("__")) {
+            // double-underscore convention: __ = path separator, _ = hyphen
+            return String.join(".", stripped.split("__")).replace('_', '-');
+        }
+        // legacy single-underscore convention: _ = path separator
+        return stripped.replace('_', '.');
     }
 }

--- a/fogwall-server/src/test/java/com/rbc/fogwall/jetty/config/FogwallConfigLoaderTest.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/jetty/config/FogwallConfigLoaderTest.java
@@ -270,6 +270,39 @@ class FogwallConfigLoaderTest {
         assertFalse(config.getSecretScan().isEnabled());
     }
 
+    // --- envVarToConfigPath ---
+
+    @Test
+    void envVarToConfigPath_legacySimplePath() {
+        assertEquals("server.port", FogwallConfigLoader.envVarToConfigPath("FOGWALL_SERVER_PORT"));
+    }
+
+    @Test
+    void envVarToConfigPath_legacyThreeSegments() {
+        assertEquals(
+                "providers.github.enabled", FogwallConfigLoader.envVarToConfigPath("FOGWALL_PROVIDERS_GITHUB_ENABLED"));
+    }
+
+    @Test
+    void envVarToConfigPath_doubleUnderscore_hyphenatedKey() {
+        assertEquals(
+                "providers.gitea-ssh.api-token",
+                FogwallConfigLoader.envVarToConfigPath("FOGWALL_PROVIDERS__GITEA_SSH__API_TOKEN"));
+    }
+
+    @Test
+    void envVarToConfigPath_doubleUnderscore_noHyphensInSegments() {
+        assertEquals(
+                "providers.github.enabled",
+                FogwallConfigLoader.envVarToConfigPath("FOGWALL_PROVIDERS__GITHUB__ENABLED"));
+    }
+
+    @Test
+    void envVarToConfigPath_doubleUnderscore_hyphenatedTopLevelKey() {
+        // FOGWALL_SECRET_SCAN__ENABLED → secret-scan.enabled
+        assertEquals("secret-scan.enabled", FogwallConfigLoader.envVarToConfigPath("FOGWALL_SECRET_SCAN__ENABLED"));
+    }
+
     private Path writeYaml(String yaml) throws IOException {
         Path f = Files.createTempFile(tempDir, "override-", ".yml");
         Files.writeString(f, yaml);


### PR DESCRIPTION
## Summary

- Adds a double-underscore convention for `FOGWALL_` env var overrides so hyphenated config keys can be targeted
- Within the path portion (after `FOGWALL_`), `__` maps to `.` and `_` maps to `-`; activated only when `__` appears in the name
- All existing single-underscore vars are unchanged (non-breaking)

## Examples

```
FOGWALL_PROVIDERS__GITEA_SSH__API_TOKEN → providers.gitea-ssh.api-token
FOGWALL_SECRET_SCAN__ENABLED            → secret-scan.enabled
FOGWALL_SERVER_PORT (legacy)            → server.port  ← unchanged
```

## Test plan

- [ ] Unit tests for `envVarToConfigPath()` cover both conventions and hyphenated top-level keys
- [ ] `./gradlew :fogwall-server:test :fogwall-server:jacocoTestCoverageVerification --rerun` passes

closes #386