### PR TITLE
ux: hyperlink repo and forwarded commit in push list and push record

### DIFF
--- a/fogwall-core/src/main/java/com/rbc/fogwall/db/PushStore.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/db/PushStore.java
@@ -41,6 +41,7 @@ public interface PushStore {
                         .status(r.getStatus())
                         .url(r.getUrl())
                         .upstreamUrl(r.getUpstreamUrl())
+                        .provider(r.getProvider())
                         .project(r.getProject())
                         .repoName(r.getRepoName())
                         .branch(r.getBranch())

--- a/fogwall-core/src/main/java/com/rbc/fogwall/db/jdbc/JdbcPushStore.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/db/jdbc/JdbcPushStore.java
@@ -101,7 +101,7 @@ public class JdbcPushStore implements PushStore {
         MapSqlParameterSource params = new MapSqlParameterSource();
         String where = buildWhere(query, params);
         String sql =
-                "SELECT id, status, url, upstream_url, project, repo_name, branch, commit_to, author, push_user, resolved_user, timestamp"
+                "SELECT id, status, url, upstream_url, provider, project, repo_name, branch, commit_to, author, push_user, resolved_user, timestamp"
                         + " FROM push_records" + where
                         + " ORDER BY timestamp " + (query.isNewestFirst() ? "DESC" : "ASC")
                         + " LIMIT :limit OFFSET :offset";
@@ -115,6 +115,7 @@ public class JdbcPushStore implements PushStore {
                         .status(PushStatus.valueOf(rs.getString("status")))
                         .url(rs.getString("url"))
                         .upstreamUrl(rs.getString("upstream_url"))
+                        .provider(rs.getString("provider"))
                         .project(rs.getString("project"))
                         .repoName(rs.getString("repo_name"))
                         .branch(rs.getString("branch"))

--- a/fogwall-core/src/main/java/com/rbc/fogwall/db/model/PushRecord.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/db/model/PushRecord.java
@@ -28,6 +28,18 @@ public class PushRecord {
     /** The upstream repository URL being proxied to (e.g., https://github.com/owner/repo). */
     private String upstreamUrl;
 
+    /**
+     * Browsable web URL for the repository, computed from the provider at query time — not persisted. Absent for
+     * generic providers with no stable public repo URL shape.
+     */
+    private String repoUrl;
+
+    /**
+     * Browsable web URL for {@link #commitTo}, computed from the provider at query time — not persisted. Absent for
+     * generic providers with no stable public repo URL shape.
+     */
+    private String commitUrl;
+
     /** Provider name (e.g., "github", "gitlab"). */
     private String provider;
 

--- a/fogwall-core/src/main/java/com/rbc/fogwall/db/model/PushSummary.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/db/model/PushSummary.java
@@ -9,12 +9,13 @@ import lombok.Value;
  * {@link Attestation} data to keep list-endpoint responses small.
  */
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class PushSummary {
     String id;
     PushStatus status;
     String url;
     String upstreamUrl;
+    String provider;
     String project;
     String repoName;
     String branch;
@@ -23,4 +24,12 @@ public class PushSummary {
     String user;
     String resolvedUser;
     Instant timestamp;
+
+    /** Browsable web URL for the repository, computed from the provider at query time. Absent for generic providers. */
+    String repoUrl;
+
+    /**
+     * Browsable web URL for {@link #commitTo}, computed from the provider at query time. Absent for generic providers.
+     */
+    String commitUrl;
 }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/AbstractFogwallProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/AbstractFogwallProvider.java
@@ -2,6 +2,7 @@ package com.rbc.fogwall.provider;
 
 import com.rbc.fogwall.servlet.FogwallServlet;
 import java.net.URI;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 /** An upstream Git server that will be proxied by the application. */
@@ -74,6 +75,21 @@ public abstract class AbstractFogwallProvider implements FogwallProvider {
     @Override
     public URI getUri() {
         return uri;
+    }
+
+    /**
+     * Web base URL for constructing browsable repo/commit links, present only when {@link #uri} already uses
+     * {@code http}/{@code https}. There is no reliable way to derive a working web URL from an {@code ssh://} transport
+     * URI (the SSH port has no relationship to the web frontend's scheme, host, or port), so pushes made over SSH
+     * transport get no repo/commit link at all rather than a guessed one.
+     */
+    protected Optional<String> webBaseUrl() {
+        String scheme = uri.getScheme();
+        if (!"http".equals(scheme) && !"https".equals(scheme)) {
+            return Optional.empty();
+        }
+        String s = uri.toString();
+        return Optional.of(s.endsWith("/") ? s.substring(0, s.length() - 1) : s);
     }
 
     @Override

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/BitbucketProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/BitbucketProvider.java
@@ -66,6 +66,16 @@ public class BitbucketProvider extends AbstractFogwallProvider implements HttpTo
         return String.format("%s/site/oauth2", uri);
     }
 
+    @Override
+    public Optional<String> buildRepoUrl(String owner, String repo) {
+        return webBaseUrl().map(base -> base + "/" + owner + "/" + repo);
+    }
+
+    @Override
+    public Optional<String> buildCommitUrl(String owner, String repo, String sha) {
+        return buildRepoUrl(owner, repo).map(repoUrl -> repoUrl + "/commits/" + sha);
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/FogwallProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/FogwallProvider.java
@@ -1,6 +1,7 @@
 package com.rbc.fogwall.provider;
 
 import java.net.URI;
+import java.util.Optional;
 
 public interface FogwallProvider {
 
@@ -35,5 +36,23 @@ public interface FogwallProvider {
      */
     default int getBlockedInfoRefsStatus() {
         return 403;
+    }
+
+    /**
+     * Builds a browsable web URL for the given repository on this provider's platform, e.g.
+     * {@code https://github.com/owner/repo}. Returns {@link Optional#empty()} for providers with no stable public repo
+     * URL shape (generic bare-git providers).
+     */
+    default Optional<String> buildRepoUrl(String owner, String repo) {
+        return Optional.empty();
+    }
+
+    /**
+     * Builds a browsable web URL for a specific commit within the given repository, e.g.
+     * {@code https://github.com/owner/repo/commit/<sha>}. Returns {@link Optional#empty()} for providers with no stable
+     * public repo URL shape (generic bare-git providers).
+     */
+    default Optional<String> buildCommitUrl(String owner, String repo, String sha) {
+        return Optional.empty();
     }
 }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/ForgejoProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/ForgejoProvider.java
@@ -53,6 +53,16 @@ public class ForgejoProvider extends AbstractFogwallProvider implements HttpToke
         return uri + "/api/v1";
     }
 
+    @Override
+    public Optional<String> buildRepoUrl(String owner, String repo) {
+        return webBaseUrl().map(base -> base + "/" + owner + "/" + repo);
+    }
+
+    @Override
+    public Optional<String> buildCommitUrl(String owner, String repo, String sha) {
+        return buildRepoUrl(owner, repo).map(repoUrl -> repoUrl + "/commit/" + sha);
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/GitHubProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/GitHubProvider.java
@@ -110,6 +110,16 @@ public class GitHubProvider extends AbstractFogwallProvider implements HttpToken
         }
     }
 
+    @Override
+    public Optional<String> buildRepoUrl(String owner, String repo) {
+        return webBaseUrl().map(base -> base + "/" + owner + "/" + repo);
+    }
+
+    @Override
+    public Optional<String> buildCommitUrl(String owner, String repo, String sha) {
+        return buildRepoUrl(owner, repo).map(repoUrl -> repoUrl + "/commit/" + sha);
+    }
+
     /**
      * Determines if the provider is a GitHub Enterprise Cloud with data residency. These instances have a custom domain
      * (e.g. mycompany.ghe.com) and use a different API path from GHEC or self-hosted GHES.

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/GitLabProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/GitLabProvider.java
@@ -44,6 +44,16 @@ public class GitLabProvider extends AbstractFogwallProvider implements HttpToken
         return String.format("%s/oauth", uri);
     }
 
+    @Override
+    public Optional<String> buildRepoUrl(String owner, String repo) {
+        return webBaseUrl().map(base -> base + "/" + owner + "/" + repo);
+    }
+
+    @Override
+    public Optional<String> buildCommitUrl(String owner, String repo, String sha) {
+        return buildRepoUrl(owner, repo).map(repoUrl -> repoUrl + "/-/commit/" + sha);
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/fogwall-core/src/test/java/com/rbc/fogwall/provider/ProviderTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/provider/ProviderTest.java
@@ -47,6 +47,42 @@ class ProviderTest {
         assertEquals("github", new GitHubProvider("/proxy").getName());
     }
 
+    @Test
+    void gitHub_buildRepoUrl() {
+        var p = new GitHubProvider(null);
+        assertEquals(
+                "https://github.com/acme/widgets",
+                p.buildRepoUrl("acme", "widgets").orElseThrow());
+    }
+
+    @Test
+    void gitHub_buildCommitUrl() {
+        var p = new GitHubProvider(null);
+        assertEquals(
+                "https://github.com/acme/widgets/commit/abc123",
+                p.buildCommitUrl("acme", "widgets", "abc123").orElseThrow());
+    }
+
+    @Test
+    void gitHub_sshUri_buildRepoUrl_isEmpty() {
+        // An ssh:// transport URI has no reliable relationship to the web frontend's scheme/host/port —
+        // never guess a link for SSH-forwarded pushes.
+        var p = GitHubProvider.builder()
+                .uri(URI.create("ssh://git@github.example.com:2222"))
+                .pathSuffix("/proxy")
+                .build();
+        assertTrue(p.buildRepoUrl("acme", "widgets").isEmpty());
+    }
+
+    @Test
+    void gitHub_sshUri_buildCommitUrl_isEmpty() {
+        var p = GitHubProvider.builder()
+                .uri(URI.create("ssh://git@github.example.com:2222"))
+                .pathSuffix("/proxy")
+                .build();
+        assertTrue(p.buildCommitUrl("acme", "widgets", "abc123").isEmpty());
+    }
+
     // --- GitLabProvider ---
 
     @Test
@@ -77,6 +113,22 @@ class ProviderTest {
     @Test
     void gitLab_getName() {
         assertEquals("gitlab", new GitLabProvider("/proxy").getName());
+    }
+
+    @Test
+    void gitLab_buildRepoUrl() {
+        var p = new GitLabProvider(null);
+        assertEquals(
+                "https://gitlab.com/acme/widgets",
+                p.buildRepoUrl("acme", "widgets").orElseThrow());
+    }
+
+    @Test
+    void gitLab_buildCommitUrl() {
+        var p = new GitLabProvider(null);
+        assertEquals(
+                "https://gitlab.com/acme/widgets/-/commit/abc123",
+                p.buildCommitUrl("acme", "widgets", "abc123").orElseThrow());
     }
 
     // --- BitbucketProvider ---
@@ -113,6 +165,55 @@ class ProviderTest {
         assertEquals("bitbucket", new BitbucketProvider("/proxy").getName());
     }
 
+    @Test
+    void bitbucket_buildRepoUrl() {
+        var p = new BitbucketProvider(null);
+        assertEquals(
+                "https://bitbucket.org/acme/widgets",
+                p.buildRepoUrl("acme", "widgets").orElseThrow());
+    }
+
+    @Test
+    void bitbucket_buildCommitUrl() {
+        var p = new BitbucketProvider(null);
+        assertEquals(
+                "https://bitbucket.org/acme/widgets/commits/abc123",
+                p.buildCommitUrl("acme", "widgets", "abc123").orElseThrow());
+    }
+
+    // --- ForgejoProvider ---
+
+    @Test
+    void forgejo_buildRepoUrl() {
+        var p = ForgejoProvider.builder()
+                .name("codeberg")
+                .uri(ForgejoProvider.CODEBERG)
+                .build();
+        assertEquals(
+                "https://codeberg.org/acme/widgets",
+                p.buildRepoUrl("acme", "widgets").orElseThrow());
+    }
+
+    @Test
+    void forgejo_buildCommitUrl() {
+        var p = ForgejoProvider.builder()
+                .name("codeberg")
+                .uri(ForgejoProvider.CODEBERG)
+                .build();
+        assertEquals(
+                "https://codeberg.org/acme/widgets/commit/abc123",
+                p.buildCommitUrl("acme", "widgets", "abc123").orElseThrow());
+    }
+
+    @Test
+    void forgejo_sshUri_buildRepoUrl_isEmpty() {
+        var p = ForgejoProvider.builder()
+                .name("internal-gitea")
+                .uri(URI.create("ssh://git@gitea.corp.internal:2222"))
+                .build();
+        assertTrue(p.buildRepoUrl("acme", "widgets").isEmpty());
+    }
+
     // --- GenericProxyProvider ---
 
     @Test
@@ -132,6 +233,24 @@ class ProviderTest {
                 .pathSuffix("/custom")
                 .build();
         assertEquals("/custom", p.servletPath());
+    }
+
+    @Test
+    void generic_buildRepoUrl_isEmpty() {
+        var p = GenericProxyProvider.builder()
+                .name("my-git")
+                .uri(URI.create("https://git.corp.com"))
+                .build();
+        assertTrue(p.buildRepoUrl("acme", "widgets").isEmpty());
+    }
+
+    @Test
+    void generic_buildCommitUrl_isEmpty() {
+        var p = GenericProxyProvider.builder()
+                .name("my-git")
+                .uri(URI.create("https://git.corp.com"))
+                .build();
+        assertTrue(p.buildCommitUrl("acme", "widgets", "abc123").isEmpty());
     }
 
     // --- InMemoryProviderRegistry ---

--- a/fogwall-dashboard/frontend/src/pages/PushDetail.tsx
+++ b/fogwall-dashboard/frontend/src/pages/PushDetail.tsx
@@ -106,7 +106,13 @@ function formatTime(ts: string | number | undefined) {
   }
 }
 
-function upstreamCommitUrl(upstreamUrl: string, sha: string): string {
+/**
+ * Fallback heuristic used only when the backend-computed `commitUrl` is unavailable (e.g. provider no longer
+ * resolvable). Returns undefined for anything other than an http(s) URL — upstreamUrl can be an ssh:// transport URL
+ * (SSH-forwarded pushes) and must never be rendered as a clickable link.
+ */
+function upstreamCommitUrl(upstreamUrl: string, sha: string): string | undefined {
+  if (!/^https?:\/\//.test(upstreamUrl)) return undefined
   const base = upstreamUrl.replace(/\/$/, '').replace(/\.git$/, '')
   if (/gitlab\./.test(base)) return `${base}/-/commit/${sha}`
   return `${base}/commit/${sha}`
@@ -194,9 +200,10 @@ function PushTimeline({ record }: { record: PushRecord }) {
   const forwardStep = (record.steps ?? []).find((s) => FORWARDING_STEPS.has(s.stepName))
   if (record.status === 'FORWARDED') {
     const commitLink =
-      record.upstreamUrl && record.commitTo
+      record.commitUrl ??
+      (record.upstreamUrl && record.commitTo
         ? upstreamCommitUrl(record.upstreamUrl, record.commitTo)
-        : undefined
+        : undefined)
     events.push({
       icon: '→',
       label: 'Forwarded to upstream',
@@ -635,15 +642,38 @@ export function PushDetail({ currentUser, dark = false }: PushDetailProps) {
 
               <div className="flex-1 min-w-0 space-y-0.5">
                 <div className="font-mono text-sm text-gray-900 truncate dark:text-gray-100">
-                  {record.upstreamUrl ??
+                  {record.repoUrl ??
+                    record.upstreamUrl ??
                     record.url ??
                     (record.project ?? '') + '/' + (record.repoName ?? '')}
+                  {record.repoUrl && (
+                    <a
+                      href={record.repoUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title="Open repo"
+                      className="ml-1.5 text-blue-500 no-underline hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+                    >
+                      ↗
+                    </a>
+                  )}
                 </div>
                 <div className="text-xs text-gray-500 font-mono dark:text-gray-400">
                   {record.branch}
                 </div>
                 <div className="text-xs font-mono text-gray-400 break-all dark:text-gray-500">
                   {record.commitTo}
+                  {record.commitUrl && (
+                    <a
+                      href={record.commitUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title="Open commit"
+                      className="ml-1.5 text-blue-500 no-underline hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+                    >
+                      ↗
+                    </a>
+                  )}
                 </div>
                 {record.message && (
                   <div className="text-xs text-gray-600 italic pt-0.5 dark:text-gray-400">

--- a/fogwall-dashboard/frontend/src/pages/PushList.tsx
+++ b/fogwall-dashboard/frontend/src/pages/PushList.tsx
@@ -369,15 +369,40 @@ export function PushList({ currentUser, bulkReviewEnabled = false }: PushListPro
               <StatusBadge status={push.status} />
               <div className="flex-1 min-w-0 space-y-0.5">
                 <div className="font-mono text-sm text-gray-900 truncate dark:text-gray-100">
-                  {push.upstreamUrl ??
+                  {push.repoUrl ??
+                    push.upstreamUrl ??
                     push.url ??
                     (push.project ?? '') + '/' + (push.repoName ?? 'unknown')}
+                  {push.repoUrl && (
+                    <a
+                      href={push.repoUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                      title="Open repo"
+                      className="ml-1.5 text-blue-500 no-underline hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+                    >
+                      ↗
+                    </a>
+                  )}
                 </div>
                 <div className="text-xs text-gray-500 truncate dark:text-gray-400">
                   {push.branch ?? '—'}
                 </div>
                 <div className="font-mono text-xs text-gray-400 break-all dark:text-gray-500">
                   {push.commitTo ?? '—'}
+                  {push.commitUrl && (
+                    <a
+                      href={push.commitUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                      title="Open commit"
+                      className="ml-1.5 text-blue-500 no-underline hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+                    >
+                      ↗
+                    </a>
+                  )}
                 </div>
               </div>
               <div className="text-right text-sm text-gray-500 shrink-0 dark:text-gray-400">

--- a/fogwall-dashboard/frontend/src/types.ts
+++ b/fogwall-dashboard/frontend/src/types.ts
@@ -53,8 +53,12 @@ export interface PushRecord {
   repoName?: string
   url?: string
   upstreamUrl?: string
+  /** Browsable web URL for the repository, computed server-side from the provider. Absent for generic providers. */
+  repoUrl?: string
   branch?: string
   commitTo?: string
+  /** Browsable web URL for {@link commitTo}, computed server-side from the provider. Absent for generic providers. */
+  commitUrl?: string
   commitFrom?: string
   message?: string
   author?: string

--- a/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/PushController.java
+++ b/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/PushController.java
@@ -12,8 +12,10 @@ import com.rbc.fogwall.db.model.PushSummary;
 import com.rbc.fogwall.jetty.reload.ConfigHolder;
 import com.rbc.fogwall.permission.RepoPermission;
 import com.rbc.fogwall.permission.RepoPermissionService;
+import com.rbc.fogwall.provider.ProviderRegistry;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Resource;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -41,6 +43,9 @@ public class PushController {
 
     @Autowired
     private ConfigHolder configHolder;
+
+    @Resource(name = "providers")
+    private ProviderRegistry providerRegistry;
 
     /** Returns the authenticated username, falling back to {@code body.reviewerUsername}, then {@code "system"}. */
     private static String resolveReviewer(Map<String, String> body) {
@@ -88,7 +93,50 @@ public class PushController {
         if (user != null && !user.isBlank()) query.user(user);
         if (search != null && !search.isBlank()) query.search(search);
 
-        return pushStore.findSummaries(query.build());
+        return pushStore.findSummaries(query.build()).stream()
+                .map(this::enrichUrls)
+                .toList();
+    }
+
+    /**
+     * Populates {@code repoUrl} and (when {@code commitTo} is set) {@code commitUrl} from the push's provider. Absent
+     * for generic providers with no stable public repo URL shape, or when the provider can no longer be resolved (e.g.
+     * removed from config since the push was recorded).
+     */
+    private PushSummary enrichUrls(PushSummary summary) {
+        if (summary.getProvider() == null || summary.getProject() == null || summary.getRepoName() == null) {
+            return summary;
+        }
+        return providerRegistry
+                .getProvider(summary.getProvider())
+                .map(p -> summary.toBuilder()
+                        .repoUrl(p.buildRepoUrl(summary.getProject(), summary.getRepoName())
+                                .orElse(null))
+                        .commitUrl(
+                                summary.getCommitTo() != null
+                                        ? p.buildCommitUrl(
+                                                        summary.getProject(),
+                                                        summary.getRepoName(),
+                                                        summary.getCommitTo())
+                                                .orElse(null)
+                                        : null)
+                        .build())
+                .orElse(summary);
+    }
+
+    /** Record-level counterpart of {@link #enrichUrls(PushSummary)}; mutates {@code record} in place. */
+    private void enrichUrls(PushRecord record) {
+        if (record.getProvider() == null || record.getProject() == null || record.getRepoName() == null) {
+            return;
+        }
+        providerRegistry.getProvider(record.getProvider()).ifPresent(p -> {
+            record.setRepoUrl(
+                    p.buildRepoUrl(record.getProject(), record.getRepoName()).orElse(null));
+            if (record.getCommitTo() != null) {
+                record.setCommitUrl(p.buildCommitUrl(record.getProject(), record.getRepoName(), record.getCommitTo())
+                        .orElse(null));
+            }
+        });
     }
 
     /**
@@ -147,7 +195,12 @@ public class PushController {
                     .collect(Collectors.toList());
         }
 
-        return records.isEmpty() ? ResponseEntity.notFound().build() : ResponseEntity.ok(records.get(0));
+        if (records.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        PushRecord record = records.get(0);
+        enrichUrls(record);
+        return ResponseEntity.ok(record);
     }
 
     /**
@@ -163,6 +216,7 @@ public class PushController {
                 .map(record -> {
                     stripDiffContent(record);
                     record.setCanCurrentUserSelfCertify(computeCanCurrentUserSelfCertify(record));
+                    enrichUrls(record);
                     return ResponseEntity.ok(record);
                 })
                 .orElse(ResponseEntity.notFound().build());

--- a/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/PushControllerTest.java
+++ b/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/PushControllerTest.java
@@ -12,8 +12,11 @@ import com.rbc.fogwall.config.ServerConfig;
 import com.rbc.fogwall.db.PushStore;
 import com.rbc.fogwall.db.model.PushRecord;
 import com.rbc.fogwall.db.model.PushStatus;
+import com.rbc.fogwall.db.model.PushSummary;
 import com.rbc.fogwall.jetty.reload.ConfigHolder;
 import com.rbc.fogwall.permission.RepoPermissionService;
+import com.rbc.fogwall.provider.FogwallProvider;
+import com.rbc.fogwall.provider.ProviderRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -44,6 +47,9 @@ class PushControllerTest {
 
     @Mock
     ConfigHolder configHolder;
+
+    @Mock
+    ProviderRegistry providerRegistry;
 
     // Not injected by default — individual tests that need it set it on the controller directly.
     RepoPermissionService repoPermissionService;
@@ -117,6 +123,47 @@ class PushControllerTest {
             controller.list("PENDING", null, null, null, null, 50, 0, true);
             verify(pushStore).findSummaries(argThat(q -> q.getStatus() == PushStatus.PENDING));
         }
+
+        @Test
+        void resolvableProvider_enrichesRepoAndCommitUrls() {
+            var summary = PushSummary.builder()
+                    .id("p1")
+                    .provider("github")
+                    .project("acme")
+                    .repoName("widgets")
+                    .commitTo("abc123")
+                    .build();
+            when(pushStore.findSummaries(any())).thenReturn(List.of(summary));
+            var provider = mock(FogwallProvider.class);
+            when(provider.buildRepoUrl("acme", "widgets")).thenReturn(Optional.of("https://github.com/acme/widgets"));
+            when(provider.buildCommitUrl("acme", "widgets", "abc123"))
+                    .thenReturn(Optional.of("https://github.com/acme/widgets/commit/abc123"));
+            when(providerRegistry.getProvider("github")).thenReturn(Optional.of(provider));
+
+            var result = controller.list(null, null, null, null, null, 50, 0, true);
+
+            assertEquals("https://github.com/acme/widgets", result.get(0).getRepoUrl());
+            assertEquals(
+                    "https://github.com/acme/widgets/commit/abc123",
+                    result.get(0).getCommitUrl());
+        }
+
+        @Test
+        void unresolvableProvider_leavesUrlsNull() {
+            var summary = PushSummary.builder()
+                    .id("p1")
+                    .provider("removed-provider")
+                    .project("acme")
+                    .repoName("widgets")
+                    .build();
+            when(pushStore.findSummaries(any())).thenReturn(List.of(summary));
+            when(providerRegistry.getProvider("removed-provider")).thenReturn(Optional.empty());
+
+            var result = controller.list(null, null, null, null, null, 50, 0, true);
+
+            assertEquals(null, result.get(0).getRepoUrl());
+            assertEquals(null, result.get(0).getCommitUrl());
+        }
     }
 
     // ── GET /api/push/by-ref/{ref} ────────────────────────────────────────────────
@@ -162,6 +209,31 @@ class PushControllerTest {
             var resp = controller.getByRef("def456_abc123");
             assertEquals(HttpStatus.NOT_FOUND, resp.getStatusCode());
         }
+
+        @Test
+        void resolvableProvider_enrichesRepoAndCommitUrls() {
+            var push = PushRecord.builder()
+                    .id("p1")
+                    .status(PushStatus.PENDING)
+                    .provider("github")
+                    .project("acme")
+                    .repoName("widgets")
+                    .commitTo("abc123")
+                    .build();
+            when(pushStore.find(argThat(q -> "abc123".equals(q.getCommitTo())))).thenReturn(List.of(push));
+            var provider = mock(FogwallProvider.class);
+            when(provider.buildRepoUrl("acme", "widgets")).thenReturn(Optional.of("https://github.com/acme/widgets"));
+            when(provider.buildCommitUrl("acme", "widgets", "abc123"))
+                    .thenReturn(Optional.of("https://github.com/acme/widgets/commit/abc123"));
+            when(providerRegistry.getProvider("github")).thenReturn(Optional.of(provider));
+
+            var resp = controller.getByRef("def456_abc123");
+
+            assertEquals("https://github.com/acme/widgets", resp.getBody().getRepoUrl());
+            assertEquals(
+                    "https://github.com/acme/widgets/commit/abc123",
+                    resp.getBody().getCommitUrl());
+        }
     }
 
     // ── GET /api/push/{id} ────────────────────────────────────────────────────────
@@ -180,6 +252,53 @@ class PushControllerTest {
         void notFound_returns404() {
             when(pushStore.findById("missing")).thenReturn(Optional.empty());
             assertEquals(HttpStatus.NOT_FOUND, controller.getById("missing").getStatusCode());
+        }
+
+        @Test
+        void resolvableProvider_enrichesRepoAndCommitUrls() {
+            var push = PushRecord.builder()
+                    .id("p1")
+                    .status(PushStatus.PENDING)
+                    .provider("gitlab")
+                    .project("acme")
+                    .repoName("widgets")
+                    .commitTo("abc123")
+                    .build();
+            when(pushStore.findById("p1")).thenReturn(Optional.of(push));
+            var provider = mock(FogwallProvider.class);
+            when(provider.buildRepoUrl("acme", "widgets")).thenReturn(Optional.of("https://gitlab.com/acme/widgets"));
+            when(provider.buildCommitUrl("acme", "widgets", "abc123"))
+                    .thenReturn(Optional.of("https://gitlab.com/acme/widgets/-/commit/abc123"));
+            when(providerRegistry.getProvider("gitlab")).thenReturn(Optional.of(provider));
+
+            var resp = controller.getById("p1");
+
+            assertEquals("https://gitlab.com/acme/widgets", resp.getBody().getRepoUrl());
+            assertEquals(
+                    "https://gitlab.com/acme/widgets/-/commit/abc123",
+                    resp.getBody().getCommitUrl());
+        }
+
+        @Test
+        void genericProvider_leavesUrlsNull() {
+            var push = PushRecord.builder()
+                    .id("p1")
+                    .status(PushStatus.PENDING)
+                    .provider("internal-git")
+                    .project("acme")
+                    .repoName("widgets")
+                    .commitTo("abc123")
+                    .build();
+            when(pushStore.findById("p1")).thenReturn(Optional.of(push));
+            var provider = mock(FogwallProvider.class);
+            when(provider.buildRepoUrl("acme", "widgets")).thenReturn(Optional.empty());
+            when(provider.buildCommitUrl("acme", "widgets", "abc123")).thenReturn(Optional.empty());
+            when(providerRegistry.getProvider("internal-git")).thenReturn(Optional.of(provider));
+
+            var resp = controller.getById("p1");
+
+            assertEquals(null, resp.getBody().getRepoUrl());
+            assertEquals(null, resp.getBody().getCommitUrl());
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Adds `buildRepoUrl`/`buildCommitUrl` to `FogwallProvider`, overridden per provider type (GitHub, GitLab, Bitbucket, Forgejo/Gitea). Generic providers, and any provider whose configured URI is not already `http`/`https` (e.g. `ssh://` transport), have no stable public URL shape — no link is fabricated for them, ever.
- `PushController` enriches `PushSummary`/`PushRecord` responses with `repoUrl`/`commitUrl` computed from the resolved provider at query time.
- Push list and push detail show the full repo/commit URL as plain text (protocol + host visible, so you can tell providers/instances apart at a glance) with a small opt-in "↗" external-link icon next to it when a real link exists — kept visually and functionally distinct from the whole-row click-through to the push detail page.
- The "Forwarded to upstream" timeline event reuses the backend-computed `commitUrl`, falling back to the existing http(s)-only heuristic only when the provider can no longer be resolved.

closes #364

## Test plan
- [x] `ProviderTest`: URL-building per provider type, including that ssh-transport URIs correctly produce no link
- [x] `PushControllerTest`: URL enrichment for list/getById/getByRef, including unresolvable-provider fallback
- [x] `./gradlew build --rerun` — jacoco coverage floors pass
- [x] Manually verified against a running dashboard with real push records: http(s) providers get correct clickable icons, ssh-forwarded pushes show plain text only (no fabricated link), whole-row navigation to push detail still works