### PR TITLE
chore: make 'order' optional in access rules, default to YAML array position

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -850,6 +850,11 @@ for a request to proceed.
 Rules use a unified `match` block that specifies what to match against (`target`), the pattern string (`value`), and how
 to interpret it (`type`). Evaluation is first-match-wins by `order` — identical to iptables/firewall rule semantics.
 
+`order` is optional for YAML-configured rules. When omitted, it's inferred from the entry's position within its
+`allow[]`/`deny[]` array — the first entry gets `0`, the second `100`, and so on, leaving gaps for later insertion. An
+explicit `order` always takes precedence over the inferred position. Rules created via the dashboard or REST API have no
+array position to infer from, so they use a fixed default (`100`) unless an explicit `order` is set.
+
 ```yaml
 rules:
   allow:
@@ -899,16 +904,16 @@ rules:
 
 ### URL rule properties
 
-| Property       | Type    | Default | Description                                                         |
-| -------------- | ------- | ------- | ------------------------------------------------------------------- |
-| `enabled`      | boolean | `true`  | Whether this entry is active                                        |
-| `order`        | int     | `1100`  | Evaluation order (lower = earlier; first match wins)                |
-| `operation`    | string  | `BOTH`  | `FETCH`, `PUSH`, or `BOTH` — which git operation this entry matches |
-| `provider`     | string  | _(all)_ | Provider name to scope this entry to; omit or leave blank for all   |
-| `match`        | object  | —       | Repository match criteria — see below                               |
-| `match.target` | enum    | `SLUG`  | What to match: `SLUG` (`/owner/repo`), `OWNER`, or `NAME`           |
-| `match.value`  | string  | —       | The pattern to match against the chosen target                      |
-| `match.type`   | enum    | `GLOB`  | How to interpret the pattern: `LITERAL`, `GLOB`, or `REGEX`         |
+| Property       | Type    | Default      | Description                                                                |
+| -------------- | ------- | ------------ | -------------------------------------------------------------------------- |
+| `enabled`      | boolean | `true`       | Whether this entry is active                                               |
+| `order`        | int     | _(position)_ | Evaluation order (lower = earlier; first match wins). Optional — see below |
+| `operation`    | string  | `BOTH`       | `FETCH`, `PUSH`, or `BOTH` — which git operation this entry matches        |
+| `provider`     | string  | _(all)_      | Provider name to scope this entry to; omit or leave blank for all          |
+| `match`        | object  | —            | Repository match criteria — see below                                      |
+| `match.target` | enum    | `SLUG`       | What to match: `SLUG` (`/owner/repo`), `OWNER`, or `NAME`                  |
+| `match.value`  | string  | —            | The pattern to match against the chosen target                             |
+| `match.type`   | enum    | `GLOB`       | How to interpret the pattern: `LITERAL`, `GLOB`, or `REGEX`                |
 
 ### Pattern matching
 

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
@@ -653,12 +653,14 @@ public class JettyConfigurationBuilder {
     }
 
     private void appendAccessRules(List<AccessRule> result, List<RuleConfig> rules, AccessRule.Access access) {
+        int position = 0;
         for (RuleConfig rule : rules) {
             if (!rule.isEnabled()) continue;
+            int resolvedOrder = rule.getOrder() != null ? rule.getOrder() : position * 100;
+            position++;
             AccessRule.Operation ops = toOperations(rule.getOperation());
             String rawProvider = rule.getProvider().isBlank() ? null : rule.getProvider();
-            String resolvedId =
-                    resolveProviderName(access.name() + " rule (order=" + rule.getOrder() + ")", rawProvider);
+            String resolvedId = resolveProviderName(access.name() + " rule (order=" + resolvedOrder + ")", rawProvider);
             MatchConfig m = rule.getMatch();
             result.add(AccessRule.builder()
                     .provider(resolvedId)
@@ -668,7 +670,7 @@ public class JettyConfigurationBuilder {
                     .access(access)
                     .operation(ops)
                     .source(AccessRule.Source.CONFIG)
-                    .ruleOrder(rule.getOrder())
+                    .ruleOrder(resolvedOrder)
                     .build());
         }
     }

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/RuleConfig.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/RuleConfig.java
@@ -7,7 +7,13 @@ import lombok.Data;
 public class RuleConfig {
 
     private boolean enabled = true;
-    private int order = 1100;
+
+    /**
+     * Explicit evaluation order. Optional — when omitted, order is inferred from this entry's position within its
+     * {@code allow[]}/{@code deny[]} array (0, 100, 200, ... leaving gaps for later insertion). When set, the explicit
+     * value always takes precedence over the inferred position.
+     */
+    private Integer order;
 
     /** Git operation this entry matches: {@code FETCH}, {@code PUSH}, or {@code BOTH} (default). */
     private String operation = "BOTH";

--- a/fogwall-server/src/test/java/com/rbc/fogwall/jetty/config/JettyConfigurationBuilderTest.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/jetty/config/JettyConfigurationBuilderTest.java
@@ -245,6 +245,51 @@ class JettyConfigurationBuilderTest {
         assertEquals(MatchType.GLOB, rules.get(0).getMatchType());
     }
 
+    // ---- buildConfigRules — order optional, inferred from array position ----
+
+    @Test
+    void buildConfigRules_omittedOrder_infersFromArrayPosition() {
+        var config = configWithGithub();
+        config.getRules()
+                .setAllow(List.of(
+                        slugRuleNoOrder("github", "/org/repo-a"),
+                        slugRuleNoOrder("github", "/org/repo-b"),
+                        slugRuleNoOrder("github", "/org/repo-c")));
+
+        List<AccessRule> rules = new JettyConfigurationBuilder(config).buildConfigRules(config);
+
+        assertEquals(3, rules.size());
+        assertEquals(0, rules.get(0).getRuleOrder());
+        assertEquals(100, rules.get(1).getRuleOrder());
+        assertEquals(200, rules.get(2).getRuleOrder());
+    }
+
+    @Test
+    void buildConfigRules_explicitOrder_takesPrecedenceOverPosition() {
+        var config = configWithGithub();
+        var rule = slugRuleNoOrder("github", "/org/repo");
+        rule.setOrder(5000);
+        config.getRules().setAllow(List.of(rule));
+
+        List<AccessRule> rules = new JettyConfigurationBuilder(config).buildConfigRules(config);
+
+        assertEquals(5000, rules.get(0).getRuleOrder());
+    }
+
+    @Test
+    void buildConfigRules_omittedOrder_disabledRulesDoNotConsumePosition() {
+        var config = configWithGithub();
+        var disabled = slugRuleNoOrder("github", "/org/repo-disabled");
+        disabled.setEnabled(false);
+        var enabled = slugRuleNoOrder("github", "/org/repo-enabled");
+        config.getRules().setAllow(List.of(disabled, enabled));
+
+        List<AccessRule> rules = new JettyConfigurationBuilder(config).buildConfigRules(config);
+
+        assertEquals(1, rules.size());
+        assertEquals(0, rules.get(0).getRuleOrder());
+    }
+
     // ---- provider type inference from config key ----
 
     @Test
@@ -372,9 +417,14 @@ class JettyConfigurationBuilderTest {
     }
 
     private static RuleConfig slugRule(String provider, String value, int order) {
+        var rule = slugRuleNoOrder(provider, value);
+        rule.setOrder(order);
+        return rule;
+    }
+
+    private static RuleConfig slugRuleNoOrder(String provider, String value) {
         var rule = new RuleConfig();
         rule.setProvider(provider);
-        rule.setOrder(order);
         var m = new MatchConfig();
         m.setTarget("SLUG");
         m.setValue(value);


### PR DESCRIPTION
## Summary
- `RuleConfig.order` is now optional (`Integer`, nullable) instead of a primitive `int` requiring an explicit value
- When omitted, `appendAccessRules` infers order from the entry's position within its `allow[]`/`deny[]` array — 0, 100, 200, ... leaving gaps for later insertion
- An explicit `order` still takes precedence over the inferred position
- Disabled rules don't consume a position slot
- DB-sourced rules (dashboard/REST API) are unaffected — no array position to infer from, unchanged default behavior
- Updated `docs/CONFIGURATION.md` to document the optional field and inference rule

closes #346

## Test plan
- [x] `JettyConfigurationBuilderTest`: added tests for position inference, explicit-order precedence, and disabled rules not consuming a position
- [x] `./gradlew :fogwall-server:build --rerun` — jacoco coverage floors pass