### PR TITLE
feat: configurable open-access mode for IdP auth when role mappings are not enforced

### DIFF
--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -82,7 +82,9 @@ be edited from the profile UI, since the directory is the source of truth. Roles
 (LDAP group CNs → role names). When `role-mappings` is configured, a user who does not match any mapped group is
 **denied access entirely** — they authenticate successfully against the directory but are refused by the proxy. This is
 intentional: the proxy is not open to all directory users by default. To grant baseline access, map a broad group (e.g.
-all-staff) to `USER`.
+all-staff) to `USER`, or set `auth.require-role-mapping: false` to treat the directory purely as an authentication
+mechanism and grant `ROLE_USER` to anyone who authenticates. See
+[CONFIGURATION.md — Role mappings](CONFIGURATION.md#role-mappings).
 
 SCM identities and permissions still need to be set up after first login — either by the user themselves from their
 profile page, by an admin via the dashboard, or via a supplemental `users:` YAML entry (which can carry `scm-identities`

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -529,12 +529,30 @@ auth:
 ### Role mappings
 
 `auth.role-mappings` applies to LDAP, AD, and OIDC. Keys are role names (without the `ROLE_` prefix); values are lists
-of group names or claim values from the IdP. `ROLE_USER` is always granted to every authenticated user.
+of group names or claim values from the IdP.
 
 | Role    | Dashboard access                                                               |
 | ------- | ------------------------------------------------------------------------------ |
 | `USER`  | View and act on pushes awaiting approval                                       |
 | `ADMIN` | All USER permissions + create/delete users, reset passwords, manage identities |
+
+When `role-mappings` is empty, the operator has not configured group-based access control: `ROLE_USER` is granted to
+every authenticated user (open mode). When `role-mappings` is non-empty, access is **deny-by-default** — a user whose
+IdP groups don't match any mapping authenticates successfully against the directory/IdP but is refused access by
+fogwall.
+
+```yaml
+auth:
+  role-mappings:
+    ADMIN:
+      - git-admins
+  # Deny-by-default is the correct posture for regulated environments and is the default.
+  # Set to false to treat the IdP purely as an authentication mechanism (SSO convenience): any
+  # user who authenticates successfully is granted ROLE_USER even if no group mapping matches.
+  # role-mappings (if present) then only grant additional roles on top. No-op when role-mappings
+  # is empty, since open mode is already the behaviour in that case.
+  require-role-mapping: true
+```
 
 ## Providers
 

--- a/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/SecurityConfig.java
+++ b/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/SecurityConfig.java
@@ -177,11 +177,28 @@ public class SecurityConfig {
 
         var successHandler = idpProvisioningSuccessHandler();
         switch (provider) {
-            case "ldap" -> configureLdapAuth(http, authCfg.getLdap(), successHandler, authCfg.getRoleMappings());
-            case "ad" -> configureAdAuth(http, authCfg.getAd(), successHandler, authCfg.getRoleMappings());
+            case "ldap" ->
+                configureLdapAuth(
+                        http,
+                        authCfg.getLdap(),
+                        successHandler,
+                        authCfg.getRoleMappings(),
+                        authCfg.isRequireRoleMapping());
+            case "ad" ->
+                configureAdAuth(
+                        http,
+                        authCfg.getAd(),
+                        successHandler,
+                        authCfg.getRoleMappings(),
+                        authCfg.isRequireRoleMapping());
             case "oidc" ->
                 configureOidcAuth(
-                        http, authCfg.getOidc(), successHandler, authCfg.getRoleMappings(), authCfg.getGroupsClaim());
+                        http,
+                        authCfg.getOidc(),
+                        successHandler,
+                        authCfg.getRoleMappings(),
+                        authCfg.getGroupsClaim(),
+                        authCfg.isRequireRoleMapping());
             case "local" -> configureLocalAuth(http, successHandler);
             default ->
                 throw new IllegalStateException(
@@ -227,7 +244,8 @@ public class SecurityConfig {
             HttpSecurity http,
             LdapAuthConfig ldapCfg,
             AuthenticationSuccessHandler successHandler,
-            Map<String, List<String>> roleMappings)
+            Map<String, List<String>> roleMappings,
+            boolean requireRoleMapping)
             throws Exception {
         if (ldapCfg.getUrl().isBlank()) {
             throw new IllegalStateException("auth.provider=ldap requires auth.ldap.url to be set in fogwall.yml");
@@ -260,7 +278,8 @@ public class SecurityConfig {
             populator.setConvertToUpperCase(false);
             populator.setSearchSubtree(true);
             ldapProvider = new LdapAuthenticationProvider(authenticator, populator);
-            ldapProvider.setAuthoritiesMapper(ldapAuthorities -> mapIdpGroupsToRoles(ldapAuthorities, roleMappings));
+            ldapProvider.setAuthoritiesMapper(
+                    ldapAuthorities -> mapIdpGroupsToRoles(ldapAuthorities, roleMappings, requireRoleMapping));
             log.info(
                     "LDAP group search enabled: base={}, filter={}",
                     ldapCfg.getGroupSearchBase(),
@@ -301,7 +320,8 @@ public class SecurityConfig {
             HttpSecurity http,
             AdAuthConfig adCfg,
             AuthenticationSuccessHandler successHandler,
-            Map<String, List<String>> roleMappings)
+            Map<String, List<String>> roleMappings,
+            boolean requireRoleMapping)
             throws Exception {
         if (adCfg.getDomain().isBlank()) {
             throw new IllegalStateException("auth.provider=ad requires auth.ad.domain to be set in fogwall.yml");
@@ -329,7 +349,8 @@ public class SecurityConfig {
             populator.setConvertToUpperCase(false);
             populator.setSearchSubtree(true);
             adProvider.setAuthoritiesPopulator(populator);
-            adProvider.setAuthoritiesMapper(ldapAuthorities -> mapIdpGroupsToRoles(ldapAuthorities, roleMappings));
+            adProvider.setAuthoritiesMapper(
+                    ldapAuthorities -> mapIdpGroupsToRoles(ldapAuthorities, roleMappings, requireRoleMapping));
             log.info(
                     "AD group search enabled: base={}, filter={}",
                     adCfg.getGroupSearchBase(),
@@ -359,7 +380,8 @@ public class SecurityConfig {
             OidcAuthConfig oidcCfg,
             AuthenticationSuccessHandler successHandler,
             Map<String, List<String>> roleMappings,
-            String groupsClaim)
+            String groupsClaim,
+            boolean requireRoleMapping)
             throws Exception {
         if (oidcCfg.getIssuerUri().isBlank() || oidcCfg.getClientId().isBlank()) {
             throw new IllegalStateException(
@@ -394,8 +416,8 @@ public class SecurityConfig {
                             .authorizedClientRepository(new HttpSessionOAuth2AuthorizedClientRepository())
                             .successHandler(successHandler)
                             .failureUrl("/login.html?error")
-                            .userInfoEndpoint(userInfo -> userInfo.oidcUserService(
-                                    buildOidcUserService(roleMappings, groupsClaim, oidcCfg.isSkipUserInfo())));
+                            .userInfoEndpoint(userInfo -> userInfo.oidcUserService(buildOidcUserService(
+                                    roleMappings, groupsClaim, oidcCfg.isSkipUserInfo(), requireRoleMapping)));
 
                     if (usePrivateKeyJwt) {
                         RSAKey rsaKey =
@@ -504,11 +526,16 @@ public class SecurityConfig {
      * corresponding {@code ROLE_xxx} authority being added to the session.
      *
      * <p>If {@code roleMappings} is empty, {@code ROLE_USER} is granted to every authenticated user (open mode). If
-     * {@code roleMappings} is non-empty, access is <em>deny-by-default</em>: the user must belong to at least one
-     * mapped group, otherwise authentication is rejected.
+     * {@code roleMappings} is non-empty and {@code requireRoleMapping} is {@code true} (default), access is
+     * <em>deny-by-default</em>: the user must belong to at least one mapped group, otherwise authentication is
+     * rejected. If {@code requireRoleMapping} is {@code false}, a user matching no mapped group is still granted
+     * {@code ROLE_USER} instead of being denied.
      */
     private OidcUserService buildOidcUserService(
-            Map<String, List<String>> roleMappings, String groupsClaim, boolean skipUserInfo) {
+            Map<String, List<String>> roleMappings,
+            String groupsClaim,
+            boolean skipUserInfo,
+            boolean requireRoleMapping) {
         OidcUserService service = new OidcUserService() {
             @Override
             public OidcUser loadUser(OidcUserRequest userRequest) {
@@ -537,6 +564,14 @@ public class SecurityConfig {
                     }
                 }
                 if (authorities.isEmpty()) {
+                    if (!requireRoleMapping) {
+                        log.debug(
+                                "OIDC user '{}' matched no authorised group; granting ROLE_USER (require-role-mapping=false)",
+                                oidcUser.getName());
+                        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+                        return new DefaultOidcUser(
+                                authorities, oidcUser.getIdToken(), oidcUser.getUserInfo(), nameAttributeKey);
+                    }
                     log.warn("OIDC login denied for '{}': not a member of any authorised group", oidcUser.getName());
                     throw new OAuth2AuthenticationException(
                             new OAuth2Error("access_denied"),
@@ -560,12 +595,16 @@ public class SecurityConfig {
      * Maps IdP-supplied group authorities (from LDAP/AD group search) to fogwall roles using {@code roleMappings}.
      *
      * <p>If {@code roleMappings} is empty the operator has not configured group-based access control, so
-     * {@code ROLE_USER} is granted to every authenticated user (open mode). If {@code roleMappings} is non-empty,
-     * access is <em>deny-by-default</em>: the user must be a member of at least one mapped group, otherwise
-     * authentication is rejected with {@link BadCredentialsException}.
+     * {@code ROLE_USER} is granted to every authenticated user (open mode). If {@code roleMappings} is non-empty and
+     * {@code requireRoleMapping} is {@code true} (default), access is <em>deny-by-default</em>: the user must be a
+     * member of at least one mapped group, otherwise authentication is rejected with {@link BadCredentialsException}.
+     * If {@code requireRoleMapping} is {@code false}, a user matching no mapped group is still granted
+     * {@code ROLE_USER} instead of being denied.
      */
     private Set<GrantedAuthority> mapIdpGroupsToRoles(
-            Collection<? extends GrantedAuthority> ldapAuthorities, Map<String, List<String>> roleMappings) {
+            Collection<? extends GrantedAuthority> ldapAuthorities,
+            Map<String, List<String>> roleMappings,
+            boolean requireRoleMapping) {
         if (roleMappings.isEmpty()) {
             return Set.of(new SimpleGrantedAuthority("ROLE_USER"));
         }
@@ -581,6 +620,10 @@ public class SecurityConfig {
             }
         }
         if (mapped.isEmpty()) {
+            if (!requireRoleMapping) {
+                log.debug("IdP user matched no authorised group; granting ROLE_USER (require-role-mapping=false)");
+                return Set.of(new SimpleGrantedAuthority("ROLE_USER"));
+            }
             log.warn("IdP login denied: user is not a member of any authorised group");
             throw new BadCredentialsException(
                     "Access not granted: your account is not a member of any authorised group");

--- a/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/e2e/LdapRoleMappingE2ETest.java
+++ b/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/e2e/LdapRoleMappingE2ETest.java
@@ -136,4 +136,56 @@ class LdapRoleMappingE2ETest {
             assertNotEquals(200, meResp.statusCode(), "User not in mapped group must not access /api/me");
         }
     }
+
+    /**
+     * Verifies {@code auth.require-role-mapping: false}: a user whose LDAP groups match none of the configured mappings
+     * is still granted {@code ROLE_USER} instead of being denied.
+     */
+    @Test
+    @Order(4)
+    void userNotInMappedGroup_requireRoleMappingFalse_loginGrantsRoleUser() throws Exception {
+        var config = new FogwallConfig();
+        config.getAuth().setProvider("ldap");
+        config.getAuth().getLdap().setUrl(ldap.getLdapUrl());
+        config.getAuth().getLdap().setUserDnPatterns(OpenLdapContainer.USER_DN_PATTERN);
+        config.getAuth().getLdap().setBindDn(OpenLdapContainer.MANAGER_DN);
+        config.getAuth().getLdap().setBindPassword(OpenLdapContainer.ADMIN_PASSWORD);
+        config.getAuth().getLdap().setGroupSearchBase(OpenLdapContainer.GROUP_SEARCH_BASE);
+        // Map a group the test user is NOT a member of, but disable deny-by-default.
+        config.getAuth().setRoleMappings(Map.of("ADMIN", List.of("no-such-group")));
+        config.getAuth().setRequireRoleMapping(false);
+
+        try (var openDashboard = new DashboardFixture(config)) {
+            var openBaseUrl = openDashboard.getBaseUrl();
+            var cookieManager = new CookieManager(null, CookiePolicy.ACCEPT_ALL);
+            var openClient = HttpClient.newBuilder()
+                    .cookieHandler(cookieManager)
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+                    .build();
+
+            String formBody =
+                    "username=" + OpenLdapContainer.TEST_USER + "&password=" + OpenLdapContainer.TEST_PASSWORD;
+            openClient.send(
+                    HttpRequest.newBuilder()
+                            .uri(URI.create(openBaseUrl + "/login"))
+                            .header("Content-Type", "application/x-www-form-urlencoded")
+                            .POST(HttpRequest.BodyPublishers.ofString(formBody, StandardCharsets.UTF_8))
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+
+            var meResp = openClient.send(
+                    HttpRequest.newBuilder()
+                            .uri(URI.create(openBaseUrl + "/api/me"))
+                            .GET()
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+            assertEquals(
+                    200,
+                    meResp.statusCode(),
+                    "User not in mapped group must still log in when require-role-mapping=false");
+            assertTrue(
+                    meResp.body().contains("ROLE_USER"),
+                    "Expected ROLE_USER to be granted unconditionally; got: " + meResp.body());
+        }
+    }
 }

--- a/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/e2e/OidcRoleMappingE2ETest.java
+++ b/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/e2e/OidcRoleMappingE2ETest.java
@@ -164,7 +164,84 @@ class OidcRoleMappingE2ETest {
         assertNotEquals(200, meResp.statusCode(), "Unmapped OIDC user must not access /api/me");
     }
 
+    /**
+     * Verifies {@code auth.require-role-mapping: false}: a user whose OIDC groups claim matches none of the configured
+     * mappings is still granted a session with {@code ROLE_USER}, instead of being denied.
+     */
+    @Test
+    void userNotInMappedGroup_requireRoleMappingFalse_loginGrantsRoleUser() throws Exception {
+        var config = new FogwallConfig();
+        config.getAuth().setProvider("oidc");
+        config.getAuth().getOidc().setIssuerUri(mockOAuth2.getIssuerUri());
+        config.getAuth().getOidc().setClientId(MockOAuth2Container.CLIENT_ID);
+        config.getAuth().getOidc().setClientSecret(MockOAuth2Container.CLIENT_SECRET);
+        config.getAuth().setGroupsClaim("groups");
+        config.getAuth().setRoleMappings(Map.of("ADMIN", List.of(ADMIN_GROUP)));
+        config.getAuth().setRequireRoleMapping(false);
+
+        try (var openDashboard = new DashboardFixture(config)) {
+            String openBaseUrl = openDashboard.getBaseUrl();
+            var cookieManager = new CookieManager(null, CookiePolicy.ACCEPT_ALL);
+            var client = HttpClient.newBuilder()
+                    .cookieHandler(cookieManager)
+                    .followRedirects(HttpClient.Redirect.NEVER)
+                    .build();
+
+            var authorizePageResponse =
+                    followUntil200(client, openBaseUrl + "/oauth2/authorization/fogwall", openBaseUrl);
+            assertEquals(200, authorizePageResponse.statusCode());
+
+            // Groups claim does NOT match "ADMIN" → ["git-admins"]
+            URI authorizeUri = authorizePageResponse.uri();
+            String loginBody = "username=" + MockOAuth2Container.TEST_USER
+                    + "&claims=%7B%22groups%22%3A%5B%22unrelated-group%22%5D%7D";
+
+            var loginResp = client.send(
+                    HttpRequest.newBuilder()
+                            .uri(authorizeUri)
+                            .header("Content-Type", "application/x-www-form-urlencoded")
+                            .POST(HttpRequest.BodyPublishers.ofString(loginBody, StandardCharsets.UTF_8))
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+
+            assertEquals(302, loginResp.statusCode());
+            String callbackUrl = loginResp.headers().firstValue("Location").orElseThrow();
+
+            var callbackResp = client.send(
+                    HttpRequest.newBuilder().uri(URI.create(callbackUrl)).GET().build(),
+                    HttpResponse.BodyHandlers.ofString());
+            String callbackLocation =
+                    callbackResp.headers().firstValue("Location").orElse("(none)");
+            assertEquals(302, callbackResp.statusCode(), "Expected 302 from callback; location=" + callbackLocation);
+            assertFalse(callbackLocation.contains("error"), "Callback redirected to error: " + callbackLocation);
+
+            String successUrl = callbackLocation.startsWith("http") ? callbackLocation : openBaseUrl + callbackLocation;
+            client.send(
+                    HttpRequest.newBuilder().uri(URI.create(successUrl)).GET().build(),
+                    HttpResponse.BodyHandlers.ofString());
+
+            var meResp = client.send(
+                    HttpRequest.newBuilder()
+                            .uri(URI.create(openBaseUrl + "/api/me"))
+                            .GET()
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+            assertEquals(
+                    200,
+                    meResp.statusCode(),
+                    "User not matching any group mapping must still log in when require-role-mapping=false");
+            assertTrue(
+                    meResp.body().contains("ROLE_USER"),
+                    "Expected ROLE_USER to be granted unconditionally; got: " + meResp.body());
+        }
+    }
+
     private static HttpResponse<String> followUntil200(HttpClient client, String startUrl) throws Exception {
+        return followUntil200(client, startUrl, baseUrl);
+    }
+
+    private static HttpResponse<String> followUntil200(HttpClient client, String startUrl, String base)
+            throws Exception {
         String url = startUrl;
         for (int i = 0; i < 10; i++) {
             var resp = client.send(
@@ -173,7 +250,7 @@ class OidcRoleMappingE2ETest {
             String location = resp.headers()
                     .firstValue("Location")
                     .orElseThrow(() -> new AssertionError("3xx without Location: " + resp.uri()));
-            if (!location.startsWith("http")) location = baseUrl + location;
+            if (!location.startsWith("http")) location = base + location;
             url = location;
         }
         throw new AssertionError("Too many redirects starting from " + startUrl);

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/AuthConfig.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/AuthConfig.java
@@ -52,6 +52,17 @@ public class AuthConfig {
     private Map<String, List<String>> roleMappings = new HashMap<>();
 
     /**
+     * When {@code role-mappings} is non-empty, controls whether a user whose IdP groups match none of the mappings is
+     * denied access. Defaults to {@code true} — deny-by-default, the correct posture for regulated environments.
+     *
+     * <p>Set to {@code false} to restore open-access behaviour: any user who authenticates successfully against the IdP
+     * is granted {@code ROLE_USER} unconditionally, and {@code role-mappings} (if present) only grant additional roles
+     * on top. This is a no-op when {@code role-mappings} is empty, since open mode is already the behaviour in that
+     * case.
+     */
+    private boolean requireRoleMapping = true;
+
+    /**
      * OIDC claim name that contains the user's group memberships. Defaults to {@code groups}, which is standard for
      * Keycloak, Okta, and most Entra ID configurations. Override if your IdP uses a different claim (e.g.
      * {@code roles}, {@code memberOf}).


### PR DESCRIPTION
## Summary
- Adds `auth.require-role-mapping` (default `true`, preserving the current deny-by-default posture)
- When set to `false`, a user who authenticates successfully against the IdP (LDAP, AD, or OIDC) but matches no configured role mapping is granted `ROLE_USER` unconditionally instead of being denied — for operators who want the IdP to act purely as an SSO/authentication mechanism rather than an authorization gate. Role mappings, if present, still grant additional roles on top.
- No-op when `role-mappings` is empty, since open mode is already the behaviour in that case.
- Updated `docs/CONFIGURATION.md` (Role mappings section) and `docs/ADMIN_GUIDE.md` to document the new flag and correct a misleading claim that `ROLE_USER` is "always granted" (it wasn't, under deny-by-default).

closes #128

## Test plan
- [x] New e2e tests in `LdapRoleMappingE2ETest`/`OidcRoleMappingE2ETest` covering `require-role-mapping: false` granting `ROLE_USER` to a user matching no mapping
- [x] `./gradlew :fogwall-dashboard:e2eTest --tests "*LdapRoleMappingE2ETest*" --tests "*OidcRoleMappingE2ETest*" --rerun` — all 6 tests pass (Testcontainers LDAP + mock OIDC server)
- [x] `./gradlew build --rerun` — full build + jacoco coverage floors pass