### PR TITLE
Rule and permission test endpoints for admin dry-run checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,42 @@
 # fogwall — Claude context
 
+## Positioning
+
+fogwall is not "a Java rewrite of git-proxy that solves an OSPO-approval problem." Think of it as a general-purpose
+**gateway/integration layer for an enterprise's software estate**, with git push validation as the first fully-built use
+case, not the ceiling. Design decisions should keep the door open for:
+
+- **SDLC/SCM control plane** — a single policy-enforcement chokepoint sitting in front of heterogeneous SCM platforms
+  (GitHub, GitLab, Bitbucket, Forgejo/Gitea, and eventually non-git systems), so a regulated org doesn't need bespoke
+  compliance tooling bolted onto each one individually.
+- **M&A / subsidiary integration gateway** — a way to bridge two orgs' disparate SCM estates during an acquisition or
+  integration without granting direct cross-boundary network access, while still enforcing each side's policy.
+- **Inner-source enablement** — the trust/approval/audit layer that lets a regulated org run an internal
+  open-source-style contribution model without each app team reinventing review and provenance controls.
+
+When evaluating a new feature, prefer the more general abstraction (provider-agnostic, protocol-agnostic where
+reasonable) over one that only serves the git-push case, even if git push is what's shipping today.
+
+## Design principles
+
+fogwall sits at a security boundary. When a design choice pits security against convenience, security wins — but treat
+that as a rare, real tradeoff to name explicitly, not a reflex; a control developers route around because it's unusable
+isn't actually providing security.
+
+- **Security is non-negotiable.** Never weaken the correctness of a validation or approval control for the sake of
+  ergonomics. Where a feature must pick between "safe by default" and "convenient by default," default to safe and make
+  the convenient path an explicit, visible opt-in (self-certify grants, admin override, auto-approve mode) — never a
+  silent default.
+- **Auditability and transparency are part of the security model, not a nice-to-have.** Every decision fogwall makes
+  (blocked, approved, forwarded, overridden) should be explainable after the fact — who, which rule, what evidence — not
+  just enforced in the moment. A feature that can't produce an audit trail for its own decisions isn't done.
+- **Don't let roadmap ambition become shipped-system complexity.** The gateway/integration-layer vision above is a north
+  star, not a mandate to wire every backlog item into one interdependent system. Prefer features that are individually
+  optional and composable — an org should be able to run only the pieces it needs — over a design where understanding or
+  operating one feature requires understanding all of them. If a new capability would raise the baseline complexity for
+  someone not using it, that's a signal to make it opt-in or a separate module rather than folding it into the core
+  path.
+
 ## Repository layout
 
 | Module              | Purpose                                                                                                     |
@@ -34,72 +71,25 @@ stream partial output mid-filter-chain. Validation filters must _accumulate_ the
 `ValidationSummaryFilter` (order `Integer.MAX_VALUE - 3`) and `PushFinalizerFilter` (order `Integer.MAX_VALUE - 1`)
 collect everything and write one response at the end using `sendGitError`.
 
-## Reference implementation
+## Lineage
 
