### PR TITLE
feat: standalone server Docker image and minimal Helm chart

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,44 @@
+name: Helm Chart Lint
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: ["main"]
+    paths: ["charts/**"]
+  pull_request:
+    branches: ["main"]
+    paths: ["charts/**"]
+
+env:
+  HELM_VERSION: "3.21.3"
+
+jobs:
+  lint:
+    name: Helm (lint + template)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+
+      - name: Install helm
+        run: |
+          cd /tmp
+          ASSET="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+          curl -sSfL -o "${ASSET}" "https://get.helm.sh/${ASSET}"
+          curl -sSfL -o "${ASSET}.sha256sum" "https://get.helm.sh/${ASSET}.sha256sum"
+          sha256sum --check "${ASSET}.sha256sum"
+          tar -xzf "${ASSET}" linux-amd64/helm
+          sudo mv linux-amd64/helm /usr/local/bin/helm
+
+      - name: helm lint
+        run: helm lint charts/fogwall
+
+      - name: helm template (default values)
+        run: helm template test charts/fogwall
+
+      - name: helm template (multi-replica + secret overrides)
+        run: |
+          helm template test charts/fogwall --set replicaCount=3 \
+            --set-json 'extraEnvFrom=[{"secretRef":{"name":"fogwall-secrets"}}]'

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,17 +46,52 @@ RUN --mount=type=cache,target=/root/.gradle/caches \
       arm64) GITLEAKS_TARGET=linux_arm64 ;; \
       *)     GITLEAKS_TARGET=linux_x64   ;; \
     esac \
-    && ./gradlew clean :fogwall-dashboard:installDist \
+    && ./gradlew clean :fogwall-server:installDist :fogwall-dashboard:installDist \
        -PgitleaksTargets=${GITLEAKS_TARGET} --no-daemon -q
 
 # Prepend a conf/ directory to the classpath so that a mounted fogwall-local.yml
 # is picked up by JettyConfigurationLoader at runtime.
 RUN sed -i \
     's|^CLASSPATH=\$APP_HOME/lib|CLASSPATH=$APP_HOME/conf:$APP_HOME/lib|' \
-    fogwall-dashboard/build/install/fogwall-dashboard/bin/fogwall-dashboard
+    fogwall-dashboard/build/install/fogwall-dashboard/bin/fogwall-dashboard \
+    fogwall-server/build/install/fogwall-server/bin/fogwall-server
 
-# ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM docker.io/eclipse-temurin:25-jre-noble@sha256:2f1da100788559b397bcf48c736169ea5b070bde84e55f203bbee8e83d87a175
+# ── Runtime stage: standalone server (no dashboard, no Spring, no Node) ────────
+# Not built by default — `docker build --target server .` opts in explicitly.
+# Lighter footprint: no React/Node build step, no Spring/dashboard dependencies.
+FROM docker.io/eclipse-temurin:25-jre-noble@sha256:2f1da100788559b397bcf48c736169ea5b070bde84e55f203bbee8e83d87a175 AS server
+
+ARG SECURITY_UPGRADE_PKGS="libssl3t64 openssl"
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && if [ -n "${SECURITY_UPGRADE_PKGS}" ]; then \
+         apt-get install -y --only-upgrade ${SECURITY_UPGRADE_PKGS}; \
+       fi \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder \
+    /workspace/fogwall-server/build/install/fogwall-server/ /app/
+
+# Create the conf directory; mount a fogwall-{profile}.yml here to override config.
+RUN mkdir -p /app/conf
+
+RUN bash -c 'mkdir -p /app/{.data,logs,home} \
+    && chown -R 1000:0 /app/{.data,logs,home} \
+    && chmod g+rwX /app/{.data,logs,home}'
+
+ENV HOME=/app/home
+
+EXPOSE 8080
+
+USER 1000
+
+ENTRYPOINT ["/app/bin/fogwall-server"]
+
+# ── Runtime stage: dashboard (default) ──────────────────────────────────────────
+FROM docker.io/eclipse-temurin:25-jre-noble@sha256:2f1da100788559b397bcf48c736169ea5b070bde84e55f203bbee8e83d87a175 AS dashboard
 
 # Packages to upgrade beyond what the base image ships, space-separated.
 # Used to patch CVEs that are fixed in Ubuntu's repos but not yet picked up by

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Citigroup
+   Copyright 2026 Royal Bank of Canada
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ This is a multi-module Gradle project:
 | [Architecture](docs/ARCHITECTURE.md)                         | How the proxy works: two proxy modes, validation pipeline, core abstractions, advanced use cases                 |
 | [JGit Infrastructure](docs/internals/JGIT_INFRASTRUCTURE.md) | Store-and-forward internals: ReceivePackFactory, hook chain, forwarding, credential flow (contributor reference) |
 | [Git Internals](docs/internals/GIT_INTERNALS.md)             | Wire-protocol edge cases: tags, new branches, force pushes, pack parsing (contributor reference)                 |
