### PR TITLE
feat: permission groups (#101)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@ progress lines are sent live.
 
 **Transparent proxy** uses servlet filters. The HTTP response is a single buffered reply — there is no mechanism to
 stream partial output mid-filter-chain. Validation filters must _accumulate_ their result and return;
-`ValidationSummaryFilter` (order 4999) and `PushFinalizerFilter` (order 5000) collect everything and write one response
-at the end using `sendGitError`.
+`ValidationSummaryFilter` (order `Integer.MAX_VALUE - 3`) and `PushFinalizerFilter` (order `Integer.MAX_VALUE - 1`)
+collect everything and write one response at the end using `sendGitError`.
 
 ## Reference implementation
 
@@ -57,8 +57,9 @@ bypass the cache and verify the jacoco threshold:
 
 Always verify the threshold passes locally before pushing — CI runs without cache and will catch it.
 
-Unit tests live under each module's `src/test/`. E2e tests are in `fogwall-server/src/test/java/com/rbc/fogwall/e2e/`
-and tagged `@Tag("e2e")`.
+Unit tests live under each module's `src/test/`. E2e tests are tagged `@Tag("e2e")` and live in
+`fogwall-server/src/test/java/com/rbc/fogwall/e2e/` (proxy modes, identity resolution, SSH, config reload) and
+`fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/e2e/` (LDAP/OIDC auth and role mapping).
 
 ## Running the server locally
 
@@ -77,16 +78,23 @@ and tagged `@Tag("e2e")`.
 
 ## Docker Compose
 
-```bash
-docker compose up -d          # fogwall + Gitea (h2-mem database)
-bash docker/gitea-setup.sh          # one-time: create admin user + test repo in Gitea
+Always use the `compose.sh` wrapper — never bare `docker compose`/`podman compose` — it assembles the right `-f` overlay
+flags and auto-detects docker vs podman:
 
-# Optional database backends:
-docker compose --profile postgres up -d   # swap fogwall-local.yml for fogwall-postgres.yml
-docker compose --profile mongo up -d      # swap fogwall-local.yml for fogwall-mongo.yml
+```bash
+bash compose.sh -- up -d                        # fogwall + Gitea (h2-file database)
+bash docker/gitea-setup.sh                      # one-time: create admin user + test repo in Gitea
+
+# Optional overlays, composable:
+bash compose.sh --auth ldap -- up -d            # LDAP auth backend
+bash compose.sh --auth oidc -- up -d            # OIDC auth backend
+bash compose.sh --db postgres -- up -d          # Postgres instead of default h2-file
+bash compose.sh --db mongo -- up -d             # MongoDB instead of default h2-file
+bash compose.sh --auth ldap --db postgres -- down -v
 ```
 
-Config override file mounted at `/app/conf/fogwall-local.yml` inside the container. Templates in `docker/`.
+Default config mounted at `/app/conf/fogwall-docker-default.yml` inside the container. Templates (including
+`fogwall-local.yml` for custom overrides) live in `docker/`.
 
 ## Configuration
 

--- a/fogwall-core/build.gradle
+++ b/fogwall-core/build.gradle
@@ -109,40 +109,61 @@ tasks.named('check') {
 // ---------------------------------------------------------------------------
 // JaCoCo coverage thresholds
 //
-// Strategy: 80% line coverage for all packages where unit tests are the right
-// tool. Packages that legitimately can't hit 80% with unit tests (integration-
-// heavy stores and validation context) get a reduced 65% floor. No threshold
-// for JGit hook wiring, real-HTTP provider code, async servlet plumbing, and
-// MongoDB/JDBC DML boilerplate — those are covered by e2e and smoke tests.
+// Tiered by testability:
+//   95% — security-critical pure logic (permission engine)
+//   90% — pure business logic with no I/O or framework glue
+//   75% — logic packages with some servlet/JGit lifecycle coupling
+//   70% — user store (SSH key methods live in integration/e2e)
+//   60% — validation filter chain (Jetty lifecycle coupling)
+//   no threshold — JGit hook wiring, real-HTTP provider calls, async servlet
+//                  plumbing, and JDBC/MongoDB DML (all covered by e2e)
 // ---------------------------------------------------------------------------
 jacocoTestCoverageVerification {
     violationRules {
 
-        // Most packages: pure logic, fully unit-testable — hold at 80%.
+        // Security-critical: permission engine — held to highest standard.
+        rule {
+            element = 'PACKAGE'
+            includes = [
+                'com.rbc.fogwall.permission',
+            ]
+            limit { counter = 'LINE'; minimum = 0.95 }
+        }
+
+        // Pure business logic — no I/O, no framework lifecycle.
         rule {
             element = 'PACKAGE'
             includes = [
                 'com.rbc.fogwall.service',
                 'com.rbc.fogwall.approval',
                 'com.rbc.fogwall.config',
-                'com.rbc.fogwall.permission',
                 'com.rbc.fogwall.db.model',
                 'com.rbc.fogwall.db.jdbc.mapper',
+                'com.rbc.fogwall.db.memory',
+            ]
+            limit { counter = 'LINE'; minimum = 0.90 }
+        }
+
+        // Logic packages with some servlet/JGit lifecycle coupling.
+        rule {
+            element = 'PACKAGE'
+            includes = [
                 'com.rbc.fogwall.servlet.filter',
                 'com.rbc.fogwall.ssh',
             ]
             limit { counter = 'LINE'; minimum = 0.75 }
         }
 
-        // Reduced floor for packages with more integration complexity.
+        // User store: SSH key methods are covered by integration/e2e tests.
         rule {
             element = 'PACKAGE'
             includes = [
                 'com.rbc.fogwall.user',
             ]
-            limit { counter = 'LINE'; minimum = 0.65 }
+            limit { counter = 'LINE'; minimum = 0.70 }
         }
 
+        // Validation filter chain: some Jetty lifecycle coupling.
         rule {
             element = 'PACKAGE'
             includes = [

--- a/fogwall-core/src/main/java/com/rbc/fogwall/db/MongoStoreFactory.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/db/MongoStoreFactory.java
@@ -7,6 +7,8 @@ import com.rbc.fogwall.db.mongo.MongoPushStore;
 import com.rbc.fogwall.db.mongo.MongoScmTokenCache;
 import com.rbc.fogwall.db.mongo.MongoSshFingerprintCache;
 import com.rbc.fogwall.db.mongo.MongoUrlRuleRegistry;
+import com.rbc.fogwall.permission.GroupPermissionStore;
+import com.rbc.fogwall.permission.MongoGroupPermissionStore;
 import com.rbc.fogwall.permission.MongoRepoPermissionStore;
 import com.rbc.fogwall.permission.PermissionStore;
 import com.rbc.fogwall.permission.RepoPermission;
@@ -65,6 +67,13 @@ public final class MongoStoreFactory implements AutoCloseable {
     /** Create and initialize a {@link PermissionStore} backed by this factory's client. */
     public PermissionStore<RepoPermission> repoPermissionStore() {
         MongoRepoPermissionStore store = new MongoRepoPermissionStore(client, databaseName);
+        store.initialize();
+        return store;
+    }
+
+    /** Create and initialize a {@link GroupPermissionStore} backed by this factory's client. */
+    public GroupPermissionStore groupPermissionStore() {
+        MongoGroupPermissionStore store = new MongoGroupPermissionStore(client, databaseName);
         store.initialize();
         return store;
     }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/db/jdbc/DatabaseMigrator.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/db/jdbc/DatabaseMigrator.java
@@ -48,7 +48,8 @@ public class DatabaseMigrator {
                     "rename operations to operation",
                     "db/migration/V7__rename_operations_to_operation.sql",
                     false),
-            new Migration("8", "user ssh keys", "db/migration/V8__ssh_keys.sql", false));
+            new Migration("8", "user ssh keys", "db/migration/V8__ssh_keys.sql", false),
+            new Migration("9", "permission groups", "db/migration/V9__permission_groups.sql", false));
 
     // ---------------------------------------------------------------------------
 

--- a/fogwall-core/src/main/java/com/rbc/fogwall/permission/GroupPermissionRule.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/permission/GroupPermissionRule.java
@@ -1,0 +1,37 @@
+package com.rbc.fogwall.permission;
+
+import com.rbc.fogwall.db.model.MatchTarget;
+import com.rbc.fogwall.db.model.MatchType;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A single repository permission rule attached to a {@link PermissionGroup}. Semantically identical to
+ * {@link RepoPermission} but scoped to the group rather than an individual user.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupPermissionRule {
+
+    @Builder.Default
+    private String id = UUID.randomUUID().toString();
+
+    private String groupId;
+    private String provider;
+
+    @Builder.Default
+    private MatchTarget target = MatchTarget.SLUG;
+
+    private String value;
+
+    @Builder.Default
+    private MatchType matchType = MatchType.GLOB;
+
+    @Builder.Default
+    private RepoPermission.Grant grant = RepoPermission.Grant.PUSH;
+}

--- a/fogwall-core/src/main/java/com/rbc/fogwall/permission/GroupPermissionStore.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/permission/GroupPermissionStore.java
@@ -1,0 +1,47 @@
+package com.rbc.fogwall.permission;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GroupPermissionStore {
+
+    default void initialize() {}
+
+    // ---- groups ----
+
+    void saveGroup(PermissionGroup group);
+
+    void updateGroup(String id, String name, String description);
+
+    void deleteGroup(String id);
+
+    Optional<PermissionGroup> findGroupById(String id);
+
+    Optional<PermissionGroup> findGroupByName(String name);
+
+    List<PermissionGroup> findAllGroups();
+
+    // ---- members ----
+
+    void addMember(String groupId, String username);
+
+    void removeMember(String groupId, String username);
+
+    List<String> findMembers(String groupId);
+
+    /** Returns the IDs of all groups the given user belongs to. */
+    List<String> findGroupIdsForUser(String username);
+
+    // ---- rules ----
+
+    void saveRule(GroupPermissionRule rule);
+
+    void deleteRule(String ruleId);
+
+    Optional<GroupPermissionRule> findRuleById(String id);
+
+    List<GroupPermissionRule> findRulesForGroup(String groupId);
+
+    /** Returns all rules across all groups for the given provider. */
+    List<GroupPermissionRule> findRulesByProvider(String provider);
+}

--- a/fogwall-core/src/main/java/com/rbc/fogwall/permission/InMemoryGroupPermissionStore.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/permission/InMemoryGroupPermissionStore.java
@@ -1,0 +1,109 @@
+package com.rbc.fogwall.permission;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class InMemoryGroupPermissionStore implements GroupPermissionStore {
+
+    private final Map<String, PermissionGroup> groups = new ConcurrentHashMap<>();
+    private final Map<String, List<String>> members = new ConcurrentHashMap<>(); // groupId → usernames
+    private final Map<String, GroupPermissionRule> rules = new ConcurrentHashMap<>();
+
+    @Override
+    public void saveGroup(PermissionGroup group) {
+        groups.put(group.getId(), group);
+        members.putIfAbsent(group.getId(), new ArrayList<>());
+    }
+
+    @Override
+    public void updateGroup(String id, String name, String description) {
+        groups.computeIfPresent(
+                id,
+                (k, g) -> PermissionGroup.builder()
+                        .id(g.getId())
+                        .name(name)
+                        .description(description)
+                        .source(g.getSource())
+                        .build());
+    }
+
+    @Override
+    public void deleteGroup(String id) {
+        groups.remove(id);
+        members.remove(id);
+        rules.values().removeIf(r -> id.equals(r.getGroupId()));
+    }
+
+    @Override
+    public Optional<PermissionGroup> findGroupById(String id) {
+        return Optional.ofNullable(groups.get(id));
+    }
+
+    @Override
+    public Optional<PermissionGroup> findGroupByName(String name) {
+        return groups.values().stream().filter(g -> name.equals(g.getName())).findFirst();
+    }
+
+    @Override
+    public List<PermissionGroup> findAllGroups() {
+        return groups.values().stream()
+                .sorted((a, b) -> a.getName().compareTo(b.getName()))
+                .toList();
+    }
+
+    @Override
+    public void addMember(String groupId, String username) {
+        members.computeIfAbsent(groupId, k -> new ArrayList<>()).add(username);
+    }
+
+    @Override
+    public void removeMember(String groupId, String username) {
+        var list = members.get(groupId);
+        if (list != null) list.remove(username);
+    }
+
+    @Override
+    public List<String> findMembers(String groupId) {
+        return List.copyOf(members.getOrDefault(groupId, List.of()));
+    }
+
+    @Override
+    public List<String> findGroupIdsForUser(String username) {
+        return members.entrySet().stream()
+                .filter(e -> e.getValue().contains(username))
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    @Override
+    public void saveRule(GroupPermissionRule rule) {
+        rules.put(rule.getId(), rule);
+    }
+
+    @Override
+    public void deleteRule(String ruleId) {
+        rules.remove(ruleId);
+    }
+
+    @Override
+    public Optional<GroupPermissionRule> findRuleById(String id) {
+        return Optional.ofNullable(rules.get(id));
+    }
+
+    @Override
+    public List<GroupPermissionRule> findRulesForGroup(String groupId) {
+        return rules.values().stream()
+                .filter(r -> groupId.equals(r.getGroupId()))
+                .toList();
+    }
+
+    @Override
+    public List<GroupPermissionRule> findRulesByProvider(String provider) {
+        return rules.values().stream()
+                .filter(r -> provider.equals(r.getProvider()))
+                .toList();
+    }
+}

--- a/fogwall-core/src/main/java/com/rbc/fogwall/permission/JdbcGroupPermissionStore.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/permission/JdbcGroupPermissionStore.java
@@ -1,0 +1,173 @@
+package com.rbc.fogwall.permission;
+
+import com.rbc.fogwall.db.model.MatchTarget;
+import com.rbc.fogwall.db.model.MatchType;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+public class JdbcGroupPermissionStore implements GroupPermissionStore {
+
+    private final NamedParameterJdbcTemplate jdbc;
+
+    public JdbcGroupPermissionStore(DataSource dataSource) {
+        this.jdbc = new NamedParameterJdbcTemplate(dataSource);
+    }
+
+    // ---- groups ----
+
+    @Override
+    public void saveGroup(PermissionGroup g) {
+        jdbc.update(
+                """
+                INSERT INTO permission_groups (id, name, description, source)
+                VALUES (:id, :name, :description, :source)
+                """,
+                new MapSqlParameterSource()
+                        .addValue("id", g.getId())
+                        .addValue("name", g.getName())
+                        .addValue("description", g.getDescription())
+                        .addValue("source", g.getSource().name()));
+    }
+
+    @Override
+    public void updateGroup(String id, String name, String description) {
+        jdbc.update(
+                "UPDATE permission_groups SET name = :name, description = :description WHERE id = :id",
+                new MapSqlParameterSource()
+                        .addValue("id", id)
+                        .addValue("name", name)
+                        .addValue("description", description));
+    }
+
+    @Override
+    public void deleteGroup(String id) {
+        jdbc.update("DELETE FROM permission_groups WHERE id = :id", Map.of("id", id));
+    }
+
+    @Override
+    public Optional<PermissionGroup> findGroupById(String id) {
+        var rows = jdbc.query("SELECT * FROM permission_groups WHERE id = :id", Map.of("id", id), GROUP_MAPPER);
+        return rows.isEmpty() ? Optional.empty() : Optional.of(rows.get(0));
+    }
+
+    @Override
+    public Optional<PermissionGroup> findGroupByName(String name) {
+        var rows = jdbc.query("SELECT * FROM permission_groups WHERE name = :name", Map.of("name", name), GROUP_MAPPER);
+        return rows.isEmpty() ? Optional.empty() : Optional.of(rows.get(0));
+    }
+
+    @Override
+    public List<PermissionGroup> findAllGroups() {
+        return jdbc.query("SELECT * FROM permission_groups ORDER BY name", GROUP_MAPPER);
+    }
+
+    // ---- members ----
+
+    @Override
+    public void addMember(String groupId, String username) {
+        jdbc.update(
+                "INSERT INTO group_members (group_id, username) VALUES (:groupId, :username)",
+                Map.of("groupId", groupId, "username", username));
+    }
+
+    @Override
+    public void removeMember(String groupId, String username) {
+        jdbc.update(
+                "DELETE FROM group_members WHERE group_id = :groupId AND username = :username",
+                Map.of("groupId", groupId, "username", username));
+    }
+
+    @Override
+    public List<String> findMembers(String groupId) {
+        return jdbc.queryForList(
+                "SELECT username FROM group_members WHERE group_id = :groupId ORDER BY username",
+                Map.of("groupId", groupId),
+                String.class);
+    }
+
+    @Override
+    public List<String> findGroupIdsForUser(String username) {
+        return jdbc.queryForList(
+                "SELECT group_id FROM group_members WHERE username = :username",
+                Map.of("username", username),
+                String.class);
+    }
+
+    // ---- rules ----
+
+    @Override
+    public void saveRule(GroupPermissionRule r) {
+        jdbc.update(
+                """
+                INSERT INTO group_permissions (id, group_id, provider, target, match_value, match_type, operation)
+                VALUES (:id, :groupId, :provider, :target, :matchValue, :matchType, :operation)
+                """,
+                new MapSqlParameterSource()
+                        .addValue("id", r.getId())
+                        .addValue("groupId", r.getGroupId())
+                        .addValue("provider", r.getProvider())
+                        .addValue("target", r.getTarget().name())
+                        .addValue("matchValue", r.getValue())
+                        .addValue("matchType", r.getMatchType().name())
+                        .addValue("operation", r.getGrant().name()));
+    }
+
+    @Override
+    public void deleteRule(String ruleId) {
+        jdbc.update("DELETE FROM group_permissions WHERE id = :id", Map.of("id", ruleId));
+    }
+
+    @Override
+    public Optional<GroupPermissionRule> findRuleById(String id) {
+        var rows = jdbc.query("SELECT * FROM group_permissions WHERE id = :id", Map.of("id", id), RULE_MAPPER);
+        return rows.isEmpty() ? Optional.empty() : Optional.of(rows.get(0));
+    }
+
+    @Override
+    public List<GroupPermissionRule> findRulesForGroup(String groupId) {
+        return jdbc.query(
+                "SELECT * FROM group_permissions WHERE group_id = :groupId ORDER BY provider, match_value",
+                Map.of("groupId", groupId),
+                RULE_MAPPER);
+    }
+
+    @Override
+    public List<GroupPermissionRule> findRulesByProvider(String provider) {
+        return jdbc.query(
+                "SELECT * FROM group_permissions WHERE provider = :provider ORDER BY group_id, match_value",
+                Map.of("provider", provider),
+                RULE_MAPPER);
+    }
+
+    private static final RowMapper<PermissionGroup> GROUP_MAPPER = JdbcGroupPermissionStore::mapGroup;
+
+    private static PermissionGroup mapGroup(ResultSet rs, int i) throws SQLException {
+        return PermissionGroup.builder()
+                .id(rs.getString("id"))
+                .name(rs.getString("name"))
+                .description(rs.getString("description"))
+                .source(PermissionGroup.Source.valueOf(rs.getString("source")))
+                .build();
+    }
+
+    private static final RowMapper<GroupPermissionRule> RULE_MAPPER = JdbcGroupPermissionStore::mapRule;
+
+    private static GroupPermissionRule mapRule(ResultSet rs, int i) throws SQLException {
+        return GroupPermissionRule.builder()
+                .id(rs.getString("id"))
+                .groupId(rs.getString("group_id"))
+                .provider(rs.getString("provider"))
+                .target(MatchTarget.valueOf(rs.getString("target")))
+                .value(rs.getString("match_value"))
+                .matchType(MatchType.valueOf(rs.getString("match_type")))
+                .grant(RepoPermission.Grant.valueOf(rs.getString("operation")))
+                .build();
+    }
+}

--- a/fogwall-core/src/main/java/com/rbc/fogwall/permission/MongoGroupPermissionStore.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/permission/MongoGroupPermissionStore.java
@@ -1,0 +1,187 @@
+package com.rbc.fogwall.permission;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.Sorts;
+import com.rbc.fogwall.db.model.MatchTarget;
+import com.rbc.fogwall.db.model.MatchType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MongoGroupPermissionStore implements GroupPermissionStore {
+
+    private static final Logger log = LoggerFactory.getLogger(MongoGroupPermissionStore.class);
+    private static final String GROUPS_COLLECTION = "permission_groups";
+    private static final String RULES_COLLECTION = "group_permissions";
+    private static final String MEMBERS_COLLECTION = "group_members";
+
+    private final MongoDatabase database;
+
+    public MongoGroupPermissionStore(MongoClient mongoClient, String databaseName) {
+        this.database = mongoClient.getDatabase(databaseName);
+    }
+
+    @Override
+    public void initialize() {
+        database.getCollection(GROUPS_COLLECTION).createIndex(Indexes.ascending("name"));
+        database.getCollection(RULES_COLLECTION).createIndex(Indexes.ascending("groupId"));
+        database.getCollection(RULES_COLLECTION).createIndex(Indexes.ascending("provider"));
+        database.getCollection(MEMBERS_COLLECTION).createIndex(Indexes.ascending("username"));
+        database.getCollection(MEMBERS_COLLECTION).createIndex(Indexes.ascending("groupId"));
+        log.info("MongoDB group permission store initialized");
+    }
+
+    // ---- groups ----
+
+    @Override
+    public void saveGroup(PermissionGroup g) {
+        groups().insertOne(new Document("_id", g.getId())
+                .append("name", g.getName())
+                .append("description", g.getDescription())
+                .append("source", g.getSource().name()));
+    }
+
+    @Override
+    public void updateGroup(String id, String name, String description) {
+        groups().updateOne(
+                        Filters.eq("_id", id),
+                        new Document("$set", new Document("name", name).append("description", description)));
+    }
+
+    @Override
+    public void deleteGroup(String id) {
+        groups().deleteOne(Filters.eq("_id", id));
+        rules().deleteMany(Filters.eq("groupId", id));
+        members().deleteMany(Filters.eq("groupId", id));
+    }
+
+    @Override
+    public Optional<PermissionGroup> findGroupById(String id) {
+        Document doc = groups().find(Filters.eq("_id", id)).first();
+        return Optional.ofNullable(doc).map(MongoGroupPermissionStore::toGroup);
+    }
+
+    @Override
+    public Optional<PermissionGroup> findGroupByName(String name) {
+        Document doc = groups().find(Filters.eq("name", name)).first();
+        return Optional.ofNullable(doc).map(MongoGroupPermissionStore::toGroup);
+    }
+
+    @Override
+    public List<PermissionGroup> findAllGroups() {
+        List<PermissionGroup> result = new ArrayList<>();
+        groups().find().sort(Sorts.ascending("name")).forEach(doc -> result.add(toGroup(doc)));
+        return result;
+    }
+
+    // ---- members ----
+
+    @Override
+    public void addMember(String groupId, String username) {
+        members().insertOne(new Document("groupId", groupId).append("username", username));
+    }
+
+    @Override
+    public void removeMember(String groupId, String username) {
+        members().deleteOne(Filters.and(Filters.eq("groupId", groupId), Filters.eq("username", username)));
+    }
+
+    @Override
+    public List<String> findMembers(String groupId) {
+        List<String> result = new ArrayList<>();
+        members()
+                .find(Filters.eq("groupId", groupId))
+                .sort(Sorts.ascending("username"))
+                .forEach(doc -> result.add(doc.getString("username")));
+        return result;
+    }
+
+    @Override
+    public List<String> findGroupIdsForUser(String username) {
+        List<String> result = new ArrayList<>();
+        members().find(Filters.eq("username", username)).forEach(doc -> result.add(doc.getString("groupId")));
+        return result;
+    }
+
+    // ---- rules ----
+
+    @Override
+    public void saveRule(GroupPermissionRule r) {
+        rules().insertOne(new Document("_id", r.getId())
+                .append("groupId", r.getGroupId())
+                .append("provider", r.getProvider())
+                .append("target", r.getTarget().name())
+                .append("value", r.getValue())
+                .append("matchType", r.getMatchType().name())
+                .append("operation", r.getGrant().name()));
+    }
+
+    @Override
+    public void deleteRule(String ruleId) {
+        rules().deleteOne(Filters.eq("_id", ruleId));
+    }
+
+    @Override
+    public Optional<GroupPermissionRule> findRuleById(String id) {
+        Document doc = rules().find(Filters.eq("_id", id)).first();
+        return Optional.ofNullable(doc).map(MongoGroupPermissionStore::toRule);
+    }
+
+    @Override
+    public List<GroupPermissionRule> findRulesForGroup(String groupId) {
+        List<GroupPermissionRule> result = new ArrayList<>();
+        rules().find(Filters.eq("groupId", groupId))
+                .sort(Sorts.ascending("provider", "value"))
+                .forEach(doc -> result.add(toRule(doc)));
+        return result;
+    }
+
+    @Override
+    public List<GroupPermissionRule> findRulesByProvider(String provider) {
+        List<GroupPermissionRule> result = new ArrayList<>();
+        rules().find(Filters.eq("provider", provider))
+                .sort(Sorts.ascending("groupId", "value"))
+                .forEach(doc -> result.add(toRule(doc)));
+        return result;
+    }
+
+    private MongoCollection<Document> groups() {
+        return database.getCollection(GROUPS_COLLECTION);
+    }
+
+    private MongoCollection<Document> rules() {
+        return database.getCollection(RULES_COLLECTION);
+    }
+
+    private MongoCollection<Document> members() {
+        return database.getCollection(MEMBERS_COLLECTION);
+    }
+
+    private static PermissionGroup toGroup(Document doc) {
+        return PermissionGroup.builder()
+                .id(doc.getString("_id"))
+                .name(doc.getString("name"))
+                .description(doc.getString("description"))
+                .source(PermissionGroup.Source.valueOf(doc.getString("source")))
+                .build();
+    }
+
+    private static GroupPermissionRule toRule(Document doc) {
+        return GroupPermissionRule.builder()
+                .id(doc.getString("_id"))
+                .groupId(doc.getString("groupId"))
+                .provider(doc.getString("provider"))
+                .target(MatchTarget.valueOf(doc.getString("target")))
+                .value(doc.getString("value"))
+                .matchType(MatchType.valueOf(doc.getString("matchType")))
+                .grant(RepoPermission.Grant.valueOf(doc.getString("operation")))
+                .build();
+    }
+}

--- a/fogwall-core/src/main/java/com/rbc/fogwall/permission/PermissionGroup.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/permission/PermissionGroup.java
@@ -1,0 +1,32 @@
+package com.rbc.fogwall.permission;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A named group of users that share a common set of repository permission rules. Users assigned to a group inherit all
+ * of the group's {@link GroupPermissionRule}s in addition to any directly-assigned {@link RepoPermission}s.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PermissionGroup {
+
+    @Builder.Default
+    private String id = UUID.randomUUID().toString();
+
+    private String name;
+    private String description;
+
+    @Builder.Default
+    private Source source = Source.DB;
+
+    public enum Source {
+        CONFIG,
+        DB
+    }
+}

--- a/fogwall-core/src/main/java/com/rbc/fogwall/permission/RepoPermissionService.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/permission/RepoPermissionService.java
@@ -1,11 +1,13 @@
 package com.rbc.fogwall.permission;
 
+import com.rbc.fogwall.db.model.MatchTarget;
 import com.rbc.fogwall.db.model.MatchType;
 import java.nio.file.FileSystems;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -36,10 +38,16 @@ import lombok.extern.slf4j.Slf4j;
 public class RepoPermissionService {
 
     private final PermissionStore<RepoPermission> store;
+    private final GroupPermissionStore groupStore;
     private final ConcurrentHashMap<String, Pattern> patternCache = new ConcurrentHashMap<>();
 
     public RepoPermissionService(PermissionStore<RepoPermission> store) {
+        this(store, null);
+    }
+
+    public RepoPermissionService(PermissionStore<RepoPermission> store, GroupPermissionStore groupStore) {
         this.store = store;
+        this.groupStore = groupStore;
     }
 
     /**
@@ -64,9 +72,9 @@ public class RepoPermissionService {
      * <em>not</em> imply self-certify — the grant must be explicit.
      */
     public boolean isBypassReviewAllowed(String username, String provider, String path) {
-        List<RepoPermission> forProvider = store.findByProvider(provider);
-        List<RepoPermission> forPath =
-                forProvider.stream().filter(p -> matchesPath(p, path)).toList();
+        List<RepoPermission> forPath = store.findByProvider(provider).stream()
+                .filter(p -> matchesPath(p, path))
+                .toList();
 
         if (forPath.isEmpty()) {
             return false;
@@ -130,6 +138,10 @@ public class RepoPermissionService {
         return store.findByProvider(provider);
     }
 
+    public GroupPermissionStore getGroupStore() {
+        return groupStore;
+    }
+
     /**
      * Seeds permissions from config on startup. Clears all CONFIG-sourced rows and re-inserts to keep YAML
      * authoritative; DB-sourced rows are left untouched.
@@ -185,20 +197,32 @@ public class RepoPermissionService {
     }
 
     private boolean isAllowed(String username, String provider, String path, RepoPermission.Grant op) {
-        List<RepoPermission> forProvider = store.findByProvider(provider);
+        List<RepoPermission> forPath = store.findByProvider(provider).stream()
+                .filter(p -> matchesPath(p, path))
+                .toList();
 
-        List<RepoPermission> forPath =
-                forProvider.stream().filter(p -> matchesPath(p, path)).toList();
+        List<GroupPermissionRule> groupRulesForPath = List.of();
+        if (groupStore != null) {
+            Set<String> userGroupIds = Set.copyOf(groupStore.findGroupIdsForUser(username));
+            groupRulesForPath = groupStore.findRulesByProvider(provider).stream()
+                    .filter(r -> userGroupIds.contains(r.getGroupId()))
+                    .filter(r -> matchesPathRule(r, path))
+                    .toList();
+        }
 
-        if (forPath.isEmpty()) {
+        if (forPath.isEmpty() && groupRulesForPath.isEmpty()) {
             log.debug("No permission grants for {}/{} — DENY (fail-closed)", provider, path);
             return false;
         }
 
-        boolean allowed = forPath.stream()
+        boolean allowedDirect = forPath.stream()
                 .filter(p -> p.getGrant() == op || p.getGrant() == RepoPermission.Grant.PUSH_AND_REVIEW)
                 .anyMatch(p -> username.equals(p.getUsername()));
 
+        boolean allowedViaGroup = groupRulesForPath.stream()
+                .anyMatch(r -> r.getGrant() == op || r.getGrant() == RepoPermission.Grant.PUSH_AND_REVIEW);
+
+        boolean allowed = allowedDirect || allowedViaGroup;
         log.debug(
                 "Permission check: user={} provider={} path={} op={} → {}",
                 username,
@@ -210,10 +234,18 @@ public class RepoPermissionService {
     }
 
     private boolean matchesPath(RepoPermission perm, String path) {
-        return switch (perm.getMatchType()) {
-            case LITERAL -> perm.getValue().equals(path);
-            case GLOB -> matchesGlob(perm.getValue(), path);
-            case REGEX -> matchesRegex(perm.getValue(), path);
+        return matchesPattern(perm.getTarget(), perm.getValue(), perm.getMatchType(), path);
+    }
+
+    private boolean matchesPathRule(GroupPermissionRule rule, String path) {
+        return matchesPattern(rule.getTarget(), rule.getValue(), rule.getMatchType(), path);
+    }
+
+    private boolean matchesPattern(MatchTarget target, String value, MatchType matchType, String path) {
+        return switch (matchType) {
+            case LITERAL -> value.equals(path);
+            case GLOB -> matchesGlob(value, path);
+            case REGEX -> matchesRegex(value, path);
         };
     }
 

--- a/fogwall-core/src/main/resources/db/migration/V9__permission_groups.sql
+++ b/fogwall-core/src/main/resources/db/migration/V9__permission_groups.sql
@@ -1,0 +1,29 @@
+-- Named permission groups. Members of a group inherit the group's repo permission rules.
+CREATE TABLE IF NOT EXISTS permission_groups (
+    id          VARCHAR(36)  PRIMARY KEY,
+    name        VARCHAR(255) NOT NULL UNIQUE,
+    description VARCHAR(512),
+    source      VARCHAR(10)  NOT NULL DEFAULT 'DB'   -- CONFIG | DB
+);
+
+-- Repository permission rules attached to a group (same shape as repo_permissions but group-scoped).
+CREATE TABLE IF NOT EXISTS group_permissions (
+    id          VARCHAR(36)  PRIMARY KEY,
+    group_id    VARCHAR(36)  NOT NULL REFERENCES permission_groups(id) ON DELETE CASCADE,
+    provider    VARCHAR(100) NOT NULL,
+    target      VARCHAR(20)  NOT NULL DEFAULT 'SLUG',
+    match_value VARCHAR(512) NOT NULL,
+    match_type  VARCHAR(10)  NOT NULL DEFAULT 'GLOB',
+    operation   VARCHAR(20)  NOT NULL DEFAULT 'PUSH'
+);
+
+-- Group membership: which users belong to which groups.
+CREATE TABLE IF NOT EXISTS group_members (
+    group_id    VARCHAR(36)  NOT NULL REFERENCES permission_groups(id) ON DELETE CASCADE,
+    username    VARCHAR(255) NOT NULL REFERENCES proxy_users(username) ON DELETE CASCADE,
+    PRIMARY KEY (group_id, username)
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_permissions_group_id ON group_permissions(group_id);
+CREATE INDEX IF NOT EXISTS idx_group_permissions_provider ON group_permissions(provider);
+CREATE INDEX IF NOT EXISTS idx_group_members_username ON group_members(username);

--- a/fogwall-core/src/test/java/com/rbc/fogwall/db/memory/InMemoryFetchStoreTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/db/memory/InMemoryFetchStoreTest.java
@@ -1,0 +1,120 @@
+package com.rbc.fogwall.db.memory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.rbc.fogwall.db.model.FetchRecord;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InMemoryFetchStoreTest {
+
+    InMemoryFetchStore store;
+
+    @BeforeEach
+    void setUp() {
+        store = new InMemoryFetchStore();
+    }
+
+    private FetchRecord rec(String provider, String owner, String repo, FetchRecord.Result result, Instant ts) {
+        return FetchRecord.builder()
+                .provider(provider)
+                .owner(owner)
+                .repoName(repo)
+                .result(result)
+                .timestamp(ts)
+                .build();
+    }
+
+    @Test
+    void record_findRecent_roundTrip() {
+        FetchRecord r = rec("github", "acme", "repo", FetchRecord.Result.ALLOWED, Instant.now());
+        store.record(r);
+
+        var recent = store.findRecent(10);
+        assertEquals(1, recent.size());
+        assertEquals(r.getId(), recent.get(0).getId());
+    }
+
+    @Test
+    void findRecent_orderedNewestFirst() {
+        Instant t0 = Instant.ofEpochSecond(1000);
+        Instant t1 = Instant.ofEpochSecond(2000);
+        Instant t2 = Instant.ofEpochSecond(3000);
+        store.record(rec("github", "acme", "repo", FetchRecord.Result.ALLOWED, t1));
+        store.record(rec("github", "acme", "repo", FetchRecord.Result.ALLOWED, t0));
+        store.record(rec("github", "acme", "repo", FetchRecord.Result.ALLOWED, t2));
+
+        var recent = store.findRecent(10);
+        assertEquals(t2, recent.get(0).getTimestamp());
+        assertEquals(t0, recent.get(2).getTimestamp());
+    }
+
+    @Test
+    void findRecent_respectsLimit() {
+        for (int i = 0; i < 5; i++) {
+            store.record(rec("github", "acme", "repo-" + i, FetchRecord.Result.ALLOWED, Instant.now()));
+        }
+        assertEquals(3, store.findRecent(3).size());
+    }
+
+    @Test
+    void findByRepo_filtersCorrectly() {
+        store.record(rec("github", "acme", "repo", FetchRecord.Result.ALLOWED, Instant.now()));
+        store.record(rec("github", "acme", "other", FetchRecord.Result.ALLOWED, Instant.now()));
+        store.record(rec("gitlab", "acme", "repo", FetchRecord.Result.ALLOWED, Instant.now()));
+
+        var results = store.findByRepo("github", "acme", "repo", 10);
+        assertEquals(1, results.size());
+        assertEquals("repo", results.get(0).getRepoName());
+    }
+
+    @Test
+    void findByRepo_respectsLimit() {
+        Instant base = Instant.ofEpochSecond(1000);
+        for (int i = 0; i < 5; i++) {
+            store.record(rec("github", "acme", "repo", FetchRecord.Result.ALLOWED, base.plusSeconds(i)));
+        }
+        assertEquals(2, store.findByRepo("github", "acme", "repo", 2).size());
+    }
+
+    @Test
+    void summarizeByRepo_groupsAndCountsCorrectly() {
+        store.record(rec("github", "acme", "repo", FetchRecord.Result.ALLOWED, Instant.now()));
+        store.record(rec("github", "acme", "repo", FetchRecord.Result.BLOCKED, Instant.now()));
+        store.record(rec("github", "acme", "repo", FetchRecord.Result.ALLOWED, Instant.now()));
+        store.record(rec("github", "other", "repo", FetchRecord.Result.ALLOWED, Instant.now()));
+
+        var summary = store.summarizeByRepo();
+        assertEquals(2, summary.size());
+
+        var acme = summary.stream()
+                .filter(s -> "acme".equals(s.owner()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(3, acme.total());
+        assertEquals(1, acme.blocked());
+    }
+
+    @Test
+    void summarizeByRepo_orderedByTotalDescending() {
+        store.record(rec("github", "small", "repo", FetchRecord.Result.ALLOWED, Instant.now()));
+        for (int i = 0; i < 3; i++) {
+            store.record(rec("github", "big", "repo", FetchRecord.Result.ALLOWED, Instant.now()));
+        }
+
+        var summary = store.summarizeByRepo();
+        assertEquals("big", summary.get(0).owner());
+        assertEquals("small", summary.get(1).owner());
+    }
+
+    @Test
+    void findRecent_empty_returnsEmptyList() {
+        assertTrue(store.findRecent(10).isEmpty());
+    }
+
+    @Test
+    void initialize_doesNotThrow() {
+        assertDoesNotThrow(() -> store.initialize());
+    }
+}

--- a/fogwall-core/src/test/java/com/rbc/fogwall/db/memory/InMemoryPushStoreTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/db/memory/InMemoryPushStoreTest.java
@@ -184,6 +184,94 @@ class InMemoryPushStoreTest {
         assertThrows(Exception.class, () -> store.approve("not-a-real-id", approvalFor("not-a-real-id")));
     }
 
+    // ---- find by project / user / authorEmail ----
+
+    @Test
+    void find_byProject_returnsMatchingRecords() {
+        PushRecord a = PushRecord.builder()
+                .project("acme")
+                .repoName("repo")
+                .user("dev")
+                .build();
+        PushRecord b = PushRecord.builder()
+                .project("other")
+                .repoName("repo")
+                .user("dev")
+                .build();
+        store.save(a);
+        store.save(b);
+
+        List<PushRecord> results =
+                store.find(PushQuery.builder().project("acme").build());
+        assertEquals(1, results.size());
+        assertEquals("acme", results.get(0).getProject());
+    }
+
+    @Test
+    void find_byUser_returnsMatchingRecords() {
+        store.save(record("a", "refs/heads/main", "repo"));
+        PushRecord other = PushRecord.builder()
+                .commitTo("b")
+                .branch("refs/heads/main")
+                .repoName("repo")
+                .user("alice")
+                .build();
+        store.save(other);
+
+        List<PushRecord> results = store.find(PushQuery.builder().user("alice").build());
+        assertEquals(1, results.size());
+        assertEquals("alice", results.get(0).getUser());
+    }
+
+    @Test
+    void find_byAuthorEmail_returnsMatchingRecords() {
+        store.save(record("a", "refs/heads/main", "repo")); // authorEmail=dev@example.com
+        PushRecord other = PushRecord.builder()
+                .commitTo("b")
+                .branch("refs/heads/main")
+                .repoName("repo")
+                .user("bob")
+                .authorEmail("bob@example.com")
+                .build();
+        store.save(other);
+
+        List<PushRecord> results =
+                store.find(PushQuery.builder().authorEmail("bob@example.com").build());
+        assertEquals(1, results.size());
+        assertEquals("bob@example.com", results.get(0).getAuthorEmail());
+    }
+
+    // ---- updateForwardStatus ----
+
+    @Test
+    void updateForwardStatus_setsStatusAndErrorMessage() {
+        PushRecord r = record("abc", "refs/heads/main", "repo");
+        store.save(r);
+
+        store.updateForwardStatus(r.getId(), PushStatus.REJECTED, "upstream error");
+
+        PushRecord updated = store.findById(r.getId()).orElseThrow();
+        assertEquals(PushStatus.REJECTED, updated.getStatus());
+        assertEquals("upstream error", updated.getErrorMessage());
+        assertNotNull(updated.getForwardedAt());
+    }
+
+    @Test
+    void updateForwardStatus_nullErrorMessage_doesNotOverwrite() {
+        PushRecord r = record("abc", "refs/heads/main", "repo");
+        store.save(r);
+
+        store.updateForwardStatus(r.getId(), PushStatus.APPROVED, null);
+
+        assertEquals(
+                PushStatus.APPROVED, store.findById(r.getId()).orElseThrow().getStatus());
+    }
+
+    @Test
+    void updateForwardStatus_unknownId_noOp() {
+        assertDoesNotThrow(() -> store.updateForwardStatus("no-such-id", PushStatus.REJECTED, "err"));
+    }
+
     // ---- initialize (no-op for in-memory) ----
 
     @Test

--- a/fogwall-core/src/test/java/com/rbc/fogwall/db/memory/InMemoryUrlRuleRegistryTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/db/memory/InMemoryUrlRuleRegistryTest.java
@@ -1,0 +1,100 @@
+package com.rbc.fogwall.db.memory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.rbc.fogwall.db.model.AccessRule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InMemoryUrlRuleRegistryTest {
+
+    InMemoryUrlRuleRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new InMemoryUrlRuleRegistry();
+    }
+
+    private AccessRule rule(String value, int order) {
+        return AccessRule.builder().value(value).ruleOrder(order).build();
+    }
+
+    private AccessRule rule(String value, int order, String provider, boolean enabled) {
+        return AccessRule.builder()
+                .value(value)
+                .ruleOrder(order)
+                .provider(provider)
+                .enabled(enabled)
+                .build();
+    }
+
+    @Test
+    void save_findById_roundTrip() {
+        AccessRule r = rule("/acme/*", 10);
+        registry.save(r);
+
+        var found = registry.findById(r.getId());
+        assertTrue(found.isPresent());
+        assertEquals("/acme/*", found.get().getValue());
+    }
+
+    @Test
+    void findById_unknownId_empty() {
+        assertTrue(registry.findById("missing").isEmpty());
+    }
+
+    @Test
+    void update_replacesRule() {
+        AccessRule r = rule("/acme/*", 10);
+        registry.save(r);
+
+        AccessRule updated = AccessRule.builder()
+                .id(r.getId())
+                .value("/acme/**")
+                .ruleOrder(20)
+                .build();
+        registry.update(updated);
+
+        assertEquals("/acme/**", registry.findById(r.getId()).orElseThrow().getValue());
+    }
+
+    @Test
+    void delete_removesRule() {
+        AccessRule r = rule("/acme/*", 10);
+        registry.save(r);
+        registry.delete(r.getId());
+        assertTrue(registry.findById(r.getId()).isEmpty());
+    }
+
+    @Test
+    void findAll_sortedByOrderThenId() {
+        AccessRule a = rule("/a", 20);
+        AccessRule b = rule("/b", 10);
+        AccessRule c = rule("/c", 20);
+        registry.save(a);
+        registry.save(b);
+        registry.save(c);
+
+        var all = registry.findAll();
+        assertEquals(3, all.size());
+        assertEquals("/b", all.get(0).getValue());
+    }
+
+    @Test
+    void initialize_doesNotThrow() {
+        assertDoesNotThrow(() -> registry.initialize());
+    }
+
+    @Test
+    void findEnabledForProvider_filtersDisabledAndWrongProvider() {
+        registry.save(rule("/allow-all", 10, null, true));
+        registry.save(rule("/github-only", 20, "github", true));
+        registry.save(rule("/gitlab-only", 30, "gitlab", true));
+        registry.save(rule("/disabled", 5, null, false));
+
+        var results = registry.findEnabledForProvider("github");
+        assertEquals(2, results.size());
+        assertTrue(results.stream().anyMatch(r -> "/allow-all".equals(r.getValue())));
+        assertTrue(results.stream().anyMatch(r -> "/github-only".equals(r.getValue())));
+    }
+}

--- a/fogwall-core/src/test/java/com/rbc/fogwall/db/mongo/MongoFetchStoreIntegrationTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/db/mongo/MongoFetchStoreIntegrationTest.java
@@ -19,7 +19,8 @@ import org.testcontainers.utility.DockerImageName;
 class MongoFetchStoreIntegrationTest {
 
     @Container
-    static final MongoDBContainer MONGO = new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
+    static final MongoDBContainer MONGO =
+            new MongoDBContainer(DockerImageName.parse("docker.io/mongo:7.0").asCompatibleSubstituteFor("mongo"));
 
     MongoFetchStore store;
 

--- a/fogwall-core/src/test/java/com/rbc/fogwall/db/mongo/MongoPushStoreIntegrationTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/db/mongo/MongoPushStoreIntegrationTest.java
@@ -19,7 +19,8 @@ import org.testcontainers.utility.DockerImageName;
 class MongoPushStoreIntegrationTest {
 
     @Container
-    static final MongoDBContainer MONGO = new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
+    static final MongoDBContainer MONGO =
+            new MongoDBContainer(DockerImageName.parse("docker.io/mongo:7.0").asCompatibleSubstituteFor("mongo"));
 
     MongoPushStore store;
 

--- a/fogwall-core/src/test/java/com/rbc/fogwall/db/mongo/MongoUrlRuleRegistryIntegrationTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/db/mongo/MongoUrlRuleRegistryIntegrationTest.java
@@ -19,7 +19,8 @@ import org.testcontainers.utility.DockerImageName;
 class MongoUrlRuleRegistryIntegrationTest {
 
     @Container
-    static final MongoDBContainer MONGO = new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
+    static final MongoDBContainer MONGO =
+            new MongoDBContainer(DockerImageName.parse("docker.io/mongo:7.0").asCompatibleSubstituteFor("mongo"));
 
     MongoUrlRuleRegistry registry;
 

--- a/fogwall-core/src/test/java/com/rbc/fogwall/permission/GroupPermissionServiceTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/permission/GroupPermissionServiceTest.java
@@ -1,0 +1,187 @@
+package com.rbc.fogwall.permission;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.rbc.fogwall.db.model.MatchType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link RepoPermissionService} group-union semantics using in-memory stores. */
+class GroupPermissionServiceTest {
+
+    RepoPermissionService svc;
+    InMemoryGroupPermissionStore groupStore;
+
+    @BeforeEach
+    void setUp() {
+        groupStore = new InMemoryGroupPermissionStore();
+        svc = new RepoPermissionService(new InMemoryRepoPermissionStore(), groupStore);
+    }
+
+    private PermissionGroup group(String name) {
+        PermissionGroup g = PermissionGroup.builder()
+                .name(name)
+                .source(PermissionGroup.Source.DB)
+                .build();
+        groupStore.saveGroup(g);
+        return g;
+    }
+
+    private GroupPermissionRule rule(String groupId, String provider, String value, RepoPermission.Grant grant) {
+        GroupPermissionRule r = GroupPermissionRule.builder()
+                .groupId(groupId)
+                .provider(provider)
+                .value(value)
+                .matchType(MatchType.LITERAL)
+                .grant(grant)
+                .build();
+        groupStore.saveRule(r);
+        return r;
+    }
+
+    private GroupPermissionRule globRule(String groupId, String provider, String value, RepoPermission.Grant grant) {
+        GroupPermissionRule r = GroupPermissionRule.builder()
+                .groupId(groupId)
+                .provider(provider)
+                .value(value)
+                .matchType(MatchType.GLOB)
+                .grant(grant)
+                .build();
+        groupStore.saveRule(r);
+        return r;
+    }
+
+    // ---- group member can push via group rule ----
+
+    @Test
+    void groupMember_allowedViaPushRule() {
+        PermissionGroup g = group("devs");
+        rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        groupStore.addMember(g.getId(), "alice");
+
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/repo"));
+    }
+
+    @Test
+    void groupMember_allowedViaReviewRule() {
+        PermissionGroup g = group("reviewers");
+        rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.REVIEW);
+        groupStore.addMember(g.getId(), "alice");
+
+        assertTrue(svc.isAllowedToReview("alice", "github", "/acme/repo"));
+    }
+
+    @Test
+    void groupMember_pushAndReview_allowsBoth() {
+        PermissionGroup g = group("devs");
+        rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH_AND_REVIEW);
+        groupStore.addMember(g.getId(), "alice");
+
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/repo"));
+        assertTrue(svc.isAllowedToReview("alice", "github", "/acme/repo"));
+    }
+
+    // ---- non-member cannot use group rules ----
+
+    @Test
+    void nonMember_deniedByGroupRule() {
+        PermissionGroup g = group("devs");
+        rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        groupStore.addMember(g.getId(), "alice");
+
+        assertFalse(svc.isAllowedToPush("bob", "github", "/acme/repo"));
+    }
+
+    // ---- fail-closed: path has group rules but user is not a member ----
+
+    @Test
+    void pathCoveredByGroupRule_nonMember_denied() {
+        PermissionGroup g = group("devs");
+        rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        // no members added
+
+        assertFalse(svc.isAllowedToPush("alice", "github", "/acme/repo"));
+    }
+
+    // ---- union: direct OR group grants access ----
+
+    @Test
+    void directGrant_noGroupMembership_stillAllowed() {
+        PermissionGroup g = group("devs");
+        rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        groupStore.addMember(g.getId(), "alice");
+
+        RepoPermission direct = RepoPermission.builder()
+                .username("bob")
+                .provider("github")
+                .value("/acme/repo")
+                .matchType(MatchType.LITERAL)
+                .grant(RepoPermission.Grant.PUSH)
+                .source(RepoPermission.Source.DB)
+                .build();
+        svc.save(direct);
+
+        assertTrue(svc.isAllowedToPush("bob", "github", "/acme/repo"));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/repo"));
+    }
+
+    // ---- glob rules in groups ----
+
+    @Test
+    void groupGlobRule_matchesAllReposUnderOwner() {
+        PermissionGroup g = group("devs");
+        globRule(g.getId(), "github", "/acme/*", RepoPermission.Grant.PUSH);
+        groupStore.addMember(g.getId(), "alice");
+
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/repo-a"));
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/repo-b"));
+        assertFalse(svc.isAllowedToPush("alice", "github", "/other/repo"));
+    }
+
+    // ---- provider isolation ----
+
+    @Test
+    void groupRule_doesNotApplyToOtherProvider() {
+        PermissionGroup g = group("devs");
+        rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        groupStore.addMember(g.getId(), "alice");
+
+        assertFalse(svc.isAllowedToPush("alice", "gitlab", "/acme/repo"));
+    }
+
+    // ---- push-only rule does not grant review ----
+
+    @Test
+    void pushOnlyGroupRule_deniesReview() {
+        PermissionGroup g = group("devs");
+        rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        groupStore.addMember(g.getId(), "alice");
+
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/repo"));
+        assertFalse(svc.isAllowedToReview("alice", "github", "/acme/repo"));
+    }
+
+    // ---- multiple groups ----
+
+    @Test
+    void userInMultipleGroups_unionOfAllRules() {
+        PermissionGroup pushers = group("pushers");
+        rule(pushers.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        groupStore.addMember(pushers.getId(), "alice");
+
+        PermissionGroup reviewers = group("reviewers");
+        rule(reviewers.getId(), "github", "/acme/repo", RepoPermission.Grant.REVIEW);
+        groupStore.addMember(reviewers.getId(), "alice");
+
+        assertTrue(svc.isAllowedToPush("alice", "github", "/acme/repo"));
+        assertTrue(svc.isAllowedToReview("alice", "github", "/acme/repo"));
+    }
+
+    // ---- no group store configured ----
+
+    @Test
+    void noGroupStore_noDirectPermissions_denied() {
+        RepoPermissionService noGroupSvc = new RepoPermissionService(new InMemoryRepoPermissionStore());
+        assertFalse(noGroupSvc.isAllowedToPush("alice", "github", "/acme/repo"));
+    }
+}

--- a/fogwall-core/src/test/java/com/rbc/fogwall/permission/InMemoryGroupPermissionStoreTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/permission/InMemoryGroupPermissionStoreTest.java
@@ -1,0 +1,187 @@
+package com.rbc.fogwall.permission;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.rbc.fogwall.db.model.MatchType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InMemoryGroupPermissionStoreTest {
+
+    InMemoryGroupPermissionStore store;
+
+    @BeforeEach
+    void setUp() {
+        store = new InMemoryGroupPermissionStore();
+    }
+
+    private PermissionGroup dbGroup(String name) {
+        PermissionGroup g = PermissionGroup.builder()
+                .name(name)
+                .source(PermissionGroup.Source.DB)
+                .build();
+        store.saveGroup(g);
+        return g;
+    }
+
+    private GroupPermissionRule rule(String groupId, String provider, String value) {
+        GroupPermissionRule r = GroupPermissionRule.builder()
+                .groupId(groupId)
+                .provider(provider)
+                .value(value)
+                .matchType(MatchType.LITERAL)
+                .grant(RepoPermission.Grant.PUSH)
+                .build();
+        store.saveRule(r);
+        return r;
+    }
+
+    // ---- groups ----
+
+    @Test
+    void saveGroup_findById_roundTrip() {
+        PermissionGroup g = dbGroup("devs");
+        var found = store.findGroupById(g.getId());
+        assertTrue(found.isPresent());
+        assertEquals("devs", found.get().getName());
+        assertEquals(PermissionGroup.Source.DB, found.get().getSource());
+    }
+
+    @Test
+    void findGroupByName_returnsGroup() {
+        PermissionGroup g = dbGroup("devs");
+        assertTrue(store.findGroupByName("devs").isPresent());
+        assertEquals(g.getId(), store.findGroupByName("devs").get().getId());
+    }
+
+    @Test
+    void findGroupByName_unknownName_empty() {
+        assertTrue(store.findGroupByName("nobody").isEmpty());
+    }
+
+    @Test
+    void findAllGroups_sortedByName() {
+        dbGroup("zebra");
+        dbGroup("alpha");
+        dbGroup("middle");
+        var all = store.findAllGroups();
+        assertEquals(
+                List.of("alpha", "middle", "zebra"),
+                all.stream().map(PermissionGroup::getName).toList());
+    }
+
+    @Test
+    void updateGroup_changesNameAndDescription() {
+        PermissionGroup g = dbGroup("devs");
+        store.updateGroup(g.getId(), "engineers", "All engineers");
+        var updated = store.findGroupById(g.getId()).orElseThrow();
+        assertEquals("engineers", updated.getName());
+        assertEquals("All engineers", updated.getDescription());
+        assertEquals(PermissionGroup.Source.DB, updated.getSource());
+    }
+
+    @Test
+    void deleteGroup_removesGroupMembersAndRules() {
+        PermissionGroup g = dbGroup("devs");
+        store.addMember(g.getId(), "alice");
+        rule(g.getId(), "github", "/acme/repo");
+
+        store.deleteGroup(g.getId());
+
+        assertTrue(store.findGroupById(g.getId()).isEmpty());
+        assertTrue(store.findMembers(g.getId()).isEmpty());
+        assertTrue(store.findRulesForGroup(g.getId()).isEmpty());
+    }
+
+    // ---- members ----
+
+    @Test
+    void addMember_findMembers_roundTrip() {
+        PermissionGroup g = dbGroup("devs");
+        store.addMember(g.getId(), "alice");
+        store.addMember(g.getId(), "bob");
+
+        var members = store.findMembers(g.getId());
+        assertEquals(2, members.size());
+        assertTrue(members.contains("alice"));
+        assertTrue(members.contains("bob"));
+    }
+
+    @Test
+    void removeMember_noLongerReturned() {
+        PermissionGroup g = dbGroup("devs");
+        store.addMember(g.getId(), "alice");
+        store.removeMember(g.getId(), "alice");
+        assertTrue(store.findMembers(g.getId()).isEmpty());
+    }
+
+    @Test
+    void findGroupIdsForUser_returnsAllGroupsUserBelongsTo() {
+        PermissionGroup g1 = dbGroup("devs");
+        PermissionGroup g2 = dbGroup("admins");
+        store.addMember(g1.getId(), "alice");
+        store.addMember(g2.getId(), "alice");
+        store.addMember(g1.getId(), "bob");
+
+        var aliceGroups = store.findGroupIdsForUser("alice");
+        assertEquals(2, aliceGroups.size());
+        assertTrue(aliceGroups.contains(g1.getId()));
+        assertTrue(aliceGroups.contains(g2.getId()));
+
+        var bobGroups = store.findGroupIdsForUser("bob");
+        assertEquals(1, bobGroups.size());
+        assertEquals(g1.getId(), bobGroups.get(0));
+    }
+
+    @Test
+    void findGroupIdsForUser_notMember_empty() {
+        assertTrue(store.findGroupIdsForUser("nobody").isEmpty());
+    }
+
+    // ---- rules ----
+
+    @Test
+    void saveRule_findRuleById_roundTrip() {
+        PermissionGroup g = dbGroup("devs");
+        GroupPermissionRule r = rule(g.getId(), "github", "/acme/repo");
+
+        var found = store.findRuleById(r.getId());
+        assertTrue(found.isPresent());
+        assertEquals("github", found.get().getProvider());
+        assertEquals("/acme/repo", found.get().getValue());
+    }
+
+    @Test
+    void findRulesForGroup_returnsOnlyThatGroup() {
+        PermissionGroup g1 = dbGroup("devs");
+        PermissionGroup g2 = dbGroup("ops");
+        rule(g1.getId(), "github", "/acme/repo");
+        rule(g2.getId(), "github", "/other/repo");
+
+        var rules = store.findRulesForGroup(g1.getId());
+        assertEquals(1, rules.size());
+        assertEquals("/acme/repo", rules.get(0).getValue());
+    }
+
+    @Test
+    void findRulesByProvider_returnsAcrossGroups() {
+        PermissionGroup g1 = dbGroup("devs");
+        PermissionGroup g2 = dbGroup("ops");
+        rule(g1.getId(), "github", "/acme/repo");
+        rule(g2.getId(), "github", "/other/repo");
+        rule(g1.getId(), "gitlab", "/acme/repo");
+
+        var githubRules = store.findRulesByProvider("github");
+        assertEquals(2, githubRules.size());
+    }
+
+    @Test
+    void deleteRule_removedFromStore() {
+        PermissionGroup g = dbGroup("devs");
+        GroupPermissionRule r = rule(g.getId(), "github", "/acme/repo");
+        store.deleteRule(r.getId());
+        assertTrue(store.findRuleById(r.getId()).isEmpty());
+        assertTrue(store.findRulesForGroup(g.getId()).isEmpty());
+    }
+}

--- a/fogwall-core/src/test/java/com/rbc/fogwall/permission/JdbcGroupPermissionStoreIntegrationTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/permission/JdbcGroupPermissionStoreIntegrationTest.java
@@ -1,0 +1,214 @@
+package com.rbc.fogwall.permission;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.rbc.fogwall.db.jdbc.DataSourceFactory;
+import com.rbc.fogwall.db.jdbc.DatabaseMigrator;
+import com.rbc.fogwall.db.model.MatchType;
+import java.util.Map;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+/**
+ * Integration tests for {@link JdbcGroupPermissionStore} backed by an H2 in-memory database.
+ *
+ * <p>Each test gets its own isolated H2 database via a unique name to prevent state leakage.
+ */
+class JdbcGroupPermissionStoreIntegrationTest {
+
+    JdbcGroupPermissionStore store;
+    NamedParameterJdbcTemplate jdbc;
+
+    @BeforeEach
+    void setUp() {
+        DataSource ds = DataSourceFactory.h2InMemory("group-test-" + UUID.randomUUID());
+        DatabaseMigrator.migrate(ds);
+        store = new JdbcGroupPermissionStore(ds);
+        jdbc = new NamedParameterJdbcTemplate(ds);
+        seedUser("alice");
+        seedUser("bob");
+    }
+
+    private void seedUser(String username) {
+        jdbc.update("INSERT INTO proxy_users (username, roles) VALUES (:u, 'USER')", Map.of("u", username));
+    }
+
+    private PermissionGroup dbGroup(String name) {
+        PermissionGroup g = PermissionGroup.builder()
+                .name(name)
+                .source(PermissionGroup.Source.DB)
+                .build();
+        store.saveGroup(g);
+        return g;
+    }
+
+    private GroupPermissionRule rule(String groupId, String provider, String value, RepoPermission.Grant grant) {
+        GroupPermissionRule r = GroupPermissionRule.builder()
+                .groupId(groupId)
+                .provider(provider)
+                .value(value)
+                .matchType(MatchType.LITERAL)
+                .grant(grant)
+                .build();
+        store.saveRule(r);
+        return r;
+    }
+
+    // ---- groups ----
+
+    @Test
+    void saveGroup_findById_roundTrip() {
+        PermissionGroup g = dbGroup("devs");
+        var found = store.findGroupById(g.getId());
+        assertTrue(found.isPresent());
+        assertEquals("devs", found.get().getName());
+        assertEquals(PermissionGroup.Source.DB, found.get().getSource());
+    }
+
+    @Test
+    void findGroupByName_returnsGroup() {
+        PermissionGroup g = dbGroup("devs");
+        var found = store.findGroupByName("devs");
+        assertTrue(found.isPresent());
+        assertEquals(g.getId(), found.get().getId());
+    }
+
+    @Test
+    void findGroupByName_unknownName_empty() {
+        assertTrue(store.findGroupByName("nobody").isEmpty());
+    }
+
+    @Test
+    void findAllGroups_sortedByName() {
+        dbGroup("zebra");
+        dbGroup("alpha");
+        dbGroup("middle");
+        var names = store.findAllGroups().stream().map(PermissionGroup::getName).toList();
+        assertEquals(java.util.List.of("alpha", "middle", "zebra"), names);
+    }
+
+    @Test
+    void updateGroup_changesNameAndDescription() {
+        PermissionGroup g = dbGroup("devs");
+        store.updateGroup(g.getId(), "engineers", "All engineers");
+        var updated = store.findGroupById(g.getId()).orElseThrow();
+        assertEquals("engineers", updated.getName());
+        assertEquals("All engineers", updated.getDescription());
+        assertEquals(PermissionGroup.Source.DB, updated.getSource());
+    }
+
+    @Test
+    void deleteGroup_cascadesRulesAndMembers() {
+        PermissionGroup g = dbGroup("devs");
+        store.addMember(g.getId(), "alice");
+        rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+
+        store.deleteGroup(g.getId());
+
+        assertTrue(store.findGroupById(g.getId()).isEmpty());
+        assertTrue(store.findMembers(g.getId()).isEmpty());
+        assertTrue(store.findRulesForGroup(g.getId()).isEmpty());
+    }
+
+    // ---- members ----
+
+    @Test
+    void addMember_findMembers_roundTrip() {
+        PermissionGroup g = dbGroup("devs");
+        store.addMember(g.getId(), "alice");
+        store.addMember(g.getId(), "bob");
+
+        var members = store.findMembers(g.getId());
+        assertEquals(2, members.size());
+        assertTrue(members.contains("alice"));
+        assertTrue(members.contains("bob"));
+    }
+
+    @Test
+    void removeMember_removedFromList() {
+        PermissionGroup g = dbGroup("devs");
+        store.addMember(g.getId(), "alice");
+        store.removeMember(g.getId(), "alice");
+        assertTrue(store.findMembers(g.getId()).isEmpty());
+    }
+
+    @Test
+    void findGroupIdsForUser_returnsAllGroups() {
+        PermissionGroup g1 = dbGroup("devs");
+        PermissionGroup g2 = dbGroup("admins");
+        store.addMember(g1.getId(), "alice");
+        store.addMember(g2.getId(), "alice");
+        store.addMember(g1.getId(), "bob");
+
+        var aliceGroups = store.findGroupIdsForUser("alice");
+        assertEquals(2, aliceGroups.size());
+        assertTrue(aliceGroups.contains(g1.getId()));
+        assertTrue(aliceGroups.contains(g2.getId()));
+    }
+
+    @Test
+    void findGroupIdsForUser_notMember_empty() {
+        assertTrue(store.findGroupIdsForUser("alice").isEmpty());
+    }
+
+    // ---- rules ----
+
+    @Test
+    void saveRule_findRuleById_roundTrip() {
+        PermissionGroup g = dbGroup("devs");
+        GroupPermissionRule r = rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+
+        var found = store.findRuleById(r.getId());
+        assertTrue(found.isPresent());
+        assertEquals("github", found.get().getProvider());
+        assertEquals("/acme/repo", found.get().getValue());
+        assertEquals(RepoPermission.Grant.PUSH, found.get().getGrant());
+    }
+
+    @Test
+    void findRulesForGroup_returnsOnlyThatGroup() {
+        PermissionGroup g1 = dbGroup("devs");
+        PermissionGroup g2 = dbGroup("ops");
+        rule(g1.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        rule(g2.getId(), "github", "/other/repo", RepoPermission.Grant.REVIEW);
+
+        var rules = store.findRulesForGroup(g1.getId());
+        assertEquals(1, rules.size());
+        assertEquals("/acme/repo", rules.get(0).getValue());
+    }
+
+    @Test
+    void findRulesByProvider_returnsAcrossGroups() {
+        PermissionGroup g1 = dbGroup("devs");
+        PermissionGroup g2 = dbGroup("ops");
+        rule(g1.getId(), "github", "/acme/a", RepoPermission.Grant.PUSH);
+        rule(g2.getId(), "github", "/acme/b", RepoPermission.Grant.PUSH);
+        rule(g1.getId(), "gitlab", "/acme/a", RepoPermission.Grant.PUSH);
+
+        var githubRules = store.findRulesByProvider("github");
+        assertEquals(2, githubRules.size());
+        assertTrue(githubRules.stream().allMatch(r -> "github".equals(r.getProvider())));
+    }
+
+    @Test
+    void deleteRule_removedFromGroup() {
+        PermissionGroup g = dbGroup("devs");
+        GroupPermissionRule r = rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        store.deleteRule(r.getId());
+        assertTrue(store.findRuleById(r.getId()).isEmpty());
+        assertTrue(store.findRulesForGroup(g.getId()).isEmpty());
+    }
+
+    @Test
+    void allGrantTypes_roundTrip() {
+        PermissionGroup g = dbGroup("devs");
+        for (var grant : RepoPermission.Grant.values()) {
+            GroupPermissionRule r =
+                    rule(g.getId(), "github", "/acme/" + grant.name().toLowerCase(), grant);
+            assertEquals(grant, store.findRuleById(r.getId()).orElseThrow().getGrant());
+        }
+    }
+}

--- a/fogwall-core/src/test/java/com/rbc/fogwall/permission/JdbcRepoPermissionStoreIntegrationTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/permission/JdbcRepoPermissionStoreIntegrationTest.java
@@ -72,6 +72,13 @@ class JdbcRepoPermissionStoreIntegrationTest {
         assertTrue(store.findById("does-not-exist").isEmpty());
     }
 
+    @Test
+    void save_unseededUser_autoCreatesUserRow() {
+        RepoPermission p = perm("newuser", "github", "/owner/repo");
+        store.save(p);
+        assertTrue(store.findById(p.getId()).isPresent());
+    }
+
     // ---- delete ----
 
     @Test

--- a/fogwall-core/src/test/java/com/rbc/fogwall/permission/MongoGroupPermissionStoreIntegrationTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/permission/MongoGroupPermissionStoreIntegrationTest.java
@@ -1,0 +1,198 @@
+package com.rbc.fogwall.permission;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.mongodb.client.MongoClients;
+import com.rbc.fogwall.db.model.MatchType;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+@Tag("integration")
+class MongoGroupPermissionStoreIntegrationTest {
+
+    @Container
+    static final MongoDBContainer MONGO = new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
+
+    MongoGroupPermissionStore store;
+
+    @BeforeEach
+    void setUp() {
+        store = new MongoGroupPermissionStore(
+                MongoClients.create(MONGO.getConnectionString()),
+                "testdb_" + UUID.randomUUID().toString().replace("-", ""));
+        store.initialize();
+    }
+
+    private PermissionGroup dbGroup(String name) {
+        PermissionGroup g = PermissionGroup.builder()
+                .name(name)
+                .source(PermissionGroup.Source.DB)
+                .build();
+        store.saveGroup(g);
+        return g;
+    }
+
+    private GroupPermissionRule rule(String groupId, String provider, String value, RepoPermission.Grant grant) {
+        GroupPermissionRule r = GroupPermissionRule.builder()
+                .groupId(groupId)
+                .provider(provider)
+                .value(value)
+                .matchType(MatchType.LITERAL)
+                .grant(grant)
+                .build();
+        store.saveRule(r);
+        return r;
+    }
+
+    // ---- groups ----
+
+    @Test
+    void saveGroup_findById_roundTrip() {
+        PermissionGroup g = dbGroup("devs");
+        var found = store.findGroupById(g.getId());
+        assertTrue(found.isPresent());
+        assertEquals("devs", found.get().getName());
+        assertEquals(PermissionGroup.Source.DB, found.get().getSource());
+    }
+
+    @Test
+    void findGroupByName_returnsGroup() {
+        PermissionGroup g = dbGroup("devs");
+        var found = store.findGroupByName("devs");
+        assertTrue(found.isPresent());
+        assertEquals(g.getId(), found.get().getId());
+    }
+
+    @Test
+    void findAllGroups_sortedByName() {
+        dbGroup("zebra");
+        dbGroup("alpha");
+        dbGroup("middle");
+        var names = store.findAllGroups().stream().map(PermissionGroup::getName).toList();
+        assertEquals(java.util.List.of("alpha", "middle", "zebra"), names);
+    }
+
+    @Test
+    void updateGroup_changesNameAndDescription() {
+        PermissionGroup g = dbGroup("devs");
+        store.updateGroup(g.getId(), "engineers", "All engineers");
+        var updated = store.findGroupById(g.getId()).orElseThrow();
+        assertEquals("engineers", updated.getName());
+        assertEquals("All engineers", updated.getDescription());
+        assertEquals(PermissionGroup.Source.DB, updated.getSource());
+    }
+
+    @Test
+    void deleteGroup_cascadesRulesAndMembers() {
+        PermissionGroup g = dbGroup("devs");
+        store.addMember(g.getId(), "alice");
+        rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+
+        store.deleteGroup(g.getId());
+
+        assertTrue(store.findGroupById(g.getId()).isEmpty());
+        assertTrue(store.findMembers(g.getId()).isEmpty());
+        assertTrue(store.findRulesForGroup(g.getId()).isEmpty());
+    }
+
+    // ---- members ----
+
+    @Test
+    void addMember_findMembers_roundTrip() {
+        PermissionGroup g = dbGroup("devs");
+        store.addMember(g.getId(), "alice");
+        store.addMember(g.getId(), "bob");
+
+        var members = store.findMembers(g.getId());
+        assertEquals(2, members.size());
+        assertTrue(members.contains("alice"));
+        assertTrue(members.contains("bob"));
+    }
+
+    @Test
+    void removeMember_removedFromList() {
+        PermissionGroup g = dbGroup("devs");
+        store.addMember(g.getId(), "alice");
+        store.removeMember(g.getId(), "alice");
+        assertTrue(store.findMembers(g.getId()).isEmpty());
+    }
+
+    @Test
+    void findGroupIdsForUser_returnsAllGroups() {
+        PermissionGroup g1 = dbGroup("devs");
+        PermissionGroup g2 = dbGroup("admins");
+        store.addMember(g1.getId(), "alice");
+        store.addMember(g2.getId(), "alice");
+        store.addMember(g1.getId(), "bob");
+
+        var aliceGroups = store.findGroupIdsForUser("alice");
+        assertEquals(2, aliceGroups.size());
+        assertTrue(aliceGroups.contains(g1.getId()));
+        assertTrue(aliceGroups.contains(g2.getId()));
+    }
+
+    // ---- rules ----
+
+    @Test
+    void saveRule_findRuleById_roundTrip() {
+        PermissionGroup g = dbGroup("devs");
+        GroupPermissionRule r = rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+
+        var found = store.findRuleById(r.getId());
+        assertTrue(found.isPresent());
+        assertEquals("github", found.get().getProvider());
+        assertEquals("/acme/repo", found.get().getValue());
+        assertEquals(RepoPermission.Grant.PUSH, found.get().getGrant());
+    }
+
+    @Test
+    void findRulesForGroup_returnsOnlyThatGroup() {
+        PermissionGroup g1 = dbGroup("devs");
+        PermissionGroup g2 = dbGroup("ops");
+        rule(g1.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        rule(g2.getId(), "github", "/other/repo", RepoPermission.Grant.REVIEW);
+
+        var rules = store.findRulesForGroup(g1.getId());
+        assertEquals(1, rules.size());
+        assertEquals("/acme/repo", rules.get(0).getValue());
+    }
+
+    @Test
+    void findRulesByProvider_returnsAcrossGroups() {
+        PermissionGroup g1 = dbGroup("devs");
+        PermissionGroup g2 = dbGroup("ops");
+        rule(g1.getId(), "github", "/acme/a", RepoPermission.Grant.PUSH);
+        rule(g2.getId(), "github", "/acme/b", RepoPermission.Grant.PUSH);
+        rule(g1.getId(), "gitlab", "/acme/a", RepoPermission.Grant.PUSH);
+
+        var githubRules = store.findRulesByProvider("github");
+        assertEquals(2, githubRules.size());
+        assertTrue(githubRules.stream().allMatch(r -> "github".equals(r.getProvider())));
+    }
+
+    @Test
+    void deleteRule_removedFromGroup() {
+        PermissionGroup g = dbGroup("devs");
+        GroupPermissionRule r = rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        store.deleteRule(r.getId());
+        assertTrue(store.findRuleById(r.getId()).isEmpty());
+        assertTrue(store.findRulesForGroup(g.getId()).isEmpty());
+    }
+
+    @Test
+    void allGrantTypes_roundTrip() {
+        PermissionGroup g = dbGroup("devs");
+        for (var grant : RepoPermission.Grant.values()) {
+            GroupPermissionRule r =
+                    rule(g.getId(), "github", "/acme/" + grant.name().toLowerCase(), grant);
+            assertEquals(grant, store.findRuleById(r.getId()).orElseThrow().getGrant());
+        }
+    }
+}

--- a/fogwall-core/src/test/java/com/rbc/fogwall/permission/MongoGroupPermissionStoreIntegrationTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/permission/MongoGroupPermissionStoreIntegrationTest.java
@@ -18,7 +18,8 @@ import org.testcontainers.utility.DockerImageName;
 class MongoGroupPermissionStoreIntegrationTest {
 
     @Container
-    static final MongoDBContainer MONGO = new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
+    static final MongoDBContainer MONGO =
+            new MongoDBContainer(DockerImageName.parse("docker.io/mongo:7.0").asCompatibleSubstituteFor("mongo"));
 
     MongoGroupPermissionStore store;
 

--- a/fogwall-core/src/test/java/com/rbc/fogwall/permission/MongoRepoPermissionStoreIntegrationTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/permission/MongoRepoPermissionStoreIntegrationTest.java
@@ -18,7 +18,8 @@ import org.testcontainers.utility.DockerImageName;
 class MongoRepoPermissionStoreIntegrationTest {
 
     @Container
-    static final MongoDBContainer MONGO = new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
+    static final MongoDBContainer MONGO =
+            new MongoDBContainer(DockerImageName.parse("docker.io/mongo:7.0").asCompatibleSubstituteFor("mongo"));
 
     MongoRepoPermissionStore store;
 

--- a/fogwall-core/src/test/java/com/rbc/fogwall/permission/RepoPermissionServiceTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/permission/RepoPermissionServiceTest.java
@@ -380,6 +380,60 @@ class RepoPermissionServiceTest {
         assertThrows(IllegalStateException.class, () -> svc.seedFromConfig(permissions));
     }
 
+    // ---- isBypassReviewAllowed ----
+
+    @Test
+    void bypassReview_noPermissionsForPath_denied() {
+        assertFalse(svc.isBypassReviewAllowed("alice", "github", "/acme/repo"));
+    }
+
+    @Test
+    void bypassReview_pushAndReview_doesNotImplySelfCertify() {
+        svc.save(grant("alice", "github", "/acme/repo", MatchType.LITERAL, RepoPermission.Grant.PUSH_AND_REVIEW));
+        assertFalse(svc.isBypassReviewAllowed("alice", "github", "/acme/repo"));
+    }
+
+    @Test
+    void bypassReview_explicitSelfCertify_allowed() {
+        svc.save(grant("alice", "github", "/acme/repo", MatchType.LITERAL, RepoPermission.Grant.SELF_CERTIFY));
+        assertTrue(svc.isBypassReviewAllowed("alice", "github", "/acme/repo"));
+    }
+
+    @Test
+    void bypassReview_pathCoveredBySelfCertify_otherUser_denied() {
+        svc.save(grant("alice", "github", "/acme/repo", MatchType.LITERAL, RepoPermission.Grant.SELF_CERTIFY));
+        assertFalse(svc.isBypassReviewAllowed("bob", "github", "/acme/repo"));
+    }
+
+    @Test
+    void bypassReview_globSelfCertify_matchedPath_allowed() {
+        svc.save(grant("alice", "github", "/acme/*", MatchType.GLOB, RepoPermission.Grant.SELF_CERTIFY));
+        assertTrue(svc.isBypassReviewAllowed("alice", "github", "/acme/repo"));
+        assertFalse(svc.isBypassReviewAllowed("alice", "github", "/other/repo"));
+    }
+
+    // ---- matchesGlob: invalid pattern ----
+
+    @Test
+    void glob_invalidPattern_treatedAsNoMatch() {
+        svc.save(grant("alice", "github", "{{invalid", MatchType.GLOB, RepoPermission.Grant.PUSH));
+        assertFalse(svc.isAllowedToPush("alice", "github", "/acme/repo"));
+    }
+
+    // ---- findAll / getGroupStore ----
+
+    @Test
+    void findAll_returnsAllSavedPermissions() {
+        svc.save(grant("alice", "github", "/acme/a"));
+        svc.save(grant("bob", "github", "/acme/b"));
+        assertEquals(2, svc.findAll().size());
+    }
+
+    @Test
+    void getGroupStore_returnsNullWhenNotConfigured() {
+        assertNull(svc.getGroupStore());
+    }
+
     @Test
     void seedFromConfig_configConflictsWithExistingDb_throwsIllegalStateException() {
         svc.save(grant("alice", "github", "/acme/repo", MatchType.LITERAL, RepoPermission.Grant.PUSH));

--- a/fogwall-core/src/test/java/com/rbc/fogwall/user/MongoUserStoreIntegrationTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/user/MongoUserStoreIntegrationTest.java
@@ -20,7 +20,8 @@ import org.testcontainers.utility.DockerImageName;
 class MongoUserStoreIntegrationTest {
 
     @Container
-    static final MongoDBContainer MONGO = new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
+    static final MongoDBContainer MONGO =
+            new MongoDBContainer(DockerImageName.parse("docker.io/mongo:7.0").asCompatibleSubstituteFor("mongo"));
 
     MongoUserStore store;
     MongoRepoPermissionStore permissionStore;

--- a/fogwall-dashboard/frontend/src/App.tsx
+++ b/fogwall-dashboard/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { PushDiff } from './pages/PushDiff'
 import { PushList } from './pages/PushList'
 import { Profile } from './pages/Profile'
 import { Repos } from './pages/Repos'
+import { Groups } from './pages/Groups'
 import { Users } from './pages/Users'
 import { UserDetail } from './pages/UserDetail'
 import type { CurrentUser } from './types'
@@ -53,6 +54,7 @@ export default function App() {
               path="/users/:username"
               element={<UserDetail authProvider={authProvider} currentUser={currentUser} />}
             />
+            <Route path="/groups" element={<Groups />} />
             <Route path="/admin" element={<Admin />} />
           </Routes>
         </main>

--- a/fogwall-dashboard/frontend/src/api.ts
+++ b/fogwall-dashboard/frontend/src/api.ts
@@ -1,3 +1,5 @@
+import type { GroupPermissionRule, RepoPermission } from './types'
+
 /** Reads the XSRF-TOKEN cookie set by Spring Security's CookieCsrfTokenRepository. */
 function getCsrfToken(): string | null {
   const match = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]+)/)
@@ -249,6 +251,23 @@ export async function fetchUserGroups(username: string) {
   const res = await apiFetch(`/api/users/${encodeURIComponent(username)}/permissions/groups`)
   if (!res.ok) throw new Error('Failed to fetch user groups')
   return res.json()
+}
+
+export async function fetchMyPermissions(): Promise<{
+  direct: RepoPermission[]
+  groups: UserGroupView[]
+}> {
+  const res = await apiFetch('/api/me/permissions')
+  if (!res.ok) throw new Error('Failed to fetch permissions')
+  return res.json()
+}
+
+export interface UserGroupView {
+  id: string
+  name: string
+  description: string | null
+  source: string
+  rules: GroupPermissionRule[]
 }
 
 export async function addUserPermission(

--- a/fogwall-dashboard/frontend/src/api.ts
+++ b/fogwall-dashboard/frontend/src/api.ts
@@ -245,6 +245,12 @@ export async function fetchUserPermissions(username: string) {
   return res.json()
 }
 
+export async function fetchUserGroups(username: string) {
+  const res = await apiFetch(`/api/users/${encodeURIComponent(username)}/permissions/groups`)
+  if (!res.ok) throw new Error('Failed to fetch user groups')
+  return res.json()
+}
+
 export async function addUserPermission(
   username: string,
   data: { provider: string; value: string; matchType: string; grant: string },
@@ -280,6 +286,81 @@ export async function createUrlRule(rule: {
 export async function deleteUrlRule(id: string) {
   const res = await apiFetch(`/api/repos/rules/${encodeURIComponent(id)}`, { method: 'DELETE' })
   if (!res.ok) await parseErrorResponse(res, 'Failed to delete URL rule')
+}
+
+export async function fetchGroups() {
+  const res = await apiFetch('/api/groups')
+  if (!res.ok) throw new Error('Failed to fetch groups')
+  return res.json()
+}
+
+export async function fetchGroup(id: string) {
+  const res = await apiFetch(`/api/groups/${encodeURIComponent(id)}`)
+  if (!res.ok) throw new Error('Failed to fetch group')
+  return res.json()
+}
+
+export async function createGroup(data: { name: string; description?: string }) {
+  const res = await apiFetch('/api/groups', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) await parseErrorResponse(res, 'Failed to create group')
+  return res.json()
+}
+
+export async function updateGroup(id: string, data: { name: string; description?: string }) {
+  const res = await apiFetch(`/api/groups/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) await parseErrorResponse(res, 'Failed to update group')
+  return res.json()
+}
+
+export async function deleteGroup(id: string) {
+  const res = await apiFetch(`/api/groups/${encodeURIComponent(id)}`, { method: 'DELETE' })
+  if (!res.ok) await parseErrorResponse(res, 'Failed to delete group')
+}
+
+export async function addGroupMember(groupId: string, username: string) {
+  const res = await apiFetch(`/api/groups/${encodeURIComponent(groupId)}/members`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username }),
+  })
+  if (!res.ok) await parseErrorResponse(res, 'Failed to add member')
+}
+
+export async function removeGroupMember(groupId: string, username: string) {
+  const res = await apiFetch(
+    `/api/groups/${encodeURIComponent(groupId)}/members/${encodeURIComponent(username)}`,
+    { method: 'DELETE' },
+  )
+  if (!res.ok) await parseErrorResponse(res, 'Failed to remove member')
+}
+
+export async function addGroupPermission(
+  groupId: string,
+  data: { provider: string; value: string; matchType: string; grant: string },
+) {
+  const res = await apiFetch(`/api/groups/${encodeURIComponent(groupId)}/permissions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) await parseErrorResponse(res, 'Failed to add group permission')
+  return res.json()
+}
+
+export async function deleteGroupPermission(groupId: string, ruleId: string) {
+  const res = await apiFetch(
+    `/api/groups/${encodeURIComponent(groupId)}/permissions/${encodeURIComponent(ruleId)}`,
+    { method: 'DELETE' },
+  )
+  if (!res.ok) await parseErrorResponse(res, 'Failed to delete group permission')
 }
 
 export interface TcpResult {

--- a/fogwall-dashboard/frontend/src/components/Nav.tsx
+++ b/fogwall-dashboard/frontend/src/components/Nav.tsx
@@ -123,6 +123,17 @@ export function Nav({ currentUser, dark, toggleDark }: NavProps) {
               Users
             </NavLink>
             <NavLink
+              to="/groups"
+              className={({ isActive }) =>
+                'px-3 py-1 rounded text-sm transition-colors ' +
+                (isActive
+                  ? 'bg-slate-600 text-white'
+                  : 'text-slate-300 hover:text-white hover:bg-slate-700')
+              }
+            >
+              Groups
+            </NavLink>
+            <NavLink
               to="/admin"
               className={({ isActive }) =>
                 'px-3 py-1 rounded text-sm transition-colors ' +

--- a/fogwall-dashboard/frontend/src/pages/Groups.tsx
+++ b/fogwall-dashboard/frontend/src/pages/Groups.tsx
@@ -1,0 +1,485 @@
+import { useEffect, useState } from 'react'
+import {
+  addGroupMember,
+  addGroupPermission,
+  createGroup,
+  deleteGroup,
+  deleteGroupPermission,
+  fetchGroup,
+  fetchGroups,
+  fetchProviders,
+  fetchUsers,
+  removeGroupMember,
+  updateGroup,
+} from '../api'
+import type {
+  GroupDetail,
+  GroupPermissionRule,
+  GroupSummary,
+  Provider,
+  UserSummary,
+} from '../types'
+
+export function Groups() {
+  const [groups, setGroups] = useState<GroupSummary[]>([])
+  const [selected, setSelected] = useState<GroupDetail | null>(null)
+  const [providers, setProviders] = useState<Provider[]>([])
+  const [users, setUsers] = useState<UserSummary[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  // create group form
+  const [newName, setNewName] = useState('')
+  const [newDesc, setNewDesc] = useState('')
+  const [createError, setCreateError] = useState<string | null>(null)
+
+  // edit group form
+  const [editName, setEditName] = useState('')
+  const [editDesc, setEditDesc] = useState('')
+  const [editError, setEditError] = useState<string | null>(null)
+  const [editSaving, setEditSaving] = useState(false)
+
+  // add member form
+  const [newMember, setNewMember] = useState('')
+  const [memberError, setMemberError] = useState<string | null>(null)
+
+  // add rule form
+  const [ruleProvider, setRuleProvider] = useState('')
+  const [ruleValue, setRuleValue] = useState('')
+  const [ruleMatchType, setRuleMatchType] = useState('GLOB')
+  const [ruleGrant, setRuleGrant] = useState('PUSH')
+  const [ruleError, setRuleError] = useState<string | null>(null)
+
+  const refreshGroups = () =>
+    fetchGroups()
+      .then((data: GroupSummary[]) => setGroups(data))
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Failed to load groups'))
+      .finally(() => setLoading(false))
+
+  const loadDetail = (id: string) =>
+    fetchGroup(id)
+      .then((data: GroupDetail) => {
+        setSelected(data)
+        setEditName(data.name)
+        setEditDesc(data.description ?? '')
+        setEditError(null)
+      })
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Failed to load group'))
+
+  useEffect(() => {
+    fetchGroups()
+      .then((data: GroupSummary[]) => setGroups(data))
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Failed to load groups'))
+      .finally(() => setLoading(false))
+    fetchProviders()
+      .then((data: Provider[]) => {
+        setProviders(data)
+        if (data.length > 0) setRuleProvider(data[0].id)
+      })
+      .catch(() => {})
+    fetchUsers()
+      .then((data: UserSummary[]) => setUsers(data))
+      .catch(() => {})
+  }, [])
+
+  const handleSaveEdit = async () => {
+    if (!selected || !editName.trim()) {
+      setEditError('Name is required')
+      return
+    }
+    setEditError(null)
+    setEditSaving(true)
+    try {
+      const updated = await updateGroup(selected.id, {
+        name: editName.trim(),
+        description: editDesc.trim() || undefined,
+      })
+      setSelected(updated)
+      await refreshGroups()
+    } catch (e) {
+      setEditError(e instanceof Error ? e.message : 'Failed to update group')
+    } finally {
+      setEditSaving(false)
+    }
+  }
+
+  const handleCreate = async () => {
+    if (!newName.trim()) {
+      setCreateError('Name is required')
+      return
+    }
+    setCreateError(null)
+    try {
+      await createGroup({ name: newName.trim(), description: newDesc.trim() || undefined })
+      setNewName('')
+      setNewDesc('')
+      await refreshGroups()
+    } catch (e) {
+      setCreateError(e instanceof Error ? e.message : 'Failed to create group')
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteGroup(id)
+      if (selected?.id === id) setSelected(null)
+      await refreshGroups()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to delete group')
+    }
+  }
+
+  const handleAddMember = async () => {
+    if (!selected || !newMember) {
+      setMemberError('Select a user')
+      return
+    }
+    setMemberError(null)
+    try {
+      await addGroupMember(selected.id, newMember.trim())
+      setNewMember('')
+      await loadDetail(selected.id)
+    } catch (e) {
+      setMemberError(e instanceof Error ? e.message : 'Failed to add member')
+    }
+  }
+
+  const handleRemoveMember = async (username: string) => {
+    if (!selected) return
+    try {
+      await removeGroupMember(selected.id, username)
+      await loadDetail(selected.id)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to remove member')
+    }
+  }
+
+  const handleAddRule = async () => {
+    if (!selected) return
+    if (!ruleProvider.trim() || !ruleValue.trim()) {
+      setRuleError('Provider and value are required')
+      return
+    }
+    setRuleError(null)
+    try {
+      await addGroupPermission(selected.id, {
+        provider: ruleProvider.trim(),
+        value: ruleValue.trim(),
+        matchType: ruleMatchType,
+        grant: ruleGrant,
+      })
+      setRuleProvider('')
+      setRuleValue('')
+      await loadDetail(selected.id)
+    } catch (e) {
+      setRuleError(e instanceof Error ? e.message : 'Failed to add permission rule')
+    }
+  }
+
+  const handleDeleteRule = async (ruleId: string) => {
+    if (!selected) return
+    try {
+      await deleteGroupPermission(selected.id, ruleId)
+      await loadDetail(selected.id)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to delete rule')
+    }
+  }
+
+  if (loading) return <div className="p-6 text-slate-500 dark:text-slate-400">Loading groups…</div>
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-6">
+        Permission Groups
+      </h1>
+
+      {error && (
+        <div className="mb-4 p-3 rounded bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 text-sm">
+          {error}
+        </div>
+      )}
+
+      <div className="flex gap-6">
+        {/* left: group list + create form */}
+        <div className="w-80 flex-shrink-0 space-y-4">
+          {/* create */}
+          <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-4 space-y-3">
+            <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-300">New Group</h2>
+            <input
+              className="w-full text-sm border rounded px-2 py-1 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
+              placeholder="Name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+            <input
+              className="w-full text-sm border rounded px-2 py-1 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
+              placeholder="Description (optional)"
+              value={newDesc}
+              onChange={(e) => setNewDesc(e.target.value)}
+            />
+            {createError && <p className="text-red-500 text-xs">{createError}</p>}
+            <button
+              onClick={handleCreate}
+              className="w-full text-sm bg-blue-600 hover:bg-blue-700 text-white rounded px-3 py-1.5 transition-colors"
+            >
+              Create
+            </button>
+          </div>
+
+          {/* list */}
+          <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 divide-y divide-slate-100 dark:divide-slate-700">
+            {groups.length === 0 && (
+              <p className="p-4 text-sm text-slate-400">No groups defined.</p>
+            )}
+            {groups.map((g) => (
+              <div
+                key={g.id}
+                className={`p-3 cursor-pointer transition-colors ${
+                  selected?.id === g.id
+                    ? 'bg-blue-50 dark:bg-blue-900/20'
+                    : 'hover:bg-slate-50 dark:hover:bg-slate-700/50'
+                }`}
+                onClick={() => loadDetail(g.id)}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-slate-800 dark:text-slate-100 truncate">
+                      {g.name}
+                    </p>
+                    {g.description && (
+                      <p className="text-xs text-slate-500 dark:text-slate-400 truncate">
+                        {g.description}
+                      </p>
+                    )}
+                    <p className="text-xs text-slate-400 mt-0.5">
+                      {g.memberCount} member{g.memberCount !== 1 ? 's' : ''} · {g.ruleCount} rule
+                      {g.ruleCount !== 1 ? 's' : ''}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-1 flex-shrink-0">
+                    {g.source === 'CONFIG' && (
+                      <span className="text-xs bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 rounded px-1.5 py-0.5">
+                        config
+                      </span>
+                    )}
+                    {g.source === 'DB' && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleDelete(g.id)
+                        }}
+                        className="text-xs text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 transition-colors"
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* right: detail panel */}
+        {selected ? (
+          <div className="flex-1 space-y-5">
+            <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-5">
+              {selected.source === 'CONFIG' ? (
+                <>
+                  <div className="flex items-center gap-2 mb-1">
+                    <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
+                      {selected.name}
+                    </h2>
+                    <span className="text-xs bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 rounded px-1.5 py-0.5">
+                      config
+                    </span>
+                  </div>
+                  {selected.description && (
+                    <p className="text-sm text-slate-500 dark:text-slate-400">
+                      {selected.description}
+                    </p>
+                  )}
+                </>
+              ) : (
+                <div className="space-y-2">
+                  <input
+                    className="w-full text-base font-semibold border rounded px-2 py-1 text-slate-800 dark:text-slate-100 dark:bg-slate-700 dark:border-slate-600"
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    placeholder="Group name"
+                  />
+                  <input
+                    className="w-full text-sm border rounded px-2 py-1 text-slate-500 dark:text-slate-400 dark:bg-slate-700 dark:border-slate-600"
+                    value={editDesc}
+                    onChange={(e) => setEditDesc(e.target.value)}
+                    placeholder="Description (optional)"
+                  />
+                  {editError && <p className="text-red-500 text-xs">{editError}</p>}
+                  <div className="flex justify-end">
+                    <button
+                      onClick={handleSaveEdit}
+                      disabled={editSaving}
+                      className="text-sm bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded px-3 py-1 transition-colors"
+                    >
+                      {editSaving ? 'Saving…' : 'Save'}
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* members */}
+            <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-5">
+              <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-3">
+                Members
+              </h3>
+              {selected.members.length === 0 ? (
+                <p className="text-sm text-slate-400">No members.</p>
+              ) : (
+                <ul className="space-y-1 mb-3">
+                  {selected.members.map((m) => (
+                    <li key={m} className="flex items-center justify-between text-sm">
+                      <span className="text-slate-700 dark:text-slate-200 font-mono">{m}</span>
+                      {selected.source === 'DB' && (
+                        <button
+                          onClick={() => handleRemoveMember(m)}
+                          className="text-xs text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 transition-colors"
+                        >
+                          Remove
+                        </button>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {selected.source === 'DB' && (
+                <div className="flex gap-2 mt-2">
+                  <select
+                    className="flex-1 text-sm border rounded px-2 py-1 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
+                    value={newMember}
+                    onChange={(e) => setNewMember(e.target.value)}
+                  >
+                    <option value="">Select user…</option>
+                    {users
+                      .filter((u) => !selected.members.includes(u.username))
+                      .map((u) => (
+                        <option key={u.username} value={u.username}>
+                          {u.username}
+                        </option>
+                      ))}
+                  </select>
+                  <button
+                    onClick={handleAddMember}
+                    className="text-sm bg-blue-600 hover:bg-blue-700 text-white rounded px-3 py-1 transition-colors"
+                  >
+                    Add
+                  </button>
+                </div>
+              )}
+              {memberError && <p className="text-red-500 text-xs mt-1">{memberError}</p>}
+            </div>
+
+            {/* permission rules */}
+            <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-5">
+              <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-3">
+                Permission Rules
+              </h3>
+              {selected.rules.length === 0 ? (
+                <p className="text-sm text-slate-400 mb-3">No rules.</p>
+              ) : (
+                <table className="w-full text-sm mb-4">
+                  <thead>
+                    <tr className="text-left text-xs text-slate-500 dark:text-slate-400 border-b border-slate-100 dark:border-slate-700">
+                      <th className="pb-1 pr-3">Provider</th>
+                      <th className="pb-1 pr-3">Value</th>
+                      <th className="pb-1 pr-3">Match</th>
+                      <th className="pb-1 pr-3">Grant</th>
+                      {selected.source === 'DB' && <th className="pb-1" />}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-50 dark:divide-slate-700/50">
+                    {selected.rules.map((r: GroupPermissionRule) => (
+                      <tr key={r.id} className="text-slate-700 dark:text-slate-300">
+                        <td className="py-1 pr-3 font-mono text-xs">{r.provider}</td>
+                        <td className="py-1 pr-3 font-mono text-xs">{r.value}</td>
+                        <td className="py-1 pr-3 text-xs">{r.matchType}</td>
+                        <td className="py-1 pr-3 text-xs">{r.grant}</td>
+                        {selected.source === 'DB' && (
+                          <td className="py-1 text-right">
+                            <button
+                              onClick={() => handleDeleteRule(r.id)}
+                              className="text-xs text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 transition-colors"
+                            >
+                              Remove
+                            </button>
+                          </td>
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+              {selected.source === 'DB' && (
+                <div className="space-y-2">
+                  <div className="flex gap-2">
+                    <select
+                      className="text-sm border rounded px-2 py-1 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
+                      value={ruleProvider}
+                      onChange={(e) => setRuleProvider(e.target.value)}
+                    >
+                      <option value="">Select provider…</option>
+                      {providers.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.name}
+                        </option>
+                      ))}
+                    </select>
+                    <input
+                      className="flex-1 text-sm border rounded px-2 py-1 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
+                      placeholder="Value (e.g. /myorg/**)"
+                      value={ruleValue}
+                      onChange={(e) => setRuleValue(e.target.value)}
+                    />
+                  </div>
+                  <div className="flex gap-2">
+                    <select
+                      className="text-sm border rounded px-2 py-1 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
+                      value={ruleMatchType}
+                      onChange={(e) => setRuleMatchType(e.target.value)}
+                    >
+                      <option value="LITERAL">Literal</option>
+                      <option value="GLOB">Glob</option>
+                      <option value="REGEX">Regex</option>
+                    </select>
+                    <select
+                      className="text-sm border rounded px-2 py-1 dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100"
+                      value={ruleGrant}
+                      onChange={(e) => setRuleGrant(e.target.value)}
+                    >
+                      <option value="PUSH">Push</option>
+                      <option value="REVIEW">Review</option>
+                      <option value="PUSH_AND_REVIEW">Push and review</option>
+                      <option value="SELF_CERTIFY">Self-certify</option>
+                    </select>
+                    <button
+                      onClick={handleAddRule}
+                      className="text-sm bg-blue-600 hover:bg-blue-700 text-white rounded px-3 py-1 transition-colors"
+                    >
+                      Add Rule
+                    </button>
+                  </div>
+                  {ruleError && <p className="text-red-500 text-xs">{ruleError}</p>}
+                </div>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="flex-1 flex items-center justify-center text-slate-400 dark:text-slate-500 text-sm">
+            Select a group to view details
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/fogwall-dashboard/frontend/src/pages/Profile.tsx
+++ b/fogwall-dashboard/frontend/src/pages/Profile.tsx
@@ -4,12 +4,14 @@ import {
   addScmIdentity,
   addSshKey,
   fetchMe,
+  fetchMyPermissions,
   fetchMySshKeys,
   fetchProviders,
   removeEmail,
   removeScmIdentity,
   removeSshKey,
 } from '../api'
+import type { UserGroupView } from '../api'
 import { OperationsBadge, PathTypeBadge } from '../components/PermissionBadges'
 import type { CurrentUser, EmailEntry, RepoPermission, ScmIdentity, SshKeyEntry } from '../types'
 
@@ -35,6 +37,7 @@ export function Profile() {
 
   const [tab, setTab] = useState<'emails' | 'identities' | 'sshkeys' | 'permissions'>('emails')
   const [permissions, setPermissions] = useState<RepoPermission[]>([])
+  const [groups, setGroups] = useState<UserGroupView[]>([])
 
   const [sshKeys, setSshKeys] = useState<SshKeyEntry[]>([])
   const [newSshKey, setNewSshKey] = useState('')
@@ -55,12 +58,15 @@ export function Profile() {
 
   useEffect(() => {
     fetchMe()
-      .then((data) => {
-        setProfile(data)
-        setPermissions(data.permissions ?? [])
-      })
+      .then((data) => setProfile(data))
       .catch(() => setError('Failed to load profile'))
       .finally(() => setLoading(false))
+    fetchMyPermissions()
+      .then((data) => {
+        setPermissions(data.direct)
+        setGroups(data.groups)
+      })
+      .catch(() => {})
     fetchProviders()
       .then((list: { name: string; id: string; host: string }[]) => {
         setProviders(list)
@@ -439,6 +445,67 @@ export function Profile() {
                   ))}
                 </tbody>
               </table>
+            </div>
+          )}
+          {groups.length > 0 && (
+            <div className="space-y-3 mt-6">
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+                Group memberships
+              </h3>
+              {groups.map((g) => (
+                <div
+                  key={g.id}
+                  className="rounded-lg border border-gray-200 bg-white dark:bg-slate-800 dark:border-slate-700 overflow-hidden"
+                >
+                  <div className="px-4 py-3 flex items-center gap-2 border-b border-gray-100 dark:border-slate-700">
+                    <span className="text-sm font-medium text-gray-800 dark:text-gray-100">
+                      {g.name}
+                    </span>
+                    <span className="text-xs bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 rounded px-1.5 py-0.5">
+                      {g.source.toLowerCase()}
+                    </span>
+                    {g.description && (
+                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                        — {g.description}
+                      </span>
+                    )}
+                  </div>
+                  {g.rules.length === 0 ? (
+                    <p className="px-4 py-3 text-xs text-gray-400 italic">
+                      No rules in this group.
+                    </p>
+                  ) : (
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="text-left text-xs text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-slate-700/50">
+                          <th className="px-4 py-2">Provider</th>
+                          <th className="px-4 py-2">Type</th>
+                          <th className="px-4 py-2">Path</th>
+                          <th className="px-4 py-2">Grant</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100 dark:divide-slate-700">
+                        {g.rules.map((r) => (
+                          <tr key={r.id} className="text-gray-700 dark:text-gray-300">
+                            <td className="px-4 py-2">
+                              <span className="rounded bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-700 dark:text-slate-300">
+                                {r.provider}
+                              </span>
+                            </td>
+                            <td className="px-4 py-2">
+                              <PathTypeBadge matchType={r.matchType} />
+                            </td>
+                            <td className="px-4 py-2 font-mono text-xs">{r.value}</td>
+                            <td className="px-4 py-2">
+                              <OperationsBadge operations={r.grant} />
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              ))}
             </div>
           )}
         </div>

--- a/fogwall-dashboard/frontend/src/pages/UserDetail.tsx
+++ b/fogwall-dashboard/frontend/src/pages/UserDetail.tsx
@@ -9,6 +9,7 @@ import {
   fetchProviders,
   fetchPushes,
   fetchUser,
+  fetchUserGroups,
   fetchUserPermissions,
   removeUserEmail,
   removeUserIdentity,
@@ -19,12 +20,21 @@ import { StatusBadge } from '../components/StatusBadge'
 import type {
   CurrentUser,
   EmailEntry,
+  GroupPermissionRule,
   Provider,
   PushRecord,
   RepoPermission,
   ScmIdentity,
   UserDetail as UserDetailType,
 } from '../types'
+
+interface UserGroupView {
+  id: string
+  name: string
+  description: string | null
+  source: string
+  rules: GroupPermissionRule[]
+}
 
 interface UserDetailProps {
   authProvider: string
@@ -723,6 +733,7 @@ function AddPermissionModal({
 
 function PermissionsTab({ username, isAdmin }: { username: string; isAdmin: boolean }) {
   const [permissions, setPermissions] = useState<RepoPermission[]>([])
+  const [groups, setGroups] = useState<UserGroupView[]>([])
   const [loading, setLoading] = useState(true)
   const [showAdd, setShowAdd] = useState(false)
   const [deletingId, setDeletingId] = useState<string | null>(null)
@@ -730,8 +741,11 @@ function PermissionsTab({ username, isAdmin }: { username: string; isAdmin: bool
 
   const loadPermissions = useCallback(() => {
     setLoading(true)
-    fetchUserPermissions(username)
-      .then(setPermissions)
+    Promise.all([fetchUserPermissions(username), fetchUserGroups(username).catch(() => [])])
+      .then(([perms, grps]) => {
+        setPermissions(perms)
+        setGroups(grps)
+      })
       .catch(console.error)
       .finally(() => setLoading(false))
   }, [username])
@@ -840,6 +854,77 @@ function PermissionsTab({ username, isAdmin }: { username: string; isAdmin: bool
           + Add Permission
         </button>
       )}
+
+      {/* group memberships */}
+      <div className="pt-2 space-y-2">
+        <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide dark:text-gray-500">
+          Group memberships
+        </p>
+        {groups.length === 0 ? (
+          <p className="text-sm text-gray-400 italic dark:text-gray-500">
+            Not a member of any groups.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {groups.map((g) => (
+              <div
+                key={g.id}
+                className="rounded-lg border border-gray-200 bg-white overflow-hidden dark:bg-slate-800 dark:border-slate-700"
+              >
+                <div className="px-4 py-2 bg-gray-50 dark:bg-slate-700/50 flex items-center gap-2 border-b border-gray-100 dark:border-slate-700">
+                  <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
+                    {g.name}
+                  </span>
+                  {g.source === 'CONFIG' && (
+                    <span className="text-xs bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 rounded px-1.5 py-0.5">
+                      config
+                    </span>
+                  )}
+                  {g.description && (
+                    <span className="text-xs text-gray-400 dark:text-gray-500">
+                      {g.description}
+                    </span>
+                  )}
+                </div>
+                {g.rules.length === 0 ? (
+                  <p className="px-4 py-2 text-xs text-gray-400 italic dark:text-gray-500">
+                    No rules defined.
+                  </p>
+                ) : (
+                  <table className="w-full text-xs">
+                    <thead>
+                      <tr className="text-left text-gray-400 dark:text-gray-500 border-b border-gray-100 dark:border-slate-700">
+                        <th className="px-4 py-2">Provider</th>
+                        <th className="px-4 py-2">Type</th>
+                        <th className="px-4 py-2">Path</th>
+                        <th className="px-4 py-2">Grant</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-50 dark:divide-slate-700/50">
+                      {g.rules.map((r) => (
+                        <tr key={r.id} className="text-gray-600 dark:text-gray-300">
+                          <td className="px-4 py-2">
+                            <span className="rounded bg-slate-100 px-1.5 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-700 dark:text-slate-300">
+                              {r.provider}
+                            </span>
+                          </td>
+                          <td className="px-4 py-2">
+                            <PathTypeBadge matchType={r.matchType} />
+                          </td>
+                          <td className="px-4 py-2 font-mono">{r.value}</td>
+                          <td className="px-4 py-2">
+                            <OperationsBadge operations={r.grant} />
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
 
       <div className="pt-2 space-y-2">
         <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide dark:text-gray-500">

--- a/fogwall-dashboard/frontend/src/types.ts
+++ b/fogwall-dashboard/frontend/src/types.ts
@@ -142,3 +142,31 @@ export interface RepoPermission {
   grant: 'PUSH' | 'REVIEW' | 'PUSH_AND_REVIEW' | 'SELF_CERTIFY'
   source: 'CONFIG' | 'DB'
 }
+
+export interface GroupPermissionRule {
+  id: string
+  groupId: string
+  provider: string
+  target: string
+  value: string
+  matchType: 'LITERAL' | 'GLOB' | 'REGEX'
+  grant: 'PUSH' | 'REVIEW' | 'PUSH_AND_REVIEW' | 'SELF_CERTIFY'
+}
+
+export interface GroupSummary {
+  id: string
+  name: string
+  description: string | null
+  source: 'CONFIG' | 'DB'
+  memberCount: number
+  ruleCount: number
+}
+
+export interface GroupDetail {
+  id: string
+  name: string
+  description: string | null
+  source: 'CONFIG' | 'DB'
+  members: string[]
+  rules: GroupPermissionRule[]
+}

--- a/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/GroupController.java
+++ b/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/GroupController.java
@@ -1,0 +1,269 @@
+package com.rbc.fogwall.dashboard.controller;
+
+import com.rbc.fogwall.db.model.MatchTarget;
+import com.rbc.fogwall.db.model.MatchType;
+import com.rbc.fogwall.permission.GroupPermissionRule;
+import com.rbc.fogwall.permission.GroupPermissionStore;
+import com.rbc.fogwall.permission.PermissionGroup;
+import com.rbc.fogwall.permission.RepoPermission;
+import com.rbc.fogwall.permission.RepoPermissionService;
+import com.rbc.fogwall.user.ReadOnlyUserStore;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Groups", description = "Permission group management — requires ROLE_ADMIN")
+@RestController
+@RequestMapping("/api/groups")
+public class GroupController {
+
+    @Autowired
+    private RepoPermissionService permissionService;
+
+    @Autowired
+    private ReadOnlyUserStore userStore;
+
+    private GroupPermissionStore groupStore() {
+        return permissionService.getGroupStore();
+    }
+
+    // ---- groups ----
+
+    @Operation(operationId = "listGroups", summary = "List all permission groups")
+    @GetMapping
+    public ResponseEntity<?> list() {
+        List<PermissionGroup> groups = groupStore().findAllGroups();
+        List<GroupSummary> summaries = groups.stream()
+                .map(g -> new GroupSummary(
+                        g.getId(),
+                        g.getName(),
+                        g.getDescription(),
+                        g.getSource().name(),
+                        groupStore().findMembers(g.getId()).size(),
+                        groupStore().findRulesForGroup(g.getId()).size()))
+                .toList();
+        return ResponseEntity.ok(summaries);
+    }
+
+    @Operation(operationId = "createGroup", summary = "Create a permission group")
+    @PostMapping
+    public ResponseEntity<?> create(@RequestBody CreateGroupRequest req) {
+        if (req.name() == null || req.name().isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "name is required"));
+        }
+        if (groupStore().findGroupByName(req.name().trim()).isPresent()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "group name already exists: " + req.name()));
+        }
+        PermissionGroup group = PermissionGroup.builder()
+                .name(req.name().trim())
+                .description(req.description() != null ? req.description().trim() : null)
+                .source(PermissionGroup.Source.DB)
+                .build();
+        groupStore().saveGroup(group);
+        return ResponseEntity.status(HttpStatus.CREATED).body(group);
+    }
+
+    @Operation(operationId = "getGroup", summary = "Get group details including members and rules")
+    @GetMapping("/{id}")
+    public ResponseEntity<?> get(@PathVariable String id) {
+        return groupStore()
+                .findGroupById(id)
+                .map(g -> ResponseEntity.ok(new GroupDetail(
+                        g.getId(),
+                        g.getName(),
+                        g.getDescription(),
+                        g.getSource().name(),
+                        groupStore().findMembers(g.getId()),
+                        groupStore().findRulesForGroup(g.getId()))))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @Operation(operationId = "updateGroup", summary = "Update a group's name and description")
+    @PatchMapping("/{id}")
+    public ResponseEntity<?> update(@PathVariable String id, @RequestBody CreateGroupRequest req) {
+        var existing = groupStore().findGroupById(id);
+        if (existing.isEmpty()) return ResponseEntity.notFound().build();
+        if (existing.get().getSource() == PermissionGroup.Source.CONFIG) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", "Cannot modify config-defined groups"));
+        }
+        if (req.name() == null || req.name().isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "name is required"));
+        }
+        var nameConflict = groupStore().findGroupByName(req.name().trim());
+        if (nameConflict.isPresent() && !nameConflict.get().getId().equals(id)) {
+            return ResponseEntity.badRequest().body(Map.of("error", "group name already exists: " + req.name()));
+        }
+        groupStore()
+                .updateGroup(
+                        id,
+                        req.name().trim(),
+                        req.description() != null ? req.description().trim() : null);
+        return groupStore()
+                .findGroupById(id)
+                .map(g -> ResponseEntity.ok(new GroupDetail(
+                        g.getId(),
+                        g.getName(),
+                        g.getDescription(),
+                        g.getSource().name(),
+                        groupStore().findMembers(g.getId()),
+                        groupStore().findRulesForGroup(g.getId()))))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @Operation(operationId = "deleteGroup", summary = "Delete a permission group")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> delete(@PathVariable String id) {
+        var existing = groupStore().findGroupById(id);
+        if (existing.isEmpty()) return ResponseEntity.notFound().build();
+        if (existing.get().getSource() == PermissionGroup.Source.CONFIG) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", "Cannot delete config-defined groups"));
+        }
+        groupStore().deleteGroup(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ---- members ----
+
+    @Operation(operationId = "addGroupMember", summary = "Add a user to a group")
+    @PostMapping("/{id}/members")
+    public ResponseEntity<?> addMember(@PathVariable String id, @RequestBody MemberRequest req) {
+        var group = groupStore().findGroupById(id);
+        if (group.isEmpty()) return ResponseEntity.notFound().build();
+        if (group.get().getSource() == PermissionGroup.Source.CONFIG) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", "Cannot modify members of config-defined groups"));
+        }
+        if (req.username() == null || req.username().isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "username is required"));
+        }
+        if (userStore.findByUsername(req.username()).isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "user not found: " + req.username()));
+        }
+        List<String> current = groupStore().findMembers(id);
+        if (current.contains(req.username())) {
+            return ResponseEntity.badRequest().body(Map.of("error", "user already a member of this group"));
+        }
+        groupStore().addMember(id, req.username());
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("username", req.username()));
+    }
+
+    @Operation(operationId = "removeGroupMember", summary = "Remove a user from a group")
+    @DeleteMapping("/{id}/members/{username}")
+    public ResponseEntity<?> removeMember(@PathVariable String id, @PathVariable String username) {
+        var group = groupStore().findGroupById(id);
+        if (group.isEmpty()) return ResponseEntity.notFound().build();
+        if (group.get().getSource() == PermissionGroup.Source.CONFIG) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", "Cannot modify members of config-defined groups"));
+        }
+        groupStore().removeMember(id, username);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ---- rules ----
+
+    @Operation(operationId = "listGroupPermissions", summary = "List permission rules for a group")
+    @GetMapping("/{id}/permissions")
+    public ResponseEntity<?> listRules(@PathVariable String id) {
+        if (groupStore().findGroupById(id).isEmpty())
+            return ResponseEntity.notFound().build();
+        return ResponseEntity.ok(groupStore().findRulesForGroup(id));
+    }
+
+    @Operation(operationId = "addGroupPermission", summary = "Add a permission rule to a group")
+    @PostMapping("/{id}/permissions")
+    public ResponseEntity<?> addRule(@PathVariable String id, @RequestBody AddRuleRequest req) {
+        var group = groupStore().findGroupById(id);
+        if (group.isEmpty()) return ResponseEntity.notFound().build();
+        if (group.get().getSource() == PermissionGroup.Source.CONFIG) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", "Cannot modify rules of config-defined groups"));
+        }
+        if (req.provider() == null || req.provider().isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "provider is required"));
+        }
+        if (req.value() == null || req.value().isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "value is required"));
+        }
+
+        MatchTarget target;
+        try {
+            target = req.target() != null ? MatchTarget.valueOf(req.target().toUpperCase()) : MatchTarget.SLUG;
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "invalid target: " + req.target()));
+        }
+
+        MatchType matchType;
+        try {
+            matchType =
+                    req.matchType() != null ? MatchType.valueOf(req.matchType().toUpperCase()) : MatchType.LITERAL;
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "invalid matchType: " + req.matchType()));
+        }
+
+        RepoPermission.Grant grant;
+        try {
+            grant = req.grant() != null
+                    ? RepoPermission.Grant.valueOf(req.grant().toUpperCase())
+                    : RepoPermission.Grant.PUSH;
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "invalid grant: " + req.grant()));
+        }
+
+        GroupPermissionRule rule = GroupPermissionRule.builder()
+                .groupId(id)
+                .provider(req.provider().trim())
+                .target(target)
+                .value(req.value().trim())
+                .matchType(matchType)
+                .grant(grant)
+                .build();
+        groupStore().saveRule(rule);
+        return ResponseEntity.status(HttpStatus.CREATED).body(rule);
+    }
+
+    @Operation(operationId = "deleteGroupPermission", summary = "Remove a permission rule from a group")
+    @DeleteMapping("/{id}/permissions/{ruleId}")
+    public ResponseEntity<?> deleteRule(@PathVariable String id, @PathVariable String ruleId) {
+        var group = groupStore().findGroupById(id);
+        if (group.isEmpty()) return ResponseEntity.notFound().build();
+        if (group.get().getSource() == PermissionGroup.Source.CONFIG) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", "Cannot modify rules of config-defined groups"));
+        }
+        var rule = groupStore().findRuleById(ruleId);
+        if (rule.isEmpty()) return ResponseEntity.notFound().build();
+        if (!id.equals(rule.get().getGroupId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("error", "Rule does not belong to this group"));
+        }
+        groupStore().deleteRule(ruleId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ---- DTOs ----
+
+    public record CreateGroupRequest(String name, String description) {}
+
+    public record MemberRequest(String username) {}
+
+    public record AddRuleRequest(String provider, String target, String value, String matchType, String grant) {}
+
+    public record GroupSummary(
+            String id, String name, String description, String source, int memberCount, int ruleCount) {}
+
+    public record GroupDetail(
+            String id,
+            String name,
+            String description,
+            String source,
+            List<String> members,
+            List<GroupPermissionRule> rules) {}
+}

--- a/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/PermissionController.java
+++ b/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/PermissionController.java
@@ -2,11 +2,13 @@ package com.rbc.fogwall.dashboard.controller;
 
 import com.rbc.fogwall.db.model.MatchTarget;
 import com.rbc.fogwall.db.model.MatchType;
+import com.rbc.fogwall.permission.GroupPermissionStore;
 import com.rbc.fogwall.permission.RepoPermission;
 import com.rbc.fogwall.permission.RepoPermissionService;
 import com.rbc.fogwall.user.ReadOnlyUserStore;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -119,5 +121,30 @@ public class PermissionController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(operationId = "listUserGroups", summary = "List permission groups the user belongs to")
+    @GetMapping("/groups")
+    public ResponseEntity<?> listGroups(@PathVariable String username) {
+        if (userStore.findByUsername(username).isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        GroupPermissionStore groupStore = permissionService.getGroupStore();
+        if (groupStore == null) {
+            return ResponseEntity.ok(List.of());
+        }
+        List<UserGroupView> result = groupStore.findGroupIdsForUser(username).stream()
+                .map(groupStore::findGroupById)
+                .flatMap(java.util.Optional::stream)
+                .map(g -> new UserGroupView(
+                        g.getId(),
+                        g.getName(),
+                        g.getDescription(),
+                        g.getSource().name(),
+                        groupStore.findRulesForGroup(g.getId())))
+                .toList();
+        return ResponseEntity.ok(result);
+    }
+
     public record AddPermissionRequest(String provider, String target, String value, String matchType, String grant) {}
+
+    public record UserGroupView(String id, String name, String description, String source, List<?> rules) {}
 }

--- a/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/ProfileController.java
+++ b/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/ProfileController.java
@@ -1,5 +1,6 @@
 package com.rbc.fogwall.dashboard.controller;
 
+import com.rbc.fogwall.permission.RepoPermissionService;
 import com.rbc.fogwall.ssh.SshKeyUtils;
 import com.rbc.fogwall.user.EmailConflictException;
 import com.rbc.fogwall.user.LockedByConfigException;
@@ -48,6 +49,9 @@ public class ProfileController {
 
     @Autowired
     private ReadOnlyUserStore userStore;
+
+    @Autowired
+    private RepoPermissionService permissionService;
 
     // ---- email claims ----
 
@@ -179,6 +183,28 @@ public class ProfileController {
         if (!(userStore instanceof UserStore mutable)) return NOT_MUTABLE;
         mutable.removeSshKey(currentUsername(), id);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(operationId = "getMyPermissions", summary = "Get current user's direct and group-inherited permissions")
+    @GetMapping("/permissions")
+    public ResponseEntity<?> getPermissions() {
+        String username = currentUsername();
+        var direct = permissionService.findByUsername(username);
+        var groupStore = permissionService.getGroupStore();
+        List<PermissionController.UserGroupView> groups = List.of();
+        if (groupStore != null) {
+            groups = groupStore.findGroupIdsForUser(username).stream()
+                    .map(groupStore::findGroupById)
+                    .flatMap(java.util.Optional::stream)
+                    .map(g -> new PermissionController.UserGroupView(
+                            g.getId(),
+                            g.getName(),
+                            g.getDescription(),
+                            g.getSource().name(),
+                            groupStore.findRulesForGroup(g.getId())))
+                    .toList();
+        }
+        return ResponseEntity.ok(Map.of("direct", direct, "groups", groups));
     }
 
     private String currentUsername() {

--- a/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/GroupControllerTest.java
+++ b/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/GroupControllerTest.java
@@ -1,0 +1,391 @@
+package com.rbc.fogwall.dashboard.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.rbc.fogwall.db.model.MatchType;
+import com.rbc.fogwall.permission.GroupPermissionRule;
+import com.rbc.fogwall.permission.GroupPermissionStore;
+import com.rbc.fogwall.permission.PermissionGroup;
+import com.rbc.fogwall.permission.RepoPermission;
+import com.rbc.fogwall.permission.RepoPermissionService;
+import com.rbc.fogwall.user.ReadOnlyUserStore;
+import com.rbc.fogwall.user.UserEntry;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class GroupControllerTest {
+
+    @InjectMocks
+    GroupController controller;
+
+    @Mock
+    RepoPermissionService permissionService;
+
+    @Mock
+    ReadOnlyUserStore userStore;
+
+    @Mock
+    GroupPermissionStore groupStore;
+
+    private static final PermissionGroup DB_GROUP = PermissionGroup.builder()
+            .name("devs")
+            .description("Developers")
+            .source(PermissionGroup.Source.DB)
+            .build();
+
+    private static final PermissionGroup CONFIG_GROUP = PermissionGroup.builder()
+            .name("admins")
+            .description("Admins from config")
+            .source(PermissionGroup.Source.CONFIG)
+            .build();
+
+    private static final UserEntry ALICE = UserEntry.builder()
+            .username("alice")
+            .passwordHash("{noop}pw")
+            .emails(List.of())
+            .scmIdentities(List.of())
+            .roles(List.of("USER"))
+            .build();
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(permissionService.getGroupStore()).thenReturn(groupStore);
+    }
+
+    // ── GET /api/groups ──────────────────────────────────────────────────────────
+
+    @Test
+    void list_returnsAllGroups() {
+        when(groupStore.findAllGroups()).thenReturn(List.of(DB_GROUP));
+        when(groupStore.findMembers(DB_GROUP.getId())).thenReturn(List.of("alice"));
+        when(groupStore.findRulesForGroup(DB_GROUP.getId())).thenReturn(List.of());
+
+        var resp = controller.list();
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+    }
+
+    // ── POST /api/groups ─────────────────────────────────────────────────────────
+
+    @Test
+    void create_missingName_returns400() {
+        var resp = controller.create(new GroupController.CreateGroupRequest("  ", null));
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+        verify(groupStore, never()).saveGroup(any());
+    }
+
+    @Test
+    void create_duplicateName_returns400() {
+        when(groupStore.findGroupByName("devs")).thenReturn(Optional.of(DB_GROUP));
+
+        var resp = controller.create(new GroupController.CreateGroupRequest("devs", null));
+
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+        verify(groupStore, never()).saveGroup(any());
+    }
+
+    @Test
+    void create_success_returns201() {
+        when(groupStore.findGroupByName("newgroup")).thenReturn(Optional.empty());
+
+        var resp = controller.create(new GroupController.CreateGroupRequest("newgroup", "A new group"));
+
+        assertEquals(HttpStatus.CREATED, resp.getStatusCode());
+        verify(groupStore).saveGroup(any(PermissionGroup.class));
+    }
+
+    // ── GET /api/groups/{id} ─────────────────────────────────────────────────────
+
+    @Test
+    void get_unknownId_returns404() {
+        when(groupStore.findGroupById("missing")).thenReturn(Optional.empty());
+
+        var resp = controller.get("missing");
+
+        assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
+    }
+
+    @Test
+    void get_knownId_returnsDetail() {
+        when(groupStore.findGroupById(DB_GROUP.getId())).thenReturn(Optional.of(DB_GROUP));
+        when(groupStore.findMembers(DB_GROUP.getId())).thenReturn(List.of("alice"));
+        when(groupStore.findRulesForGroup(DB_GROUP.getId())).thenReturn(List.of());
+
+        var resp = controller.get(DB_GROUP.getId());
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+    }
+
+    // ── PATCH /api/groups/{id} ───────────────────────────────────────────────────
+
+    @Test
+    void update_unknownId_returns404() {
+        when(groupStore.findGroupById("missing")).thenReturn(Optional.empty());
+
+        var resp = controller.update("missing", new GroupController.CreateGroupRequest("newname", null));
+
+        assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
+    }
+
+    @Test
+    void update_configGroup_returns403() {
+        when(groupStore.findGroupById(CONFIG_GROUP.getId())).thenReturn(Optional.of(CONFIG_GROUP));
+
+        var resp = controller.update(CONFIG_GROUP.getId(), new GroupController.CreateGroupRequest("newname", null));
+
+        assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+        verify(groupStore, never()).updateGroup(any(), any(), any());
+    }
+
+    @Test
+    void update_blankName_returns400() {
+        when(groupStore.findGroupById(DB_GROUP.getId())).thenReturn(Optional.of(DB_GROUP));
+
+        var resp = controller.update(DB_GROUP.getId(), new GroupController.CreateGroupRequest("", null));
+
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void update_nameConflict_returns400() {
+        when(groupStore.findGroupById(DB_GROUP.getId())).thenReturn(Optional.of(DB_GROUP));
+        when(groupStore.findGroupByName("taken")).thenReturn(Optional.of(CONFIG_GROUP));
+
+        var resp = controller.update(DB_GROUP.getId(), new GroupController.CreateGroupRequest("taken", null));
+
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void update_success_callsUpdateAndReturnsDetail() {
+        when(groupStore.findGroupById(DB_GROUP.getId()))
+                .thenReturn(Optional.of(DB_GROUP))
+                .thenReturn(Optional.of(DB_GROUP));
+        when(groupStore.findGroupByName("renamed")).thenReturn(Optional.empty());
+        when(groupStore.findMembers(DB_GROUP.getId())).thenReturn(List.of());
+        when(groupStore.findRulesForGroup(DB_GROUP.getId())).thenReturn(List.of());
+
+        var resp = controller.update(DB_GROUP.getId(), new GroupController.CreateGroupRequest("renamed", "new desc"));
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        verify(groupStore).updateGroup(DB_GROUP.getId(), "renamed", "new desc");
+    }
+
+    // ── DELETE /api/groups/{id} ──────────────────────────────────────────────────
+
+    @Test
+    void delete_unknownId_returns404() {
+        when(groupStore.findGroupById("missing")).thenReturn(Optional.empty());
+
+        var resp = controller.delete("missing");
+
+        assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
+    }
+
+    @Test
+    void delete_configGroup_returns403() {
+        when(groupStore.findGroupById(CONFIG_GROUP.getId())).thenReturn(Optional.of(CONFIG_GROUP));
+
+        var resp = controller.delete(CONFIG_GROUP.getId());
+
+        assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+        verify(groupStore, never()).deleteGroup(any());
+    }
+
+    @Test
+    void delete_dbGroup_returns204() {
+        when(groupStore.findGroupById(DB_GROUP.getId())).thenReturn(Optional.of(DB_GROUP));
+
+        var resp = controller.delete(DB_GROUP.getId());
+
+        assertEquals(HttpStatus.NO_CONTENT, resp.getStatusCode());
+        verify(groupStore).deleteGroup(DB_GROUP.getId());
+    }
+
+    // ── POST /api/groups/{id}/members ────────────────────────────────────────────
+
+    @Test
+    void addMember_unknownGroup_returns404() {
+        when(groupStore.findGroupById("missing")).thenReturn(Optional.empty());
+
+        var resp = controller.addMember("missing", new GroupController.MemberRequest("alice"));
+
+        assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
+    }
+
+    @Test
+    void addMember_configGroup_returns403() {
+        when(groupStore.findGroupById(CONFIG_GROUP.getId())).thenReturn(Optional.of(CONFIG_GROUP));
+
+        var resp = controller.addMember(CONFIG_GROUP.getId(), new GroupController.MemberRequest("alice"));
+
+        assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+    }
+
+    @Test
+    void addMember_unknownUser_returns400() {
+        when(groupStore.findGroupById(DB_GROUP.getId())).thenReturn(Optional.of(DB_GROUP));
+        when(userStore.findByUsername("nobody")).thenReturn(Optional.empty());
+
+        var resp = controller.addMember(DB_GROUP.getId(), new GroupController.MemberRequest("nobody"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void addMember_alreadyMember_returns400() {
+        when(groupStore.findGroupById(DB_GROUP.getId())).thenReturn(Optional.of(DB_GROUP));
+        when(userStore.findByUsername("alice")).thenReturn(Optional.of(ALICE));
+        when(groupStore.findMembers(DB_GROUP.getId())).thenReturn(List.of("alice"));
+
+        var resp = controller.addMember(DB_GROUP.getId(), new GroupController.MemberRequest("alice"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+        verify(groupStore, never()).addMember(any(), any());
+    }
+
+    @Test
+    void addMember_success_returns201() {
+        when(groupStore.findGroupById(DB_GROUP.getId())).thenReturn(Optional.of(DB_GROUP));
+        when(userStore.findByUsername("alice")).thenReturn(Optional.of(ALICE));
+        when(groupStore.findMembers(DB_GROUP.getId())).thenReturn(List.of());
+
+        var resp = controller.addMember(DB_GROUP.getId(), new GroupController.MemberRequest("alice"));
+
+        assertEquals(HttpStatus.CREATED, resp.getStatusCode());
+        verify(groupStore).addMember(DB_GROUP.getId(), "alice");
+    }
+
+    // ── DELETE /api/groups/{id}/members/{username} ───────────────────────────────
+
+    @Test
+    void removeMember_configGroup_returns403() {
+        when(groupStore.findGroupById(CONFIG_GROUP.getId())).thenReturn(Optional.of(CONFIG_GROUP));
+
+        var resp = controller.removeMember(CONFIG_GROUP.getId(), "alice");
+
+        assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+        verify(groupStore, never()).removeMember(any(), any());
+    }
+
+    @Test
+    void removeMember_success_returns204() {
+        when(groupStore.findGroupById(DB_GROUP.getId())).thenReturn(Optional.of(DB_GROUP));
+
+        var resp = controller.removeMember(DB_GROUP.getId(), "alice");
+
+        assertEquals(HttpStatus.NO_CONTENT, resp.getStatusCode());
+        verify(groupStore).removeMember(DB_GROUP.getId(), "alice");
+    }
+
+    // ── POST /api/groups/{id}/permissions ────────────────────────────────────────
+
+    private GroupController.AddRuleRequest ruleReq(String provider, String value, String matchType, String grant) {
+        return new GroupController.AddRuleRequest(provider, null, value, matchType, grant);
+    }
+
+    @Test
+    void addRule_configGroup_returns403() {
+        when(groupStore.findGroupById(CONFIG_GROUP.getId())).thenReturn(Optional.of(CONFIG_GROUP));
+
+        var resp = controller.addRule(CONFIG_GROUP.getId(), ruleReq("github", "/a/b", null, null));
+
+        assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+    }
+
+    @Test
+    void addRule_missingProvider_returns400() {
+        when(groupStore.findGroupById(DB_GROUP.getId())).thenReturn(Optional.of(DB_GROUP));
+
+        var resp = controller.addRule(DB_GROUP.getId(), ruleReq("", "/a/b", null, null));
+
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void addRule_invalidMatchType_returns400() {
+        when(groupStore.findGroupById(DB_GROUP.getId())).thenReturn(Optional.of(DB_GROUP));
+
+        var resp = controller.addRule(DB_GROUP.getId(), ruleReq("github", "/a/b", "WILDCARD", null));
+
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void addRule_success_returns201() {
+        when(groupStore.findGroupById(DB_GROUP.getId())).thenReturn(Optional.of(DB_GROUP));
+
+        var resp = controller.addRule(DB_GROUP.getId(), ruleReq("github", "/acme/repo", "LITERAL", "PUSH"));
+
+        assertEquals(HttpStatus.CREATED, resp.getStatusCode());
+        verify(groupStore).saveRule(any(GroupPermissionRule.class));
+    }
+
+    // ── DELETE /api/groups/{id}/permissions/{ruleId} ─────────────────────────────
+
+    @Test
+    void deleteRule_configGroup_returns403() {
+        when(groupStore.findGroupById(CONFIG_GROUP.getId())).thenReturn(Optional.of(CONFIG_GROUP));
+
+        var resp = controller.deleteRule(CONFIG_GROUP.getId(), "some-rule-id");
+
+        assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+        verify(groupStore, never()).deleteRule(any());
+    }
+
+    @Test
+    void deleteRule_ruleNotFound_returns404() {
+        when(groupStore.findGroupById(DB_GROUP.getId())).thenReturn(Optional.of(DB_GROUP));
+        when(groupStore.findRuleById("missing")).thenReturn(Optional.empty());
+
+        var resp = controller.deleteRule(DB_GROUP.getId(), "missing");
+
+        assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
+    }
+
+    @Test
+    void deleteRule_ruleBelongsToDifferentGroup_returns403() {
+        GroupPermissionRule rule = GroupPermissionRule.builder()
+                .groupId("other-group-id")
+                .provider("github")
+                .value("/a/b")
+                .matchType(MatchType.LITERAL)
+                .grant(RepoPermission.Grant.PUSH)
+                .build();
+        when(groupStore.findGroupById(DB_GROUP.getId())).thenReturn(Optional.of(DB_GROUP));
+        when(groupStore.findRuleById(rule.getId())).thenReturn(Optional.of(rule));
+
+        var resp = controller.deleteRule(DB_GROUP.getId(), rule.getId());
+
+        assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+        verify(groupStore, never()).deleteRule(any());
+    }
+
+    @Test
+    void deleteRule_success_returns204() {
+        GroupPermissionRule rule = GroupPermissionRule.builder()
+                .groupId(DB_GROUP.getId())
+                .provider("github")
+                .value("/acme/repo")
+                .matchType(MatchType.LITERAL)
+                .grant(RepoPermission.Grant.PUSH)
+                .build();
+        when(groupStore.findGroupById(DB_GROUP.getId())).thenReturn(Optional.of(DB_GROUP));
+        when(groupStore.findRuleById(rule.getId())).thenReturn(Optional.of(rule));
+
+        var resp = controller.deleteRule(DB_GROUP.getId(), rule.getId());
+
+        assertEquals(HttpStatus.NO_CONTENT, resp.getStatusCode());
+        verify(groupStore).deleteRule(rule.getId());
+    }
+}

--- a/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/PermissionControllerTest.java
+++ b/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/PermissionControllerTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.when;
 
 import com.rbc.fogwall.db.model.MatchTarget;
 import com.rbc.fogwall.db.model.MatchType;
+import com.rbc.fogwall.permission.GroupPermissionStore;
+import com.rbc.fogwall.permission.PermissionGroup;
 import com.rbc.fogwall.permission.RepoPermission;
 import com.rbc.fogwall.permission.RepoPermissionService;
 import com.rbc.fogwall.user.ReadOnlyUserStore;
@@ -252,5 +254,45 @@ class PermissionControllerTest {
 
         assertEquals(HttpStatus.NO_CONTENT, resp.getStatusCode());
         verify(permissionService).delete(DB_PERM.getId());
+    }
+
+    // ── GET /api/users/{username}/permissions/groups ─────────────────────────────
+
+    @Test
+    void listGroups_unknownUser_returns404() {
+        when(userStore.findByUsername("nobody")).thenReturn(Optional.empty());
+
+        var resp = controller.listGroups("nobody");
+
+        assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
+    }
+
+    @Test
+    void listGroups_noGroupStore_returnsEmptyList() {
+        when(userStore.findByUsername("alice")).thenReturn(Optional.of(ALICE));
+        when(permissionService.getGroupStore()).thenReturn(null);
+
+        var resp = controller.listGroups("alice");
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        assertEquals(List.of(), resp.getBody());
+    }
+
+    @Test
+    void listGroups_returnsMemberships() {
+        GroupPermissionStore groupStore = org.mockito.Mockito.mock(GroupPermissionStore.class);
+        PermissionGroup g = PermissionGroup.builder()
+                .name("devs")
+                .source(PermissionGroup.Source.DB)
+                .build();
+        when(userStore.findByUsername("alice")).thenReturn(Optional.of(ALICE));
+        when(permissionService.getGroupStore()).thenReturn(groupStore);
+        when(groupStore.findGroupIdsForUser("alice")).thenReturn(List.of(g.getId()));
+        when(groupStore.findGroupById(g.getId())).thenReturn(Optional.of(g));
+        when(groupStore.findRulesForGroup(g.getId())).thenReturn(List.of());
+
+        var resp = controller.listGroups("alice");
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
     }
 }

--- a/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/ProfileControllerTest.java
+++ b/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/ProfileControllerTest.java
@@ -8,12 +8,18 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.rbc.fogwall.permission.GroupPermissionStore;
+import com.rbc.fogwall.permission.PermissionGroup;
+import com.rbc.fogwall.permission.RepoPermission;
+import com.rbc.fogwall.permission.RepoPermissionService;
 import com.rbc.fogwall.user.EmailConflictException;
 import com.rbc.fogwall.user.LockedByConfigException;
 import com.rbc.fogwall.user.LockedEmailException;
 import com.rbc.fogwall.user.ScmIdentityConflictException;
 import com.rbc.fogwall.user.UserStore;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,6 +40,9 @@ class ProfileControllerTest {
 
     @Mock
     UserStore userStore;
+
+    @Mock
+    RepoPermissionService permissionService;
 
     @BeforeEach
     void setupSecurityContext() {
@@ -154,5 +163,50 @@ class ProfileControllerTest {
     void removeScmIdentity_success_returns204() {
         var resp = controller.removeScmIdentity("github", "alice-gh");
         assertEquals(HttpStatus.NO_CONTENT, resp.getStatusCode());
+    }
+
+    // ── GET /api/me/permissions ──────────────────────────────────────────────────
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void getPermissions_noGroupStore_returnsDirectAndEmptyGroups() {
+        RepoPermission direct = RepoPermission.builder()
+                .username("alice")
+                .provider("github")
+                .value("/acme/repo")
+                .grant(RepoPermission.Grant.PUSH)
+                .source(RepoPermission.Source.DB)
+                .build();
+        when(permissionService.findByUsername("alice")).thenReturn(List.of(direct));
+        when(permissionService.getGroupStore()).thenReturn(null);
+
+        var resp = controller.getPermissions();
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        var body = (Map<String, Object>) resp.getBody();
+        assertEquals(List.of(direct), body.get("direct"));
+        assertEquals(List.of(), body.get("groups"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void getPermissions_withGroupStore_returnsMergedResult() {
+        GroupPermissionStore groupStore = mock(GroupPermissionStore.class);
+        PermissionGroup g = PermissionGroup.builder()
+                .name("devs")
+                .source(PermissionGroup.Source.DB)
+                .build();
+        when(permissionService.findByUsername("alice")).thenReturn(List.of());
+        when(permissionService.getGroupStore()).thenReturn(groupStore);
+        when(groupStore.findGroupIdsForUser("alice")).thenReturn(List.of(g.getId()));
+        when(groupStore.findGroupById(g.getId())).thenReturn(Optional.of(g));
+        when(groupStore.findRulesForGroup(g.getId())).thenReturn(List.of());
+
+        var resp = controller.getPermissions();
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        var body = (Map<String, Object>) resp.getBody();
+        assertEquals(List.of(), body.get("direct"));
+        assertEquals(1, ((List<?>) body.get("groups")).size());
     }
 }

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/FogwallConfig.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/FogwallConfig.java
@@ -62,6 +62,12 @@ public class FogwallConfig {
     private List<PermissionConfig> permissions = new ArrayList<>();
 
     /**
+     * CONFIG-sourced permission groups seeded on startup. Each group has a name, optional description, a list of member
+     * usernames, and a list of repository permission rules that all members inherit.
+     */
+    private List<GroupConfig> groups = new ArrayList<>();
+
+    /**
      * Live config reload settings. Controls hot-reloading of commit rules and auth config without restarting the
      * server. Provider, server, and database changes always require a restart.
      */

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/GroupConfig.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/GroupConfig.java
@@ -1,0 +1,42 @@
+package com.rbc.fogwall.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+
+/**
+ * Binds a single entry in the {@code groups:} list in fogwall.yml.
+ *
+ * <p>Example:
+ *
+ * <pre>
+ * groups:
+ *   - name: team-alpha
+ *     description: "Alpha team push access"
+ *     members:
+ *       - alice
+ *       - bob
+ *     grants:
+ *       - provider: github
+ *         match:
+ *           target: SLUG
+ *           value: /myorg/**
+ *           type: GLOB
+ *         grant: PUSH
+ * </pre>
+ */
+@Data
+public class GroupConfig {
+
+    private String name = "";
+    private String description = "";
+    private List<String> members = new ArrayList<>();
+    private List<GroupGrantConfig> grants = new ArrayList<>();
+
+    @Data
+    public static class GroupGrantConfig {
+        private String provider = "";
+        private MatchConfig match = new MatchConfig();
+        private String grant = "PUSH";
+    }
+}

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
@@ -20,7 +20,11 @@ import com.rbc.fogwall.git.LocalRepositoryCache;
 import com.rbc.fogwall.jetty.FogwallContext;
 import com.rbc.fogwall.jetty.reload.ConfigHolder;
 import com.rbc.fogwall.jetty.reload.LiveConfigLoader;
+import com.rbc.fogwall.permission.GroupPermissionRule;
+import com.rbc.fogwall.permission.GroupPermissionStore;
+import com.rbc.fogwall.permission.JdbcGroupPermissionStore;
 import com.rbc.fogwall.permission.JdbcRepoPermissionStore;
+import com.rbc.fogwall.permission.PermissionGroup;
 import com.rbc.fogwall.permission.PermissionStore;
 import com.rbc.fogwall.permission.RepoPermission;
 import com.rbc.fogwall.permission.RepoPermissionService;
@@ -78,6 +82,7 @@ public class JettyConfigurationBuilder {
     private UserStore cachedUserStore;
     private ScmTokenCache cachedTokenCache;
     private RepoPermissionService cachedRepoPermissionService;
+    private GroupPermissionStore cachedGroupPermissionStore;
     private UrlRuleRegistry cachedUrlRuleRegistry;
     private ConfigHolder cachedConfigHolder;
 
@@ -468,14 +473,27 @@ public class JettyConfigurationBuilder {
         if (cachedRepoPermissionService != null) return cachedRepoPermissionService;
         PermissionStore<RepoPermission> store = buildRepoPermissionStore();
         store.initialize();
-        cachedRepoPermissionService = new RepoPermissionService(store);
+        cachedGroupPermissionStore = buildGroupPermissionStore();
+        cachedGroupPermissionStore.initialize();
+        cachedRepoPermissionService = new RepoPermissionService(store, cachedGroupPermissionStore);
 
         List<RepoPermission> configPerms = buildConfigPermissions(config);
         ensurePermissionUsersExist(configPerms);
         cachedRepoPermissionService.seedFromConfig(configPerms);
 
+        seedConfigGroups(config, cachedGroupPermissionStore);
+
         log.info("RepoPermissionService initialized with {} config permission(s)", configPerms.size());
         return cachedRepoPermissionService;
+    }
+
+    public GroupPermissionStore buildGroupPermissionStore() {
+        if (cachedGroupPermissionStore != null) return cachedGroupPermissionStore;
+        DatabaseConfig db = config.getDatabase();
+        if ("mongo".equals(db.getType())) {
+            return requireMongoStoreFactory().groupPermissionStore();
+        }
+        return new JdbcGroupPermissionStore(requireJdbcDataSource());
     }
 
     private void ensurePermissionUsersExist(List<RepoPermission> permissions) {
@@ -557,6 +575,43 @@ public class JettyConfigurationBuilder {
                             .build();
                 })
                 .toList();
+    }
+
+    private void seedConfigGroups(FogwallConfig cfg, GroupPermissionStore groupStore) {
+        // Clear existing CONFIG-sourced groups and re-seed from YAML.
+        groupStore.findAllGroups().stream()
+                .filter(g -> g.getSource() == PermissionGroup.Source.CONFIG)
+                .forEach(g -> groupStore.deleteGroup(g.getId()));
+
+        UserStore us = buildUserStore();
+        for (GroupConfig gc : cfg.getGroups()) {
+            PermissionGroup group = PermissionGroup.builder()
+                    .name(gc.getName())
+                    .description(gc.getDescription())
+                    .source(PermissionGroup.Source.CONFIG)
+                    .build();
+            groupStore.saveGroup(group);
+
+            for (String member : gc.getMembers()) {
+                us.upsertUser(member);
+                groupStore.addMember(group.getId(), member);
+            }
+
+            for (GroupConfig.GroupGrantConfig grant : gc.getGrants()) {
+                String resolvedProvider = resolveProviderName("Group '" + gc.getName() + "'", grant.getProvider());
+                MatchConfig m = grant.getMatch();
+                GroupPermissionRule rule = GroupPermissionRule.builder()
+                        .groupId(group.getId())
+                        .provider(resolvedProvider)
+                        .target(MatchTarget.valueOf(m.getTarget().toUpperCase()))
+                        .value(m.getValue())
+                        .matchType(MatchType.valueOf((m.getType() != null ? m.getType() : "GLOB").toUpperCase()))
+                        .grant(RepoPermission.Grant.valueOf(grant.getGrant().toUpperCase()))
+                        .build();
+                groupStore.saveRule(rule);
+            }
+        }
+        log.info("Seeded {} permission group(s) from config", cfg.getGroups().size());
     }
 
     public UrlRuleRegistry buildUrlRuleRegistry() {


### PR DESCRIPTION
## Summary

- Adds named permission groups as a first-class authorization concept, separate from Spring Security authorities and with an independent lifecycle
- Groups can be defined in YAML (`source: CONFIG`, read-only at runtime) or created via the dashboard UI (`source: DB`)
- `RepoPermissionService` unions direct per-user permissions with group-inherited permissions; fail-closed semantics preserved
- `/api/me/permissions` self-service endpoint returns direct and group permissions in one call
- Tiered JaCoCo coverage floors raised across the board as a kaizen pass (permission package at 95%)

## Changes

**Core (`fogwall-core`)**
- `PermissionGroup`, `GroupPermissionRule`, `GroupPermissionStore` interface
- JDBC, Mongo, and InMemory implementations
- V9 DB migration: `permission_groups`, `group_permissions`, `group_members` tables
- `RepoPermissionService` updated to evaluate group rules alongside direct permissions

**Server (`fogwall-server`)**
- `GroupConfig` POJO for YAML `groups:` section
- `JettyConfigurationBuilder` seeds CONFIG groups on startup and re-seeds on restart

**Dashboard (`fogwall-dashboard`)**
- `GET/POST/PATCH/DELETE /api/groups` — full CRUD with CONFIG-source guard
- `POST/DELETE /api/groups/{id}/members` — member management
- `POST/DELETE /api/groups/{id}/permissions` — rule management
- `GET /api/me/permissions` — self-service endpoint returning `{direct, groups}` (avoids admin-only endpoint for profile page)
- `GET /api/users/{username}/permissions/groups` — admin group membership view
- Admin Groups page: group list, create form, detail panel with inline name/description editing, member dropdown, rule form
- User profile permissions tab: direct permissions + "Group memberships" section showing inherited rules per group

**Tests**
- `GroupPermissionServiceTest` — 12 tests for group-union semantics, fail-closed, glob rules, multi-group union
- `InMemoryGroupPermissionStoreTest` — 15 CRUD tests for the in-memory store
- `JdbcGroupPermissionStoreIntegrationTest` — 14 H2-backed tests incl. cascade delete and all grant types
- `MongoGroupPermissionStoreIntegrationTest` — 14 Testcontainers tests with same coverage as JDBC
- `GroupControllerTest` — 22 Mockito controller tests covering all endpoints, CONFIG guards, and validation
- `PermissionControllerTest` — 3 new tests for `GET /api/users/{username}/permissions/groups`
- `ProfileControllerTest` — 2 new tests for `GET /api/me/permissions`
- `RepoPermissionServiceTest` — added `isBypassReviewAllowed` (5 tests), invalid-glob fallback, `findAll`, `getGroupStore`
- `InMemoryFetchStoreTest` — new (9 tests); `InMemoryPushStoreTest` expanded with project/user/authorEmail/`updateForwardStatus`
- `InMemoryUrlRuleRegistryTest` — new (7 tests)
- `JdbcRepoPermissionStoreIntegrationTest` — added `save_unseededUser_autoCreatesUserRow`
- Fixed `docker.io/` prefix + `asCompatibleSubstituteFor("mongo")` on all six `MongoDBContainer` usages (Podman compatibility)

**Coverage floors (kaizen)**

| Package | Before | After |
|---|---|---|
| `permission` | 75% | **95%** |
| `service`, `approval`, `config`, `db/model`, `db/jdbc/mapper`, `db/memory` | 75% / none | **90%** |
| `user` | 65% | **70%** |

## Test plan

- [ ] Create a DB group, add a member, add a permission rule — verify push allowed
- [ ] Remove member — verify push denied
- [ ] Define a CONFIG group in YAML — verify it appears read-only in the UI (no edit/delete/add-member controls)
- [ ] Rename a DB group — verify list updates and name uniqueness is enforced
- [ ] User profile permissions tab shows both direct permissions and group memberships with inherited rules