-The Node.js original lives at [finos/git-proxy](https://github.com/finos/git-proxy). Refer to it for the Action/Step
-model, Sink interface, and filter chain patterns when porting features.
+fogwall's push-validation core traces back to [finos/git-proxy](https://github.com/finos/git-proxy) — the Node.js
+original designed the Action/Step model, Sink interface, approval lifecycle, and multi-provider architecture that
+fogwall's own abstractions are informed by. Refer to it for prior art when porting or extending that specific piece of
+the system. It is a reference point, not a spec fogwall is obligated to mirror going forward — fogwall's roadmap
+(gateway/integration-layer use cases above) extends past what git-proxy set out to do.
 
-## Build & test
+## Development
 
-```bash
-./gradlew spotlessApply      # fix formatting (palantir-java-format) — run this before build
-./gradlew build              # compile + unit tests (no containers)
-./gradlew test               # unit tests only (e2e excluded)
-./gradlew e2eTest            # e2e tests — requires Docker/Podman
-```
+Detailed build, test, run, and Docker Compose instructions live in [CONTRIBUTING.md](CONTRIBUTING.md) — treat it as the
+source of truth for exact commands, since it's written for human contributors and kept current. In short:
 
-**Important:** Gradle caches test results. If you add new tests or change coverage-relevant code, run with `--rerun` to
-bypass the cache and verify the jacoco threshold:
-
-```bash
-./gradlew :fogwall-core:test :fogwall-core:jacocoTestCoverageVerification --rerun
-```
-
-Always verify the threshold passes locally before pushing — CI runs without cache and will catch it.
-
-Unit tests live under each module's `src/test/`. E2e tests are tagged `@Tag("e2e")` and live in
-`fogwall-server/src/test/java/com/rbc/fogwall/e2e/` (proxy modes, identity resolution, SSH, config reload) and
-`fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/e2e/` (LDAP/OIDC auth and role mapping).
-
-## Running the server locally
-
-```bash
-# Proxy only (no dashboard, no API):
-./gradlew :fogwall-server:run &
-./gradlew :fogwall-server:stop
-
-# Proxy + dashboard + REST API (http://localhost:8080/):
-./gradlew :fogwall-dashboard:run &
-./gradlew :fogwall-dashboard:stop
-
-# Logs: fogwall-server/logs/application.log  (DEBUG for com.rbc.fogwall)
-# Default DB: h2-file — persisted to fogwall-server/.data/fogwall.mv.db
-```
-
-## Docker Compose
-
-Always use the `compose.sh` wrapper — never bare `docker compose`/`podman compose` — it assembles the right `-f` overlay
-flags and auto-detects docker vs podman:
-
-```bash
-bash compose.sh -- up -d                        # fogwall + Gitea (h2-file database)
-bash docker/gitea-setup.sh                      # one-time: create admin user + test repo in Gitea
-
-# Optional overlays, composable:
-bash compose.sh --auth ldap -- up -d            # LDAP auth backend
-bash compose.sh --auth oidc -- up -d            # OIDC auth backend
-bash compose.sh --db postgres -- up -d          # Postgres instead of default h2-file
-bash compose.sh --db mongo -- up -d             # MongoDB instead of default h2-file
-bash compose.sh --auth ldap --db postgres -- down -v
-```
-
-Default config mounted at `/app/conf/fogwall-docker-default.yml` inside the container. Templates (including
-`fogwall-local.yml` for custom overrides) live in `docker/`.
-
-## Configuration
-
-Refer to [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for detailed docs on YAML config structure, environment variable
-overrides, and provider-specific settings.
+- `./gradlew spotlessApply && ./gradlew build` — format then compile + unit test
+- `./gradlew e2eTest` — e2e tests (requires Docker/Podman)
+- `bash compose.sh -- up -d` — local stack (fogwall + Gitea); see CONTRIBUTING.md for auth/db overlay flags
+- Gradle caches test results — pass `--rerun` when adding tests or touching coverage-relevant code, e.g.:
+  `./gradlew :fogwall-core:test :fogwall-core:jacocoTestCoverageVerification --rerun`. Always verify the jacoco
+  threshold locally before pushing — CI runs without cache and will catch it.
 
 ## Commit conventions
 
@@ -110,12 +100,32 @@ overrides, and provider-specific settings.
 - Always include `closes #N` / `resolves #N` in commit messages when addressing a GitHub issue.
 - Never add `[ci skip]` to commits unless explicitly asked.
 
+## Backwards compatibility
+
+Past the 1.0.0 line (current version well past it — see `build.gradle`) — respect backcompat, don't break freely:
+
+- **Config keys** — don't rename/remove without a deprecation path; accept old and new for at least one minor release.
+- **SQL schema** — changes go through `DatabaseMigrator` (new migration file + registry entry); never edit an applied
+  migration.
+- **Mongo collections** — don't rename once shipped; a rename needs a migration step (copy + drop), documented.
+- **REST API shapes** — additive only, no breaking field removals.
+- Java APIs inside `fogwall-core` are still internal and can break between minors until a stable embedding story is
+  declared.
+
+Before renaming a config key, table, column, or collection: pause and ask — the answer is almost always "ship a
+migration instead."
+
 ## Testing conventions
 
 - Always use JUnit assertions (`org.junit.jupiter.api.Assertions.*`) — not manual `if`/`throw` checks.
 - E2e tests use Testcontainers (Gitea) + `JettyProxyFixture`. Credentials in the clone URL are forwarded to upstream
   Gitea, so they must be valid Gitea credentials. Use `GiteaContainer.ADMIN_USER`/`ADMIN_PASSWORD` or create test users
   via `createTestUser()` / `addTestUserAsCollaborator()` — never invent fake usernames that won't authenticate upstream.
+
+## Configuration
+
+Refer to [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for detailed docs on YAML config structure, environment variable
+overrides, and provider-specific settings.
 
 ## Roadmap & architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,14 +275,11 @@ provider, one for the database backend. They can be combined freely.
 | `docker-compose.postgres.yml` | PostgreSQL   | `--profile postgres` | Adminer at :8082       |
 | `docker-compose.mongo.yml`    | MongoDB      | `--profile mongo`    | Mongo Express at :8081 |
 
-Any auth overlay can be combined with any database overlay (or none, to keep H2). The pattern is:
+Any auth overlay can be combined with any database overlay (or none, to keep H2). Use the `compose.sh` wrapper rather
+than bare `docker compose` — it assembles the right `-f`/`--profile` flags and auto-detects docker vs podman:
 
 ```bash
-docker compose [--profile <db>] \
-  -f docker-compose.yml \
-  [-f docker-compose.<auth>.yml] \
-  [-f docker-compose.<db>.yml] \
-  up -d
+bash compose.sh [--auth ldap|oidc] [--db postgres|mongo] -- up -d
 ```
 
 ### First-time setup
@@ -298,43 +295,31 @@ bash docker/gitea-setup.sh
 **Static auth + H2** (simplest — no external dependencies):
 
 ```shell
-docker compose up -d
+bash compose.sh -- up -d
 ```
 
 **LDAP + H2**:
 
 ```shell
-docker compose -f docker-compose.yml -f docker-compose.ldap.yml up -d
+bash compose.sh --auth ldap -- up -d
 ```
 
 **LDAP + PostgreSQL** (recommended for verifying IdP email locking and auto-provisioning):
 
 ```shell
-docker compose --profile postgres \
-  -f docker-compose.yml \
-  -f docker-compose.ldap.yml \
-  -f docker-compose.postgres.yml \
-  up -d
+bash compose.sh --auth ldap --db postgres -- up -d
 ```
 
 **OIDC + PostgreSQL**:
 
 ```shell
-docker compose --profile postgres \
-  -f docker-compose.yml \
-  -f docker-compose.oidc.yml \
-  -f docker-compose.postgres.yml \
-  up -d
+bash compose.sh --auth oidc --db postgres -- up -d
 ```
 
 **LDAP + MongoDB**:
 
 ```shell
-docker compose --profile mongo \
-  -f docker-compose.yml \
-  -f docker-compose.ldap.yml \
-  -f docker-compose.mongo.yml \
-  up -d
+bash compose.sh --auth ldap --db mongo -- up -d
 ```
 
 ### Auth provider details
@@ -358,8 +343,8 @@ from the profile UI). Inspect the `user_emails` table in Adminer or Mongo Expres
 To add more users, edit `docker/ldap-bootstrap.ldif` and recreate the container:
 
 ```shell
-docker compose -f docker-compose.yml -f docker-compose.ldap.yml rm -sf openldap
-docker compose -f docker-compose.yml -f docker-compose.ldap.yml up -d openldap
+bash compose.sh --auth ldap -- rm -sf openldap
+bash compose.sh --auth ldap -- up -d openldap
 ```
 
 #### OIDC auth
@@ -394,7 +379,7 @@ git clone http://fogwalladmin:Admin1234!@localhost:8080/push/gitea:3000/test-own
 ### Teardown
 
 ```bash
-docker compose [same -f flags as start] down -v
+bash compose.sh [same --auth/--db flags as start] -- down -v
 ```
 
 ## Code style

--- a/fogwall-core/src/main/java/com/rbc/fogwall/permission/RepoPermissionService.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/permission/RepoPermissionService.java
@@ -37,6 +37,20 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class RepoPermissionService {
 
+    /** Outcome of evaluating whether a user has a given grant for a path, and what granted it. */
+    public sealed interface GrantResult
+            permits GrantResult.GrantedDirect, GrantResult.GrantedByGroup, GrantResult.NotGranted {
+
+        /** A direct, per-user permission entry granted access. */
+        record GrantedDirect(RepoPermission permission) implements GrantResult {}
+
+        /** A group-inherited permission rule granted access. */
+        record GrantedByGroup(GroupPermissionRule rule) implements GrantResult {}
+
+        /** No direct or group permission granted access. */
+        record NotGranted() implements GrantResult {}
+    }
+
     private final PermissionStore<RepoPermission> store;
     private final GroupPermissionStore groupStore;
     private final ConcurrentHashMap<String, Pattern> patternCache = new ConcurrentHashMap<>();
@@ -197,32 +211,7 @@ public class RepoPermissionService {
     }
 
     private boolean isAllowed(String username, String provider, String path, RepoPermission.Grant op) {
-        List<RepoPermission> forPath = store.findByProvider(provider).stream()
-                .filter(p -> matchesPath(p, path))
-                .toList();
-
-        List<GroupPermissionRule> groupRulesForPath = List.of();
-        if (groupStore != null) {
-            Set<String> userGroupIds = Set.copyOf(groupStore.findGroupIdsForUser(username));
-            groupRulesForPath = groupStore.findRulesByProvider(provider).stream()
-                    .filter(r -> userGroupIds.contains(r.getGroupId()))
-                    .filter(r -> matchesPathRule(r, path))
-                    .toList();
-        }
-
-        if (forPath.isEmpty() && groupRulesForPath.isEmpty()) {
-            log.debug("No permission grants for {}/{} — DENY (fail-closed)", provider, path);
-            return false;
-        }
-
-        boolean allowedDirect = forPath.stream()
-                .filter(p -> p.getGrant() == op || p.getGrant() == RepoPermission.Grant.PUSH_AND_REVIEW)
-                .anyMatch(p -> username.equals(p.getUsername()));
-
-        boolean allowedViaGroup = groupRulesForPath.stream()
-                .anyMatch(r -> r.getGrant() == op || r.getGrant() == RepoPermission.Grant.PUSH_AND_REVIEW);
-
-        boolean allowed = allowedDirect || allowedViaGroup;
+        boolean allowed = !(evaluateGrant(username, provider, path, op) instanceof GrantResult.NotGranted);
         log.debug(
                 "Permission check: user={} provider={} path={} op={} → {}",
                 username,
@@ -231,6 +220,36 @@ public class RepoPermissionService {
                 op,
                 allowed ? "ALLOW" : "DENY");
         return allowed;
+    }
+
+    /**
+     * Evaluates whether {@code username} has {@code op} (or the combined {@code PUSH_AND_REVIEW} grant) for
+     * {@code path} at {@code provider}, and returns which permission entry granted it — a direct per-user permission, a
+     * group-inherited rule, or neither. Direct permissions are preferred over group rules when both exist.
+     */
+    public GrantResult evaluateGrant(String username, String provider, String path, RepoPermission.Grant op) {
+        Optional<RepoPermission> direct = store.findByProvider(provider).stream()
+                .filter(p -> matchesPath(p, path))
+                .filter(p -> p.getGrant() == op || p.getGrant() == RepoPermission.Grant.PUSH_AND_REVIEW)
+                .filter(p -> username.equals(p.getUsername()))
+                .findFirst();
+        if (direct.isPresent()) {
+            return new GrantResult.GrantedDirect(direct.get());
+        }
+
+        if (groupStore != null) {
+            Set<String> userGroupIds = Set.copyOf(groupStore.findGroupIdsForUser(username));
+            Optional<GroupPermissionRule> viaGroup = groupStore.findRulesByProvider(provider).stream()
+                    .filter(r -> userGroupIds.contains(r.getGroupId()))
+                    .filter(r -> matchesPathRule(r, path))
+                    .filter(r -> r.getGrant() == op || r.getGrant() == RepoPermission.Grant.PUSH_AND_REVIEW)
+                    .findFirst();
+            if (viaGroup.isPresent()) {
+                return new GrantResult.GrantedByGroup(viaGroup.get());
+            }
+        }
+
+        return new GrantResult.NotGranted();
     }
 
     private boolean matchesPath(RepoPermission perm, String path) {

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/UrlRuleEvaluator.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/UrlRuleEvaluator.java
@@ -9,6 +9,7 @@ import com.rbc.fogwall.provider.FogwallProvider;
 import java.nio.file.FileSystems;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,6 +42,12 @@ public class UrlRuleEvaluator {
         /** No rule matched — request must be rejected (fail-closed). */
         record NotAllowed() implements Result {}
     }
+
+    /** One rule considered during evaluation, in order, and whether it matched the repository reference. */
+    public record RuleEvaluation(AccessRule rule, boolean matched) {}
+
+    /** The full ordered evaluation trail plus the resulting decision. */
+    public record Trail(List<RuleEvaluation> steps, Result result) {}
 
     private static final ConcurrentHashMap<String, Pattern> REGEX_CACHE = new ConcurrentHashMap<>();
 
@@ -84,6 +91,39 @@ public class UrlRuleEvaluator {
         }
 
         return new Result.NotAllowed();
+    }
+
+    /**
+     * Evaluates all configured rules like {@link #evaluate}, but instead of stopping at the first match, continues
+     * through every enabled rule (in order) and records whether each one matched. Used by the admin-facing rule test
+     * endpoint to show a firewall-log style trail; the live push/proxy path uses {@link #evaluate} since it only needs
+     * the final decision.
+     */
+    public Trail evaluateTrail(String slug, String owner, String name, HttpOperation operation) {
+        List<AccessRule> rules = (urlRuleRegistry != null && provider != null)
+                ? urlRuleRegistry.findEnabledForProvider(provider.getProviderId())
+                : List.of();
+
+        List<AccessRule> sortedAll = rules.stream()
+                .filter(r -> operationMatches(r, operation))
+                .sorted(Comparator.comparingInt(AccessRule::getRuleOrder))
+                .toList();
+
+        List<RuleEvaluation> steps = new ArrayList<>();
+        Result result = null;
+        for (AccessRule r : sortedAll) {
+            boolean matched = matchesRepo(r, slug, owner, name);
+            steps.add(new RuleEvaluation(r, matched));
+            if (matched && result == null) {
+                result = r.getAccess() == AccessRule.Access.DENY
+                        ? new Result.Denied(r.getId())
+                        : new Result.Allowed(r.getId());
+            }
+        }
+        if (result == null) {
+            result = new Result.NotAllowed();
+        }
+        return new Trail(List.copyOf(steps), result);
     }
 
     /**

--- a/fogwall-core/src/test/java/com/rbc/fogwall/permission/GroupPermissionServiceTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/permission/GroupPermissionServiceTest.java
@@ -184,4 +184,82 @@ class GroupPermissionServiceTest {
         RepoPermissionService noGroupSvc = new RepoPermissionService(new InMemoryRepoPermissionStore());
         assertFalse(noGroupSvc.isAllowedToPush("alice", "github", "/acme/repo"));
     }
+
+    // ---- evaluateGrant: attributes which entry granted access ----
+
+    @Test
+    void evaluateGrant_directPermission_returnsGrantedDirect() {
+        RepoPermission direct = RepoPermission.builder()
+                .username("alice")
+                .provider("github")
+                .value("/acme/repo")
+                .matchType(MatchType.LITERAL)
+                .grant(RepoPermission.Grant.PUSH)
+                .source(RepoPermission.Source.DB)
+                .build();
+        svc.save(direct);
+
+        var result = svc.evaluateGrant("alice", "github", "/acme/repo", RepoPermission.Grant.PUSH);
+
+        assertInstanceOf(RepoPermissionService.GrantResult.GrantedDirect.class, result);
+        assertEquals(
+                direct.getId(),
+                ((RepoPermissionService.GrantResult.GrantedDirect) result)
+                        .permission()
+                        .getId());
+    }
+
+    @Test
+    void evaluateGrant_groupRule_returnsGrantedByGroup() {
+        PermissionGroup g = group("devs");
+        GroupPermissionRule r = rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        groupStore.addMember(g.getId(), "alice");
+
+        var result = svc.evaluateGrant("alice", "github", "/acme/repo", RepoPermission.Grant.PUSH);
+
+        assertInstanceOf(RepoPermissionService.GrantResult.GrantedByGroup.class, result);
+        assertEquals(
+                r.getId(),
+                ((RepoPermissionService.GrantResult.GrantedByGroup) result)
+                        .rule()
+                        .getId());
+    }
+
+    @Test
+    void evaluateGrant_directPreferredOverGroup() {
+        PermissionGroup g = group("devs");
+        rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        groupStore.addMember(g.getId(), "alice");
+
+        RepoPermission direct = RepoPermission.builder()
+                .username("alice")
+                .provider("github")
+                .value("/acme/repo")
+                .matchType(MatchType.LITERAL)
+                .grant(RepoPermission.Grant.PUSH)
+                .source(RepoPermission.Source.DB)
+                .build();
+        svc.save(direct);
+
+        var result = svc.evaluateGrant("alice", "github", "/acme/repo", RepoPermission.Grant.PUSH);
+
+        assertInstanceOf(RepoPermissionService.GrantResult.GrantedDirect.class, result);
+    }
+
+    @Test
+    void evaluateGrant_noMatch_returnsNotGranted() {
+        var result = svc.evaluateGrant("alice", "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        assertInstanceOf(RepoPermissionService.GrantResult.NotGranted.class, result);
+    }
+
+    @Test
+    void evaluateGrant_nonMember_returnsNotGranted() {
+        PermissionGroup g = group("devs");
+        rule(g.getId(), "github", "/acme/repo", RepoPermission.Grant.PUSH);
+        groupStore.addMember(g.getId(), "alice");
+
+        var result = svc.evaluateGrant("bob", "github", "/acme/repo", RepoPermission.Grant.PUSH);
+
+        assertInstanceOf(RepoPermissionService.GrantResult.NotGranted.class, result);
+    }
 }

--- a/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/UrlRuleEvaluatorTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/UrlRuleEvaluatorTest.java
@@ -265,6 +265,88 @@ class UrlRuleEvaluatorTest {
                 "PUSH-only deny rule must not block a fetch");
     }
 
+    // ── evaluateTrail ─────────────────────────────────────────────────────────
+
+    @Test
+    void evaluateTrail_recordsAllRulesInOrderWithMatchFlag() {
+        var denyRule = AccessRule.builder()
+                .ruleOrder(100)
+                .access(AccessRule.Access.DENY)
+                .operation(AccessRule.Operation.BOTH)
+                .target(MatchTarget.OWNER)
+                .value("blocked")
+                .matchType(MatchType.GLOB)
+                .build();
+        var allowRule = AccessRule.builder()
+                .ruleOrder(200)
+                .access(AccessRule.Access.ALLOW)
+                .operation(AccessRule.Operation.BOTH)
+                .target(MatchTarget.OWNER)
+                .value("myorg")
+                .matchType(MatchType.GLOB)
+                .build();
+        var evaluator = evaluatorWith(denyRule, allowRule);
+
+        var trail = evaluator.evaluateTrail("myorg/repo", "myorg", "repo", HttpOperation.PUSH);
+
+        assertEquals(2, trail.steps().size());
+        assertEquals(denyRule.getId(), trail.steps().get(0).rule().getId());
+        assertFalse(trail.steps().get(0).matched(), "deny rule for 'blocked' must not match 'myorg'");
+        assertEquals(allowRule.getId(), trail.steps().get(1).rule().getId());
+        assertTrue(trail.steps().get(1).matched());
+        assertInstanceOf(UrlRuleEvaluator.Result.Allowed.class, trail.result());
+    }
+
+    @Test
+    void evaluateTrail_firstMatchWinsButLaterRulesStillRecorded() {
+        var denyRule = AccessRule.builder()
+                .ruleOrder(100)
+                .access(AccessRule.Access.DENY)
+                .operation(AccessRule.Operation.BOTH)
+                .target(MatchTarget.OWNER)
+                .value("myorg")
+                .matchType(MatchType.GLOB)
+                .build();
+        var allowRule = AccessRule.builder()
+                .ruleOrder(200)
+                .access(AccessRule.Access.ALLOW)
+                .operation(AccessRule.Operation.BOTH)
+                .target(MatchTarget.OWNER)
+                .value("myorg")
+                .matchType(MatchType.GLOB)
+                .build();
+        var evaluator = evaluatorWith(denyRule, allowRule);
+
+        var trail = evaluator.evaluateTrail("myorg/repo", "myorg", "repo", HttpOperation.PUSH);
+
+        assertEquals(2, trail.steps().size(), "later rules are still recorded even though the first match decides");
+        assertTrue(trail.steps().get(0).matched());
+        assertTrue(trail.steps().get(1).matched());
+        assertInstanceOf(UrlRuleEvaluator.Result.Denied.class, trail.result());
+        assertEquals(denyRule.getId(), ((UrlRuleEvaluator.Result.Denied) trail.result()).ruleId());
+    }
+
+    @Test
+    void evaluateTrail_noRulesMatch_notAllowedWithFullTrail() {
+        var evaluator = evaluatorWith(allow(MatchTarget.OWNER, "myorg"));
+
+        var trail = evaluator.evaluateTrail("otherorg/repo", "otherorg", "repo", HttpOperation.PUSH);
+
+        assertEquals(1, trail.steps().size());
+        assertFalse(trail.steps().get(0).matched());
+        assertInstanceOf(UrlRuleEvaluator.Result.NotAllowed.class, trail.result());
+    }
+
+    @Test
+    void evaluateTrail_emptyRegistry_emptyTrail() {
+        var evaluator = new UrlRuleEvaluator(new InMemoryUrlRuleRegistry(), GITHUB);
+
+        var trail = evaluator.evaluateTrail("org/repo", "org", "repo", HttpOperation.PUSH);
+
+        assertTrue(trail.steps().isEmpty());
+        assertInstanceOf(UrlRuleEvaluator.Result.NotAllowed.class, trail.result());
+    }
+
     // ── Registry query ────────────────────────────────────────────────────────
 
     @Test

--- a/fogwall-dashboard/frontend/src/api.ts
+++ b/fogwall-dashboard/frontend/src/api.ts
@@ -307,6 +307,55 @@ export async function deleteUrlRule(id: string) {
   if (!res.ok) await parseErrorResponse(res, 'Failed to delete URL rule')
 }
 
+export interface RuleTestStep {
+  ruleId: string
+  order: number
+  access: 'ALLOW' | 'DENY'
+  description: string | null
+  matched: boolean
+}
+
+export interface RuleTestResponse {
+  decision: 'ALLOW' | 'DENY' | 'NOT_ALLOWED'
+  matchedRuleId: string | null
+  steps: RuleTestStep[]
+}
+
+export async function testUrlRules(data: {
+  provider: string
+  owner: string
+  name: string
+  operation?: 'PUSH' | 'FETCH'
+}): Promise<RuleTestResponse> {
+  const res = await apiFetch('/api/repos/rules/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) await parseErrorResponse(res, 'Rule test failed')
+  return res.json()
+}
+
+export interface PermissionTestResponse {
+  allowed: boolean
+  source: 'DIRECT' | 'GROUP' | 'NONE'
+  entryId: string | null
+  groupName: string | null
+}
+
+export async function testUserPermission(
+  username: string,
+  data: { provider: string; path: string; grant?: string },
+): Promise<PermissionTestResponse> {
+  const res = await apiFetch(`/api/users/${encodeURIComponent(username)}/permissions/test`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  if (!res.ok) await parseErrorResponse(res, 'Permission test failed')
+  return res.json()
+}
+
 export async function fetchGroups() {
   const res = await apiFetch('/api/groups')
   if (!res.ok) throw new Error('Failed to fetch groups')

--- a/fogwall-dashboard/frontend/src/pages/Repos.tsx
+++ b/fogwall-dashboard/frontend/src/pages/Repos.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
-import { createUrlRule, deleteUrlRule, fetchProviders } from '../api'
+import { createUrlRule, deleteUrlRule, fetchProviders, testUrlRules } from '../api'
+import type { RuleTestResponse } from '../api'
 import type { Provider } from '../types'
 
 interface ActiveRepo {
@@ -394,12 +395,223 @@ function AddRuleModal({
   )
 }
 
+function TestRuleModal({ onClose }: { onClose: () => void }) {
+  const [provider, setProvider] = useState('')
+  const [owner, setOwner] = useState('')
+  const [name, setName] = useState('')
+  const [operation, setOperation] = useState<'PUSH' | 'FETCH'>('PUSH')
+  const [providers, setProviders] = useState<Provider[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [result, setResult] = useState<RuleTestResponse | null>(null)
+
+  useEffect(() => {
+    fetchProviders()
+      .then((data: Provider[]) => {
+        setProviders(data)
+        if (data.length > 0) setProvider(data[0].id)
+      })
+      .catch(() => {})
+  }, [])
+
+  const handleTest = async () => {
+    if (!provider || !owner.trim() || !name.trim()) {
+      setError('Provider, owner, and repo name are required')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    setResult(null)
+    try {
+      const res = await testUrlRules({
+        provider,
+        owner: owner.trim(),
+        name: name.trim(),
+        operation,
+      })
+      setResult(res)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleReset = () => {
+    setOwner('')
+    setName('')
+    setOperation('PUSH')
+    setError(null)
+    setResult(null)
+  }
+
+  const inputClass =
+    'w-full border border-gray-300 rounded px-3 py-1.5 text-sm dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200'
+  const labelClass = 'block text-sm font-medium text-gray-700 mb-1 dark:text-gray-300'
+
+  const decisionClass =
+    result?.decision === 'ALLOW'
+      ? 'bg-green-100 text-green-800 border-green-300 dark:bg-green-900/30 dark:text-green-300 dark:border-green-700'
+      : result?.decision === 'DENY'
+        ? 'bg-red-100 text-red-800 border-red-300 dark:bg-red-900/30 dark:text-red-300 dark:border-red-700'
+        : 'bg-gray-100 text-gray-700 border-gray-300 dark:bg-slate-700 dark:text-gray-300 dark:border-slate-600'
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 dark:bg-black/60">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-lg p-6 space-y-4 dark:bg-slate-800">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200">Test a rule</h3>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 text-xl leading-none dark:text-gray-500 dark:hover:text-gray-300"
+          >
+            ×
+          </button>
+        </div>
+
+        <p className="text-xs text-gray-400 dark:text-gray-500">
+          Read-only evaluation against the live ruleset. Shows which rule matches first and the full
+          ordered trail of rules considered.
+        </p>
+
+        <div className="space-y-3">
+          <div>
+            <label className={labelClass}>Provider</label>
+            <select
+              value={provider}
+              onChange={(e) => setProvider(e.target.value)}
+              className={inputClass}
+            >
+              {providers.length === 0 && <option value="">— No providers configured —</option>}
+              {providers.map((p) => (
+                <option key={p.name} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelClass}>Owner / org</label>
+              <input
+                type="text"
+                value={owner}
+                onChange={(e) => setOwner(e.target.value)}
+                placeholder="myorg"
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Repo name</label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="myrepo"
+                className={inputClass}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className={labelClass}>Operation</label>
+            <select
+              value={operation}
+              onChange={(e) => setOperation(e.target.value as 'PUSH' | 'FETCH')}
+              className={inputClass}
+            >
+              <option value="PUSH">Push</option>
+              <option value="FETCH">Fetch</option>
+            </select>
+          </div>
+        </div>
+
+        {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+
+        {result && (
+          <div className="space-y-2">
+            <div
+              className={`flex items-center gap-2 rounded border px-3 py-2 text-sm font-medium ${decisionClass}`}
+            >
+              <span>{result.decision}</span>
+              {result.matchedRuleId && (
+                <span className="text-xs font-normal opacity-75">
+                  matched rule {result.matchedRuleId.slice(0, 8)}
+                </span>
+              )}
+            </div>
+            {result.steps.length === 0 ? (
+              <p className="text-xs text-gray-400 dark:text-gray-500">No rules considered.</p>
+            ) : (
+              <div className="border border-gray-200 rounded divide-y divide-gray-100 dark:border-slate-700 dark:divide-slate-700">
+                {result.steps.map((step, i) => (
+                  <div
+                    key={step.ruleId}
+                    className={`flex items-center gap-2 px-3 py-1.5 text-xs ${
+                      step.matched ? 'bg-gray-50 dark:bg-slate-700/50' : ''
+                    }`}
+                  >
+                    <span className="w-4 text-center">{step.matched ? '✓' : '·'}</span>
+                    <span className="w-8 text-gray-400 font-mono dark:text-gray-500">#{i + 1}</span>
+                    <span
+                      className={`px-1.5 py-0.5 rounded font-medium ${
+                        step.access === 'ALLOW'
+                          ? 'text-green-700 dark:text-green-400'
+                          : 'text-red-700 dark:text-red-400'
+                      }`}
+                    >
+                      {step.access}
+                    </span>
+                    <span className="text-gray-400 dark:text-gray-500">order {step.order}</span>
+                    {step.description && (
+                      <span className="text-gray-500 truncate dark:text-gray-400">
+                        — {step.description}
+                      </span>
+                    )}
+                    <span className="ml-auto text-gray-400 dark:text-gray-500">
+                      {step.matched ? 'matched' : 'no match'}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 pt-1">
+          <button
+            onClick={onClose}
+            className="px-4 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 dark:border-slate-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            Close
+          </button>
+          <button
+            onClick={handleReset}
+            className="px-4 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 dark:border-slate-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            Reset
+          </button>
+          <button
+            onClick={handleTest}
+            disabled={submitting}
+            className="px-4 py-1.5 text-sm bg-slate-700 hover:bg-slate-600 disabled:opacity-50 text-white rounded transition-colors"
+          >
+            {submitting ? 'Testing…' : 'Run test'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function Repos() {
   const [tab, setTab] = useState<Tab>('active')
   const [activeRepos, setActiveRepos] = useState<ActiveRepo[]>([])
   const [rules, setRules] = useState<Rule[]>([])
   const [loadedTab, setLoadedTab] = useState<Tab | null>(null)
   const [showAddRule, setShowAddRule] = useState(false)
+  const [showTestRule, setShowTestRule] = useState(false)
   const [providers, setProviders] = useState<Provider[]>([])
 
   useEffect(() => {
@@ -433,6 +645,7 @@ export function Repos() {
           onCreated={(rule) => setRules((prev) => [...prev, rule])}
         />
       )}
+      {showTestRule && <TestRuleModal onClose={() => setShowTestRule(false)} />}
 
       <div className="flex items-baseline gap-3">
         <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-200">Repositories</h2>
@@ -456,12 +669,20 @@ export function Repos() {
           ))}
         </div>
         {tab === 'rules' && (
-          <button
-            onClick={() => setShowAddRule(true)}
-            className="mb-px px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-500 text-white rounded transition-colors"
-          >
-            + Add rule
-          </button>
+          <div className="flex gap-2 mb-px">
+            <button
+              onClick={() => setShowTestRule(true)}
+              className="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 dark:border-slate-600 dark:text-gray-300 dark:hover:bg-gray-700 transition-colors"
+            >
+              Test a rule
+            </button>
+            <button
+              onClick={() => setShowAddRule(true)}
+              className="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-500 text-white rounded transition-colors"
+            >
+              + Add rule
+            </button>
+          </div>
         )}
       </div>
 

--- a/fogwall-dashboard/frontend/src/pages/UserDetail.tsx
+++ b/fogwall-dashboard/frontend/src/pages/UserDetail.tsx
@@ -14,7 +14,9 @@ import {
   removeUserEmail,
   removeUserIdentity,
   resetUserPassword,
+  testUserPermission,
 } from '../api'
+import type { PermissionTestResponse } from '../api'
 import { OperationsBadge, PathTypeBadge } from '../components/PermissionBadges'
 import { StatusBadge } from '../components/StatusBadge'
 import type {
@@ -731,11 +733,147 @@ function AddPermissionModal({
   )
 }
 
+function TestPermissionModal({ username, onClose }: { username: string; onClose: () => void }) {
+  const [providers, setProviders] = useState<Provider[]>([])
+  const [provider, setProvider] = useState('')
+  const [path, setPath] = useState('')
+  const [grant, setGrant] = useState<RepoPermission['grant']>('PUSH')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<PermissionTestResponse | null>(null)
+
+  useEffect(() => {
+    fetchProviders()
+      .then((list: Provider[]) => {
+        setProviders(list)
+        if (list.length > 0) setProvider(list[0].id)
+      })
+      .catch(console.error)
+  }, [])
+
+  async function handleTest() {
+    if (!provider || !path.trim()) {
+      setError('Provider and path are required')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    setResult(null)
+    try {
+      const res = await testUserPermission(username, { provider, path: path.trim(), grant })
+      setResult(res)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Permission test failed')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function handleReset() {
+    setPath('')
+    setGrant('PUSH')
+    setError(null)
+    setResult(null)
+  }
+
+  return (
+    <div className={modalClass}>
+      <div className={modalPanelClass}>
+        <h3 className={modalTitleClass}>Test Permission</h3>
+        <p className="text-xs text-gray-400 mb-3 dark:text-gray-500">
+          Read-only evaluation of whether <span className="font-mono">{username}</span> has this
+          grant, and whether it comes from a direct permission or an inherited group rule.
+        </p>
+        <div className="space-y-3">
+          <div>
+            <label className={labelClass}>Provider</label>
+            <select
+              value={provider}
+              onChange={(e) => setProvider(e.target.value)}
+              disabled={providers.length === 0}
+              className={`${inputClass} disabled:opacity-50`}
+            >
+              {providers.length === 0 && <option value="">Loading…</option>}
+              {providers.map((p) => (
+                <option key={p.name} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className={labelClass}>Path</label>
+            <input
+              value={path}
+              onChange={(e) => setPath(e.target.value)}
+              placeholder="/owner/repo"
+              className={`${inputClass} font-mono`}
+            />
+          </div>
+          <div>
+            <label className={labelClass}>Grant</label>
+            <select
+              value={grant}
+              onChange={(e) => setGrant(e.target.value as typeof grant)}
+              className={inputClass}
+            >
+              <option value="PUSH">Push</option>
+              <option value="REVIEW">Review</option>
+            </select>
+          </div>
+        </div>
+
+        {error && <p className="mt-3 text-xs text-red-500 dark:text-red-400">{error}</p>}
+
+        {result && (
+          <div
+            className={`mt-3 rounded border px-3 py-2 text-sm ${
+              result.allowed
+                ? 'border-green-300 bg-green-50 text-green-800 dark:border-green-700 dark:bg-green-900/30 dark:text-green-300'
+                : 'border-red-300 bg-red-50 text-red-800 dark:border-red-700 dark:bg-red-900/30 dark:text-red-300'
+            }`}
+          >
+            <div className="font-medium">{result.allowed ? 'ALLOWED' : 'DENIED'}</div>
+            {result.allowed && result.source === 'DIRECT' && (
+              <div className="mt-1 text-xs opacity-80">
+                Granted by direct permission {result.entryId?.slice(0, 8)}
+              </div>
+            )}
+            {result.allowed && result.source === 'GROUP' && (
+              <div className="mt-1 text-xs opacity-80">
+                Granted via group membership: {result.groupName}
+              </div>
+            )}
+            {!result.allowed && (
+              <div className="mt-1 text-xs opacity-80">
+                No direct or group permission grants this user access.
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 mt-4">
+          <button type="button" onClick={onClose} className={cancelBtnClass}>
+            Close
+          </button>
+          <button type="button" onClick={handleReset} className={cancelBtnClass}>
+            Reset
+          </button>
+          <button onClick={handleTest} disabled={submitting} className={submitBtnClass}>
+            {submitting ? 'Testing…' : 'Run test'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function PermissionsTab({ username, isAdmin }: { username: string; isAdmin: boolean }) {
   const [permissions, setPermissions] = useState<RepoPermission[]>([])
   const [groups, setGroups] = useState<UserGroupView[]>([])
   const [loading, setLoading] = useState(true)
   const [showAdd, setShowAdd] = useState(false)
+  const [showTest, setShowTest] = useState(false)
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
 
@@ -779,6 +917,7 @@ function PermissionsTab({ username, isAdmin }: { username: string; isAdmin: bool
           onAdded={loadPermissions}
         />
       )}
+      {showTest && <TestPermissionModal username={username} onClose={() => setShowTest(false)} />}
 
       {permissions.length === 0 ? (
         <p className="text-sm text-gray-400 italic py-4 dark:text-gray-500">
@@ -847,12 +986,20 @@ function PermissionsTab({ username, isAdmin }: { username: string; isAdmin: bool
       {actionError && <p className="text-xs text-red-500 dark:text-red-400">{actionError}</p>}
 
       {isAdmin && (
-        <button
-          onClick={() => setShowAdd(true)}
-          className="px-3 py-1.5 rounded bg-slate-700 text-white text-xs hover:bg-slate-800"
-        >
-          + Add Permission
-        </button>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setShowAdd(true)}
+            className="px-3 py-1.5 rounded bg-slate-700 text-white text-xs hover:bg-slate-800"
+          >
+            + Add Permission
+          </button>
+          <button
+            onClick={() => setShowTest(true)}
+            className="px-3 py-1.5 rounded border border-gray-300 text-xs text-gray-600 hover:bg-gray-50 dark:border-slate-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            Test Permission
+          </button>
+        </div>
       )}
 
       {/* group memberships */}

--- a/fogwall-dashboard/frontend/tests/rule-test.spec.ts
+++ b/fogwall-dashboard/frontend/tests/rule-test.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test'
+
+test('test a rule reports ALLOW and DENY for two newly added rules', async ({ page }) => {
+  const suffix = Date.now()
+  const allowOwner = `pw-allow-${suffix}`
+  const denyOwner = `pw-deny-${suffix}`
+
+  await page.goto('/dashboard/repos')
+  await page.getByRole('button', { name: 'Rules', exact: true }).click()
+
+  // Add an ALLOW rule matching allowOwner
+  await page.getByRole('button', { name: '+ Add rule' }).click()
+  let modal = page.locator('.fixed.inset-0')
+  await expect(modal.getByRole('heading', { name: 'Add Rule' })).toBeVisible()
+  await modal.getByRole('combobox').first().selectOption('owner')
+  await modal.getByPlaceholder('myorg-*').fill(allowOwner)
+  await modal.getByRole('button', { name: 'Add ALLOW rule' }).click()
+  await expect(page.getByText(allowOwner)).toBeVisible()
+
+  // Add a DENY rule matching denyOwner
+  await page.getByRole('button', { name: '+ Add rule' }).click()
+  modal = page.locator('.fixed.inset-0')
+  await expect(modal.getByRole('heading', { name: 'Add Rule' })).toBeVisible()
+  await modal.getByText('DENY', { exact: true }).click()
+  await modal.getByRole('combobox').first().selectOption('owner')
+  await modal.getByPlaceholder('myorg-*').fill(denyOwner)
+  await modal.getByRole('button', { name: 'Add DENY rule' }).click()
+  await expect(page.getByText(denyOwner)).toBeVisible()
+
+  // Open the rule test panel and confirm the allow path matches
+  await page.getByRole('button', { name: 'Test a rule' }).click()
+  modal = page.locator('.fixed.inset-0')
+  await expect(modal.getByRole('heading', { name: 'Test a rule' })).toBeVisible()
+  await modal.getByPlaceholder('myorg').fill(allowOwner)
+  await modal.getByPlaceholder('myrepo').fill('some-repo')
+  await modal.getByRole('button', { name: 'Run test' }).click()
+  await expect(modal.getByText('ALLOW', { exact: true }).first()).toBeVisible()
+
+  // Reset and confirm the deny path matches
+  await modal.getByRole('button', { name: 'Reset' }).click()
+  await modal.getByPlaceholder('myorg').fill(denyOwner)
+  await modal.getByPlaceholder('myrepo').fill('some-repo')
+  await modal.getByRole('button', { name: 'Run test' }).click()
+  await expect(modal.getByText('DENY', { exact: true }).first()).toBeVisible()
+
+  await modal.getByRole('button', { name: 'Close' }).click()
+})

--- a/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/PermissionController.java
+++ b/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/PermissionController.java
@@ -144,7 +144,60 @@ public class PermissionController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(
+            operationId = "testUserPermission",
+            summary = "Test whether a user has a permission grant for a path",
+            description =
+                    "Read-only evaluation. Returns whether the grant is allowed and, if so, whether it came from a "
+                            + "direct per-user permission or an inherited group rule.")
+    @PostMapping("/test")
+    public ResponseEntity<?> test(@PathVariable String username, @RequestBody PermissionTestRequest req) {
+        if (userStore.findByUsername(username).isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        if (req.provider() == null || req.provider().isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "provider is required"));
+        }
+        if (req.path() == null || req.path().isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "path is required"));
+        }
+
+        RepoPermission.Grant grant;
+        try {
+            grant = req.grant() != null
+                    ? RepoPermission.Grant.valueOf(req.grant().toUpperCase())
+                    : RepoPermission.Grant.PUSH;
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "invalid grant: " + req.grant()));
+        }
+
+        var result = permissionService.evaluateGrant(
+                username, req.provider().trim(), req.path().trim(), grant);
+        PermissionTestResponse response =
+                switch (result) {
+                    case RepoPermissionService.GrantResult.GrantedDirect d ->
+                        new PermissionTestResponse(
+                                true, "DIRECT", d.permission().getId(), null);
+                    case RepoPermissionService.GrantResult.GrantedByGroup g -> {
+                        String groupId = g.rule().getGroupId();
+                        String groupName = permissionService
+                                .getGroupStore()
+                                .findGroupById(groupId)
+                                .map(gr -> gr.getName())
+                                .orElse(groupId);
+                        yield new PermissionTestResponse(true, "GROUP", g.rule().getId(), groupName);
+                    }
+                    case RepoPermissionService.GrantResult.NotGranted n ->
+                        new PermissionTestResponse(false, "NONE", null, null);
+                };
+        return ResponseEntity.ok(response);
+    }
+
     public record AddPermissionRequest(String provider, String target, String value, String matchType, String grant) {}
 
     public record UserGroupView(String id, String name, String description, String source, List<?> rules) {}