+| [Helm Chart](charts/fogwall/README.md)                       | Deploying fogwall on Kubernetes: values reference, secrets, multi-replica setup, standalone server image         |
 
 ## Roadmap
 

--- a/charts/fogwall/.helmignore
+++ b/charts/fogwall/.helmignore
@@ -1,0 +1,3 @@
+.git/
+.gitignore
+.vscode/

--- a/charts/fogwall/Chart.yaml
+++ b/charts/fogwall/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: fogwall
+description: Gateway/policy-enforcement proxy for git push validation, approval, and provenance
+type: application
+version: 0.1.0
+appVersion: "1.2.1"
+home: https://github.com/RBC/fogwall
+sources:
+  - https://github.com/RBC/fogwall
+maintainers:
+  - name: RBC/fogwall contributors

--- a/charts/fogwall/README.md
+++ b/charts/fogwall/README.md
@@ -1,0 +1,98 @@
+# fogwall Helm chart
+
+A minimal starting chart for deploying fogwall on Kubernetes: `Deployment`, `Service`, `ConfigMap`, and
+liveness/readiness probes. It defaults to the dashboard image (`ghcr.io/rbc/fogwall`) — proxy, REST API, and approval
+UI.
+
+## Not yet included
+
+This is intentionally the 80% case, not the full spec from [#309](https://github.com/RBC/fogwall/issues/309). Not
+covered yet, tracked as follow-up work:
+
+- `Ingress` / `IngressRoute`
+- `PersistentVolumeClaim` for `h2-file`/SQLite (single-replica-only databases)
+- `ServiceAccount` + RBAC
+- OpenShift `SecurityContextConstraints` / `anyuid` guidance
+- A Kustomize base as a GitOps-friendly alternative
+
+## Install
+
+```bash
+helm install fogwall charts/fogwall \
+  --set image.tag=1.2.1 \
+  -f my-values.yaml
+```
+
+Where `my-values.yaml` sets at minimum the `config` value — the contents of the operator-supplied
+`fogwall-<configProfileName>.yml` profile (providers, rules, permissions; see
+[docs/CONFIGURATION.md](../../docs/CONFIGURATION.md)):
+
+```yaml
+config: |
+  providers:
+    github:
+      type: github
+      enabled: true
+  rules:
+    allow:
+      - match:
+          target: OWNER
+          value: my-org
+          type: LITERAL
+```
+
+## Secrets
+
+This chart does not create a `Secret` — bring your own (database password, OIDC client secret, API key) and project it
+via `extraEnvFrom`:
+
+```yaml
+extraEnvFrom:
+  - secretRef:
+      name: fogwall-secrets
+```
+
+## Multi-replica deployments
+
+The default config (`h2-file`) only works for a single replica — it's a local file database. For `replicaCount > 1`,
+override `config` to point at PostgreSQL or MongoDB, and set `server.session-store` to `jdbc`, `mongo`, or `redis` so
+sessions are shared across pods. See
+[docs/ADMIN_GUIDE.md — Production checklist](../../docs/ADMIN_GUIDE.md#production-checklist).
+
+## Standalone server image
+
+`variant` picks which image (and matching probe type) to deploy:
+
+```yaml
+variant: server # proxy + validation pipeline only, no dashboard/REST API
+```
+
+This switches the default image to `ghcr.io/rbc/fogwall-server` and the liveness/readiness probes to a plain `tcpSocket`
+check — the server image has no `/api/health` endpoint (see
+[docs/ADMIN_GUIDE.md — Standalone server image](../../docs/ADMIN_GUIDE.md#standalone-server-image-no-dashboard)). Set
+`image.repository`/`image.tag` or `livenessProbe`/`readinessProbe` explicitly to override either independently of
+`variant` (e.g. to point at a private mirror of either image).
+
+## Values reference
+
+| Key                  | Default        | Description                                                                       |
+| -------------------- | -------------- | --------------------------------------------------------------------------------- |
+| `variant`            | `dashboard`    | `dashboard` or `server` — picks the default image and probe type together         |
+| `replicaCount`       | `1`            | Pod replica count                                                                 |
+| `image.repository`   | _(by variant)_ | Override to deploy a private mirror; blank uses the `variant` default             |
+| `image.tag`          | `latest`       | Image tag — pin to a specific release in production                               |
+| `image.pullPolicy`   | `IfNotPresent` |                                                                                   |
+| `service.type`       | `ClusterIP`    |                                                                                   |
+| `service.port`       | `80`           | Service port (routes to `targetPort` on the pod)                                  |
+| `service.targetPort` | `8080`         | Container port                                                                    |
+| `configProfiles`     | `custom`       | `FOGWALL_CONFIG_PROFILES` value — comma-separated profile names                   |
+| `configProfileName`  | `custom`       | Name used for the operator-supplied profile file mounted from the `ConfigMap`     |
+| `config`             | _(sample)_     | Contents of `fogwall-<configProfileName>.yml` — see [Install](#install)           |
+| `extraEnvFrom`       | `[]`           | `envFrom` entries — use to project an existing `Secret`                           |
+| `extraEnv`           | `[]`           | Additional `env` entries                                                          |
+| `resources`          | `{}`           | Pod resource requests/limits                                                      |
+| `livenessProbe`      | _(by variant)_ | Override to replace the variant default entirely (`httpGet`, `tcpSocket`, `exec`) |
+| `readinessProbe`     | _(by variant)_ | Override to replace the variant default entirely                                  |
+| `nodeSelector`       | `{}`           |                                                                                   |
+| `tolerations`        | `[]`           |                                                                                   |
+| `affinity`           | `{}`           |                                                                                   |

--- a/charts/fogwall/templates/_helpers.tpl
+++ b/charts/fogwall/templates/_helpers.tpl
@@ -1,0 +1,79 @@
+{{/*
+Chart name and version label.
+*/}}
+{{- define "fogwall.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name — release name is already unique per install, so this chart's name
+is used directly (no truncation dance needed for a single-service chart).
+*/}}
+{{- define "fogwall.fullname" -}}
+{{- .Release.Name -}}
+{{- end -}}
+
+{{/*
+Common labels applied to every resource.
+*/}}
+{{- define "fogwall.labels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+helm.sh/chart: {{ include "fogwall.chart" . }}
+{{- end -}}
+
+{{/*
+Selector labels — must be a stable subset of fogwall.labels (no version, since that changes
+across upgrades and Deployment selectors are immutable).
+*/}}
+{{- define "fogwall.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Default image repository for the selected variant. Only used when .Values.image.repository is
+blank — an explicit value always wins (e.g. a private mirror of either image).
+*/}}
+{{- define "fogwall.defaultImageRepository" -}}
+{{- if eq .Values.variant "server" -}}
+ghcr.io/rbc/fogwall-server
+{{- else -}}
+ghcr.io/rbc/fogwall
+{{- end -}}
+{{- end -}}
+
+{{/*
+Fully qualified image reference.
+*/}}
+{{- define "fogwall.image" -}}
+{{- $repo := .Values.image.repository -}}
+{{- if not $repo -}}
+{{- $repo = include "fogwall.defaultImageRepository" . -}}
+{{- end -}}
+{{- printf "%s:%s" $repo .Values.image.tag -}}
+{{- end -}}
+
+{{/*
+Liveness/readiness probe block for the selected variant. An explicit .Values.livenessProbe /
+.Values.readinessProbe always wins over the variant default. The server variant has no HTTP
+health endpoint, so its default is a plain TCP check against the app port.
+*/}}
+{{- define "fogwall.probe" -}}
+{{- $probe := index .Values (printf "%sProbe" .kind) -}}
+{{- if $probe -}}
+{{ toYaml $probe }}
+{{- else if eq .Values.variant "server" -}}
+tcpSocket:
+  port: http
+initialDelaySeconds: {{ eq .kind "liveness" | ternary 15 10 }}
+periodSeconds: {{ eq .kind "liveness" | ternary 10 5 }}
+{{- else -}}
+httpGet:
+  path: /api/health
+  port: http
+initialDelaySeconds: {{ eq .kind "liveness" | ternary 15 10 }}
+periodSeconds: {{ eq .kind "liveness" | ternary 10 5 }}
+{{- end -}}
+{{- end -}}

--- a/charts/fogwall/templates/configmap.yaml
+++ b/charts/fogwall/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fogwall.fullname" . }}
+  labels:
+    {{- include "fogwall.labels" . | nindent 4 }}
+data:
+  fogwall-{{ .Values.configProfileName }}.yml: |
+{{ .Values.config | indent 4 }}

--- a/charts/fogwall/templates/deployment.yaml
+++ b/charts/fogwall/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fogwall.fullname" . }}
+  labels:
+    {{- include "fogwall.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "fogwall.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "fogwall.selectorLabels" . | nindent 8 }}
+      annotations:
+        # Forces a rollout when the mounted config changes — ConfigMap updates don't
+        # otherwise trigger a restart of already-running pods.
+        checksum/config: {{ .Values.config | sha256sum }}
+    spec:
+      # fogwall reads every FOGWALL_* env var as a config override (see docs/CONFIGURATION.md).
+      # Kubernetes auto-injects <SERVICE_NAME>_SERVICE_PORT-style env vars for every Service in
+      # the namespace — since a release/service named "fogwall*" is the common case, those
+      # auto-injected vars collide with fogwall's own env prefix and break config loading.
+      enableServiceLinks: false
+      containers:
+        - name: fogwall
+          image: "{{ include "fogwall.image" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: FOGWALL_CONFIG_PROFILES
+              value: {{ .Values.configProfiles | quote }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/conf
+              readOnly: true
+          livenessProbe:
+            {{- include "fogwall.probe" (dict "Values" .Values "kind" "liveness") | nindent 12 }}
+          readinessProbe:
+            {{- include "fogwall.probe" (dict "Values" .Values "kind" "readiness") | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "fogwall.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/fogwall/templates/service.yaml
+++ b/charts/fogwall/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fogwall.fullname" . }}
+  labels:
+    {{- include "fogwall.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "fogwall.selectorLabels" . | nindent 4 }}

--- a/charts/fogwall/values.yaml
+++ b/charts/fogwall/values.yaml
@@ -1,0 +1,69 @@
+# Default values for the fogwall Helm chart.
+# This is a minimal starting chart — Deployment, Service, ConfigMap, and health probes only.
+# Ingress, PersistentVolumeClaim, ServiceAccount/RBAC, and OpenShift SCC guidance are tracked
+# as follow-up work (see charts/fogwall/README.md).
+
+replicaCount: 1
+
+# Which fogwall image to deploy:
+#   dashboard — proxy + REST API + approval UI, has /api/health, default
+#   server    — proxy + validation pipeline only, no dashboard/REST API, no HTTP health endpoint
+# Sets the default image repository and probe type together. Set image.repository/tag explicitly
+# to override the registry/tag without changing variant-driven defaults (probe type, etc).
+variant: dashboard
+
+image:
+  # Leave blank to use the variant default (ghcr.io/rbc/fogwall or ghcr.io/rbc/fogwall-server).
+  repository: ""
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+# Config profile(s) to load, matching FOGWALL_CONFIG_PROFILES. "custom" (below) is this chart's
+# operator-supplied profile, mounted from the ConfigMap built from `config`. Comma-separated to
+# layer additional profiles baked into a custom image build — later profiles take priority.
+configProfiles: custom
+
+# Name of the operator-supplied profile — the ConfigMap key is fogwall-<configProfileName>.yml.
+# Must appear in configProfiles above for it to actually be loaded.
+configProfileName: custom
+
+# Contents of the fogwall-<configProfileName>.yml file, mounted at /app/conf/. Keep secrets (DB
+# passwords, OIDC client secret, API key) out of this value — use extraEnvFrom to pull them from
+# an existing Secret instead.
+config: |
+  # See docs/CONFIGURATION.md for the full reference.
+  providers:
+    github:
+      type: github
+      enabled: true
+
+# Name of an existing Secret to project as environment variables (e.g. FOGWALL_API_KEY,
+# FOGWALL_DATABASE_PASSWORD). This chart does not create the Secret — bring your own.
+extraEnvFrom: []
+# extraEnvFrom:
+#   - secretRef:
+#       name: fogwall-secrets
+
+extraEnv: []
+
+resources: {}
+# resources:
+#   requests:
+#     cpu: 250m
+#     memory: 512Mi
+#   limits:
+#     memory: 1Gi
+
+# Leave empty to use the variant-driven default (httpGet /api/health for dashboard, tcpSocket
+# for server — the server image has no HTTP health endpoint). Set explicitly to override.
+livenessProbe: {}
+readinessProbe: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -747,6 +747,26 @@ server:
 This merges the corporate CA with the JVM's built-in trust anchors so public providers (GitHub, GitLab SaaS) continue to
 work without changes.
 
+### Standalone server image (no dashboard)
+
+The default `docker build .` produces the dashboard image (`FogwallDashboardApplication`) — proxy, REST API, approval
+UI. For enforcement-only deployments that don't need the dashboard or approval UI (CI pipelines, automated
+environments), build the lighter standalone server target instead:
+
+```bash
+docker build --target server -t fogwall-server .
+```
+
+This runs `FogwallJettyApplication` — the git proxy and validation pipeline with YAML-driven configuration, no Spring,
+no React/Node build step, no REST API. It uses the same config override mechanism as the dashboard image (mount a
+`fogwall-{profile}.yml` at `/app/conf/`, set `FOGWALL_CONFIG_PROFILES`) and exposes the same port 8080.
+
+```bash
+docker run -e FOGWALL_CONFIG_PROFILES=docker-default \
+  -v ./docker/fogwall-docker-default.yml:/app/conf/fogwall-docker-default.yml:ro \
+  -p 8080:8080 fogwall-server
+```
+
 ### Health check
 
 The dashboard module exposes an unauthenticated health endpoint:


### PR DESCRIPTION
## Summary
- Adds a `server` build target to the Dockerfile (`docker build --target server .`) packaging `fogwall-server` (`FogwallJettyApplication`) — proxy and validation pipeline only, no Spring, no dashboard, no React/Node build step. The default `docker build .` target (dashboard image) is unchanged.
- Adds `charts/fogwall/`, a minimal Helm chart (`Deployment`, `Service`, `ConfigMap`, liveness/readiness probes). Ingress, PVC, ServiceAccount/RBAC, and OpenShift guidance are left as documented follow-up work rather than guessed at up front.
  - A single `variant: dashboard|server` value picks the default image and matching probe type together (the server image has no `/api/health`, so its default is a `tcpSocket` check). Image/probes can still be overridden independently.
  - Sets `enableServiceLinks: false` on the pod spec — without it, Kubernetes' auto-injected `<SERVICE_NAME>_SERVICE_PORT`-style env vars collide with fogwall's own `FOGWALL_*` env-var config override convention whenever the release/service name starts with "fogwall" (the common case), corrupting config on startup. Found and fixed by actually deploying both variants to a local kind cluster.
- Adds a Helm Chart Lint CI workflow (lint + template rendering, including a multi-replica + secret-override scenario) gated on `charts/**` changes.
- Corrects the LICENSE boilerplate copyright line, inherited verbatim from the finos/git-proxy template ("Copyright 2020 Citigroup"), to "Copyright 2026 Royal Bank of Canada".

CI publishing of the new server image (build-and-push, scan, release promotion) is intentionally out of scope here — tracked as a follow-up so it can land as its own focused change to the tag-gated release pipeline.

closes #122
closes #309

## Test plan
- [x] `docker build --target server .` and default `docker build .` both build and run correctly; verified a real git push through the standalone server image
- [x] `helm lint` / `helm template` for both `variant: dashboard` and `variant: server`, plus multi-replica and secret-override scenarios
- [x] Deployed both variants to a local kind cluster end-to-end — pods `1/1 Running`, probes passing, config loaded, Service routes traffic
- [x] `./gradlew build --rerun` — full build passes