### PR TITLE
fix: pause heartbeat during approval wait; hide review grants when require-review-permission is false

### DIFF
--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/HeartbeatSender.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/HeartbeatSender.java
@@ -39,6 +39,7 @@ public class HeartbeatSender implements AutoCloseable {
     private final Duration interval;
     private final Runnable onDisconnect;
     private ScheduledExecutorService executor;
+    private volatile boolean paused = false;
 
     public HeartbeatSender(ReceivePack rp, Duration interval) {
         this(rp, interval, null);
@@ -65,7 +66,20 @@ public class HeartbeatSender implements AutoCloseable {
         log.debug("Heartbeat started (interval: {}s)", seconds);
     }
 
+    /** Suppresses heartbeat dots without stopping the background thread. Call {@link #resume()} to re-enable. */
+    public void pause() {
+        paused = true;
+    }
+
+    /** Re-enables heartbeat dots after a {@link #pause()}. */
+    public void resume() {
+        paused = false;
+    }
+
     private void sendDot() {
+        if (paused) {
+            return;
+        }
         try {
             rp.sendMessage(".");
             rp.getMessageOutputStream().flush();

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/StoreAndForwardReceivePackFactory.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/StoreAndForwardReceivePackFactory.java
@@ -352,7 +352,19 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
                     if (skipValidationHooks && hook instanceof FogwallHook) {
                         continue;
                     }
-                    hook.onPreReceive(rp, commands);
+                    // Pause heartbeat dots while the approval hook streams its own progress messages to
+                    // the client; dots interleave with gateway messages without this guard.
+                    boolean isApprovalHook = hook instanceof ApprovalPreReceiveHook;
+                    if (isApprovalHook) {
+                        heartbeat.pause();
+                    }
+                    try {
+                        hook.onPreReceive(rp, commands);
+                    } finally {
+                        if (isApprovalHook) {
+                            heartbeat.resume();
+                        }
+                    }
                     // Flush sideband after each hook so messages stream to the client in real time
                     // (JGit's sendMessage() doesn't flush - without this, all output batches up)
                     try {

--- a/fogwall-dashboard/frontend/src/pages/UserDetail.tsx
+++ b/fogwall-dashboard/frontend/src/pages/UserDetail.tsx
@@ -578,10 +578,12 @@ function AddPermissionModal({
   const [provider, setProvider] = useState('')
   const [path, setPath] = useState('')
   const [pathType, setPathType] = useState<'LITERAL' | 'GLOB' | 'REGEX'>('GLOB')
-  const [grant, setGrant] = useState<RepoPermission['grant']>('PUSH_AND_REVIEW')
+  const [grant, setGrant] = useState<RepoPermission['grant']>('PUSH')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [regexError, setRegexError] = useState<string | null>(null)
+
+  const requireReviewPermission = providers.length > 0 && providers[0].requireReviewPermission
 
   function handlePathChange(value: string) {
     setPath(value)
@@ -698,9 +700,9 @@ function AddPermissionModal({
               onChange={(e) => setGrant(e.target.value as typeof grant)}
               className={inputClass}
             >
-              <option value="PUSH_AND_REVIEW">Push and review</option>
+              {requireReviewPermission && <option value="PUSH_AND_REVIEW">Push and review</option>}
               <option value="PUSH">Push only</option>
-              <option value="REVIEW">Review only</option>
+              {requireReviewPermission && <option value="REVIEW">Review only</option>}
               <option value="SELF_CERTIFY">Self-certify</option>
             </select>
           </div>

--- a/fogwall-dashboard/frontend/src/types.ts
+++ b/fogwall-dashboard/frontend/src/types.ts
@@ -86,6 +86,7 @@ export interface Provider {
   pushPath: string
   proxyPath: string
   attestationQuestions: AttestationQuestion[]
+  requireReviewPermission: boolean
 }
 
 export interface EmailEntry {

--- a/fogwall-dashboard/frontend/tests/permissions.spec.ts
+++ b/fogwall-dashboard/frontend/tests/permissions.spec.ts
@@ -19,7 +19,7 @@ test('add and remove a permission from the user detail page', async ({ page }) =
   const row = page.locator('tbody tr').filter({ hasText: testPath })
   await expect(row).toBeVisible()
   await expect(row.getByText('glob')).toBeVisible()
-  await expect(row.getByText('push_and_review')).toBeVisible()
+  await expect(row.getByText('push', { exact: true })).toBeVisible()
 
   // Remove the permission and verify it disappears
   await row.getByRole('button', { name: 'Remove' }).click()

--- a/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/ProviderController.java
+++ b/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/ProviderController.java
@@ -1,6 +1,7 @@
 package com.rbc.fogwall.dashboard.controller;
 
 import com.rbc.fogwall.config.AttestationQuestion;
+import com.rbc.fogwall.config.FogwallConfig;
 import com.rbc.fogwall.jetty.reload.ConfigHolder;
 import com.rbc.fogwall.provider.ProviderRegistry;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,12 +22,16 @@ public class ProviderController {
     @Autowired
     private ConfigHolder configHolder;
 
+    @Resource(name = "fogwallConfig")
+    private FogwallConfig fogwallConfig;
+
     @Operation(operationId = "listProviders", summary = "List configured providers")
     @GetMapping("/api/providers")
     public List<ProviderInfo> list() {
         // Attestation questions are global — every provider in the response carries the same list.
         // The per-provider API shape is preserved to avoid churning the frontend if we add per-provider variants later.
         List<AttestationQuestion> attestations = configHolder.getAttestations();
+        boolean requireReviewPermission = fogwallConfig.getServer().isRequireReviewPermission();
         return providers.getProviders().stream()
                 .map(p -> new ProviderInfo(
                         p.getName(),
@@ -35,7 +40,8 @@ public class ProviderController {
                         p.getUri().getHost(),
                         "/push" + p.servletPath(),
                         "/proxy" + p.servletPath(),
-                        attestations))
+                        attestations,
+                        requireReviewPermission))
                 .toList();
     }
 
@@ -46,5 +52,6 @@ public class ProviderController {
             String host,
             String pushPath,
             String proxyPath,
-            List<AttestationQuestion> attestationQuestions) {}
+            List<AttestationQuestion> attestationQuestions,
+            boolean requireReviewPermission) {}
 }


### PR DESCRIPTION
## Summary

- **#371**: Adds `pause()`/`resume()` to `HeartbeatSender`. `StoreAndForwardReceivePackFactory` now pauses the heartbeat around `ApprovalPreReceiveHook` so background dots no longer interleave with approval gateway progress messages streamed to the git client.
- **#372**: `ProviderController` exposes `requireReviewPermission` from `ServerConfig` on each provider in `GET /api/providers`. The `AddPermissionModal` in the frontend hides `REVIEW` and `PUSH_AND_REVIEW` grant options when the flag is `false` (the default). Existing DB rows are untouched — purely a display filter.

## Test plan

- [ ] Push that requires human approval: confirm dots stop when "Waiting for approval..." message appears, resume only after approval/rejection
- [ ] With `server.require-review-permission: false` (default): open Add Permission modal, verify only PUSH and SELF_CERTIFY are shown
- [ ] With `server.require-review-permission: true`: open modal, verify all four grants (PUSH, PUSH_AND_REVIEW, REVIEW, SELF_CERTIFY) appear
- [ ] Existing `REVIEW`/`PUSH_AND_REVIEW` rows in the DB still display correctly in the permissions table (no data change)