+
+    public record PermissionTestRequest(String provider, String path, String grant) {}
+
+    public record PermissionTestResponse(boolean allowed, String source, String entryId, String groupName) {}
 }

--- a/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/RepoController.java
+++ b/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/RepoController.java
@@ -6,7 +6,10 @@ import com.rbc.fogwall.db.PushStore;
 import com.rbc.fogwall.db.PushStore.RepoPushSummary;
 import com.rbc.fogwall.db.UrlRuleRegistry;
 import com.rbc.fogwall.db.model.AccessRule;
+import com.rbc.fogwall.git.HttpOperation;
+import com.rbc.fogwall.provider.FogwallProvider;
 import com.rbc.fogwall.provider.ProviderRegistry;
+import com.rbc.fogwall.servlet.filter.UrlRuleEvaluator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
@@ -88,6 +91,65 @@ public class RepoController {
         return ResponseEntity.ok(rule);
     }
 
+    @Operation(
+            operationId = "testRules",
+            summary = "Test which access control rule matches a repository reference",
+            description =
+                    "Read-only evaluation against the live ruleset. Returns the full ordered trail of enabled rules "
+                            + "considered, which one (if any) matched first, and the resulting decision.")
+    @PostMapping("/rules/test")
+    public ResponseEntity<?> testRules(@RequestBody RuleTestRequest req) {
+        if (req.provider() == null || req.provider().isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "provider is required"));
+        }
+        if (req.owner() == null
+                || req.owner().isBlank()
+                || req.name() == null
+                || req.name().isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "owner and name are required"));
+        }
+        ResponseEntity<?> err = validateProviderId(req.provider());
+        if (err != null) return err;
+
+        HttpOperation operation;
+        try {
+            operation = req.operation() != null
+                    ? HttpOperation.valueOf(req.operation().toUpperCase())
+                    : HttpOperation.PUSH;
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "invalid operation: " + req.operation()));
+        }
+
+        FogwallProvider provider = providerSource.getProvider(req.provider()).orElseThrow();
+        UrlRuleEvaluator evaluator = new UrlRuleEvaluator(urlRuleRegistry, provider);
+        String slug = req.owner() + "/" + req.name();
+        UrlRuleEvaluator.Trail trail = evaluator.evaluateTrail(slug, req.owner(), req.name(), operation);
+
+        List<RuleTestStep> steps = trail.steps().stream()
+                .map(s -> new RuleTestStep(
+                        s.rule().getId(),
+                        s.rule().getRuleOrder(),
+                        s.rule().getAccess().name(),
+                        s.rule().getDescription(),
+                        s.matched()))
+                .toList();
+
+        String decision =
+                switch (trail.result()) {
+                    case UrlRuleEvaluator.Result.Allowed a -> "ALLOW";
+                    case UrlRuleEvaluator.Result.Denied d -> "DENY";
+                    case UrlRuleEvaluator.Result.NotAllowed n -> "NOT_ALLOWED";
+                };
+        String matchedRuleId =
+                switch (trail.result()) {
+                    case UrlRuleEvaluator.Result.Allowed a -> a.ruleId();
+                    case UrlRuleEvaluator.Result.Denied d -> d.ruleId();
+                    case UrlRuleEvaluator.Result.NotAllowed n -> null;
+                };
+
+        return ResponseEntity.ok(new RuleTestResponse(decision, matchedRuleId, steps));
+    }
+
     /**
      * Returns a 400 response if {@code providerId} is not a configured provider name, or {@code null} if it is valid.
      */
@@ -167,4 +229,10 @@ public class RepoController {
                                 .reversed())
                         .collect(Collectors.toList());
     }
+
+    public record RuleTestRequest(String provider, String owner, String name, String operation) {}
+
+    public record RuleTestStep(String ruleId, int order, String access, String description, boolean matched) {}
+
+    public record RuleTestResponse(String decision, String matchedRuleId, List<RuleTestStep> steps) {}
 }

--- a/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/PermissionControllerTest.java
+++ b/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/PermissionControllerTest.java
@@ -2,12 +2,14 @@ package com.rbc.fogwall.dashboard.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.rbc.fogwall.db.model.MatchTarget;
 import com.rbc.fogwall.db.model.MatchType;
+import com.rbc.fogwall.permission.GroupPermissionRule;
 import com.rbc.fogwall.permission.GroupPermissionStore;
 import com.rbc.fogwall.permission.PermissionGroup;
 import com.rbc.fogwall.permission.RepoPermission;
@@ -294,5 +296,118 @@ class PermissionControllerTest {
         var resp = controller.listGroups("alice");
 
         assertEquals(HttpStatus.OK, resp.getStatusCode());
+    }
+
+    // ── POST /api/users/{username}/permissions/test ──────────────────────────────
+
+    private static PermissionController.PermissionTestRequest testReq(String provider, String path, String grant) {
+        return new PermissionController.PermissionTestRequest(provider, path, grant);
+    }
+
+    @Test
+    void test_unknownUser_returns404() {
+        when(userStore.findByUsername("nobody")).thenReturn(Optional.empty());
+
+        var resp = controller.test("nobody", testReq("github", "/acme/repo", null));
+
+        assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
+    }
+
+    @Test
+    void test_missingProvider_returns400() {
+        when(userStore.findByUsername("alice")).thenReturn(Optional.of(ALICE));
+
+        var resp = controller.test("alice", testReq("", "/acme/repo", null));
+
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void test_missingPath_returns400() {
+        when(userStore.findByUsername("alice")).thenReturn(Optional.of(ALICE));
+
+        var resp = controller.test("alice", testReq("github", " ", null));
+
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void test_invalidGrant_returns400() {
+        when(userStore.findByUsername("alice")).thenReturn(Optional.of(ALICE));
+
+        var resp = controller.test("alice", testReq("github", "/acme/repo", "READ"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void test_directGrant_returnsAllowedWithDirectSource() {
+        when(userStore.findByUsername("alice")).thenReturn(Optional.of(ALICE));
+        when(permissionService.evaluateGrant("alice", "github", "/acme/repo", RepoPermission.Grant.PUSH))
+                .thenReturn(new RepoPermissionService.GrantResult.GrantedDirect(DB_PERM));
+
+        var resp = controller.test("alice", testReq("github", "/acme/repo", "PUSH"));
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        var body = (PermissionController.PermissionTestResponse) resp.getBody();
+        assertEquals(true, body.allowed());
+        assertEquals("DIRECT", body.source());
+        assertEquals(DB_PERM.getId(), body.entryId());
+    }
+
+    @Test
+    void test_groupGrant_returnsAllowedWithGroupSourceAndName() {
+        var groupStore = mock(GroupPermissionStore.class);
+        var group = PermissionGroup.builder()
+                .name("devs")
+                .source(PermissionGroup.Source.DB)
+                .build();
+        var rule = GroupPermissionRule.builder()
+                .groupId(group.getId())
+                .provider("github")
+                .value("/acme/repo")
+                .matchType(MatchType.LITERAL)
+                .grant(RepoPermission.Grant.PUSH)
+                .build();
+        when(userStore.findByUsername("alice")).thenReturn(Optional.of(ALICE));
+        when(permissionService.evaluateGrant("alice", "github", "/acme/repo", RepoPermission.Grant.PUSH))
+                .thenReturn(new RepoPermissionService.GrantResult.GrantedByGroup(rule));
+        when(permissionService.getGroupStore()).thenReturn(groupStore);
+        when(groupStore.findGroupById(group.getId())).thenReturn(Optional.of(group));
+
+        var resp = controller.test("alice", testReq("github", "/acme/repo", "PUSH"));
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        var body = (PermissionController.PermissionTestResponse) resp.getBody();
+        assertEquals(true, body.allowed());
+        assertEquals("GROUP", body.source());
+        assertEquals(rule.getId(), body.entryId());
+        assertEquals("devs", body.groupName());
+    }
+
+    @Test
+    void test_notGranted_returnsDeniedWithNoneSource() {
+        when(userStore.findByUsername("alice")).thenReturn(Optional.of(ALICE));
+        when(permissionService.evaluateGrant("alice", "github", "/acme/repo", RepoPermission.Grant.PUSH))
+                .thenReturn(new RepoPermissionService.GrantResult.NotGranted());
+
+        var resp = controller.test("alice", testReq("github", "/acme/repo", "PUSH"));
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        var body = (PermissionController.PermissionTestResponse) resp.getBody();
+        assertEquals(false, body.allowed());
+        assertEquals("NONE", body.source());
+    }
+
+    @Test
+    void test_defaultGrant_isPush() {
+        when(userStore.findByUsername("alice")).thenReturn(Optional.of(ALICE));
+        when(permissionService.evaluateGrant("alice", "github", "/acme/repo", RepoPermission.Grant.PUSH))
+                .thenReturn(new RepoPermissionService.GrantResult.NotGranted());
+
+        var resp = controller.test("alice", testReq("github", "/acme/repo", null));
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        verify(permissionService).evaluateGrant("alice", "github", "/acme/repo", RepoPermission.Grant.PUSH);
     }
 }

--- a/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/RepoControllerTest.java
+++ b/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/RepoControllerTest.java
@@ -11,6 +11,8 @@ import com.rbc.fogwall.db.PushStore;
 import com.rbc.fogwall.db.PushStore.RepoPushSummary;
 import com.rbc.fogwall.db.UrlRuleRegistry;
 import com.rbc.fogwall.db.model.AccessRule;
+import com.rbc.fogwall.db.model.MatchTarget;
+import com.rbc.fogwall.db.model.MatchType;
 import com.rbc.fogwall.provider.FogwallProvider;
 import com.rbc.fogwall.provider.ProviderRegistry;
 import java.util.List;
@@ -150,6 +152,99 @@ class RepoControllerTest {
         when(urlRuleRegistry.findById("missing")).thenReturn(Optional.empty());
 
         assertEquals(HttpStatus.NOT_FOUND, controller.deleteRule("missing").getStatusCode());
+    }
+
+    // ── POST /api/repos/rules/test ────────────────────────────────────────────────
+
+    @Test
+    void testRules_missingProvider_returns400() {
+        var resp = controller.testRules(new RepoController.RuleTestRequest("", "acme", "repo", "PUSH"));
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void testRules_missingOwnerOrName_returns400() {
+        var resp = controller.testRules(new RepoController.RuleTestRequest("github", "", "repo", "PUSH"));
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void testRules_unknownProvider_returns400() {
+        var p = mock(FogwallProvider.class);
+        when(p.getProviderId()).thenReturn("github");
+        when(providerSource.getProviders()).thenReturn(List.of(p));
+
+        var resp = controller.testRules(new RepoController.RuleTestRequest("nonexistent", "acme", "repo", "PUSH"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void testRules_invalidOperation_returns400() {
+        var p = mock(FogwallProvider.class);
+        when(p.getProviderId()).thenReturn("github");
+        when(providerSource.getProviders()).thenReturn(List.of(p));
+
+        var resp = controller.testRules(new RepoController.RuleTestRequest("github", "acme", "repo", "MERGE"));
+
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void testRules_allowMatch_returnsAllowDecisionWithTrail() {
+        var p = mock(FogwallProvider.class);
+        when(p.getProviderId()).thenReturn("github");
+        when(providerSource.getProviders()).thenReturn(List.of(p));
+        when(providerSource.getProvider("github")).thenReturn(Optional.of(p));
+
+        var rule = AccessRule.builder()
+                .ruleOrder(100)
+                .provider("github")
+                .access(AccessRule.Access.ALLOW)
+                .operation(AccessRule.Operation.BOTH)
+                .target(MatchTarget.OWNER)
+                .value("acme")
+                .matchType(MatchType.GLOB)
+                .build();
+        when(urlRuleRegistry.findEnabledForProvider("github")).thenReturn(List.of(rule));
+
+        var resp = controller.testRules(new RepoController.RuleTestRequest("github", "acme", "repo", "PUSH"));
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        var body = (RepoController.RuleTestResponse) resp.getBody();
+        assertEquals("ALLOW", body.decision());
+        assertEquals(rule.getId(), body.matchedRuleId());
+        assertEquals(1, body.steps().size());
+        assertEquals(true, body.steps().get(0).matched());
+    }
+
+    @Test
+    void testRules_noMatch_returnsNotAllowed() {
+        var p = mock(FogwallProvider.class);
+        when(p.getProviderId()).thenReturn("github");
+        when(providerSource.getProviders()).thenReturn(List.of(p));
+        when(providerSource.getProvider("github")).thenReturn(Optional.of(p));
+        when(urlRuleRegistry.findEnabledForProvider("github")).thenReturn(List.of());
+
+        var resp = controller.testRules(new RepoController.RuleTestRequest("github", "acme", "repo", "PUSH"));
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        var body = (RepoController.RuleTestResponse) resp.getBody();
+        assertEquals("NOT_ALLOWED", body.decision());
+        assertEquals(null, body.matchedRuleId());
+    }
+
+    @Test
+    void testRules_defaultsOperationToPush() {
+        var p = mock(FogwallProvider.class);
+        when(p.getProviderId()).thenReturn("github");
+        when(providerSource.getProviders()).thenReturn(List.of(p));
+        when(providerSource.getProvider("github")).thenReturn(Optional.of(p));
+        when(urlRuleRegistry.findEnabledForProvider("github")).thenReturn(List.of());
+
+        var resp = controller.testRules(new RepoController.RuleTestRequest("github", "acme", "repo", null));
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
     }
 
     // ── GET /api/repos/active ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `POST /api/repos/rules/test` — evaluates a provider/owner/name/operation against the live URL ruleset and returns the full ordered evaluation trail plus the resulting decision (ALLOW/DENY/NOT_ALLOWED)
- Adds `POST /api/users/{username}/permissions/test` — evaluates whether a user has a given grant for a provider/path, and reports whether it came from a direct permission or an inherited group rule
- Dashboard panels: "Test a rule" under Repos > Rules tab, "Test Permission" under a user's Permissions tab (admin only)
- Lets an admin distinguish a fogwall denial from an upstream provider rejection (e.g. bad PAT) when a dev's push fails, without reading logs

## Changes

**Core (`fogwall-core`)**
- `UrlRuleEvaluator.evaluateTrail()` — records match/no-match per rule across the full ordered ruleset, alongside the existing first-match `evaluate()`
- `RepoPermissionService.evaluateGrant()` — reports which entry (direct permission or group rule) granted access; `isAllowed()` refactored to share the same logic

**Dashboard (`fogwall-dashboard`)**
- `RepoController.testRules()` — validates provider, builds a per-request `UrlRuleEvaluator`, returns the trail
- `PermissionController.test()` — validates provider/path/grant, returns allowed/source/entry

**Tests**
- `UrlRuleEvaluatorTest` — 4 new tests for `evaluateTrail`
- `GroupPermissionServiceTest` — 5 new tests for `evaluateGrant`
- `RepoControllerTest` / `PermissionControllerTest` — controller-level coverage for both new endpoints
- `rule-test.spec.ts` (new Playwright e2e) — adds an ALLOW and a DENY rule, runs the test panel against both, asserts the UI renders the correct decision

## Test plan

- [ ] Create an ALLOW rule and a DENY rule for two different owners; use "Test a rule" to confirm each returns the expected decision and trail
- [ ] Grant a user a direct PUSH permission; use "Test Permission" to confirm it reports `DIRECT` with the permission id
- [ ] Add the user to a group with a PUSH rule instead; confirm "Test Permission" reports `GROUP` with the group name
- [ ] Test a path/grant with no matching permission; confirm it reports denied with no source

closes #226