### PR TITLE
feat: add MySQL and MariaDB database backend support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,13 +273,15 @@ provider, one for the database backend. They can be combined freely.
 | ----------------------------- | ------------ | -------------------- | ---------------------- |
 | _(none)_                      | H2 in-memory | —                    | —                      |
 | `docker-compose.postgres.yml` | PostgreSQL   | `--profile postgres` | Adminer at :8082       |
+| `docker-compose.mysql.yml`    | MySQL        | `--profile mysql`    | Adminer at :8082       |
+| `docker-compose.mariadb.yml`  | MariaDB      | `--profile mariadb`  | Adminer at :8082       |
 | `docker-compose.mongo.yml`    | MongoDB      | `--profile mongo`    | Mongo Express at :8081 |
 
 Any auth overlay can be combined with any database overlay (or none, to keep H2). Use the `compose.sh` wrapper rather
 than bare `docker compose` — it assembles the right `-f`/`--profile` flags and auto-detects docker vs podman:
 
 ```bash
-bash compose.sh [--auth ldap|oidc] [--db postgres|mongo] -- up -d
+bash compose.sh [--auth ldap|oidc] [--db postgres|mysql|mariadb|mongo] -- up -d
 ```
 
 ### First-time setup

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ ext {
     hikariVersion = '7.1.0'
     h2Version = '2.4.240'
     postgresVersion = '42.7.13'
+    mysqlVersion = '9.7.0'
+    mariadbVersion = '3.5.9'
     mongoVersion = '5.9.0'
 
     // Jackson

--- a/compose.sh
+++ b/compose.sh
@@ -2,12 +2,13 @@
 # Wrapper around docker/podman compose that assembles the right overlay flags.
 #
 # Usage:
-#   bash compose.sh [--auth ldap|oidc] [--db postgres|mongo] -- <compose subcommand> [args...]
+#   bash compose.sh [--auth ldap|oidc] [--db postgres|mysql|mariadb|mongo] -- <compose subcommand> [args...]
 #
 # Examples:
 #   bash compose.sh -- up -d
 #   bash compose.sh --auth ldap -- up -d
 #   bash compose.sh --db postgres -- up -d
+#   bash compose.sh --db mysql -- up -d
 #   bash compose.sh --auth ldap --db postgres -- up -d
 #   bash compose.sh --auth ldap --db postgres -- down -v
 
@@ -32,7 +33,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     *)
       echo "Unknown option: $1" >&2
-      echo "Usage: bash compose.sh [--auth ldap|oidc] [--db postgres|mongo] -- <compose subcommand> [args...]" >&2
+      echo "Usage: bash compose.sh [--auth ldap|oidc] [--db postgres|mysql|mariadb|mongo] -- <compose subcommand> [args...]" >&2
       exit 1
       ;;
   esac
@@ -43,8 +44,8 @@ if [[ -n "$AUTH" && "$AUTH" != "ldap" && "$AUTH" != "oidc" ]]; then
   exit 1
 fi
 
-if [[ -n "$DB" && "$DB" != "postgres" && "$DB" != "mongo" ]]; then
-  echo "Invalid --db value: $DB (must be postgres or mongo)" >&2
+if [[ -n "$DB" && "$DB" != "postgres" && "$DB" != "mysql" && "$DB" != "mariadb" && "$DB" != "mongo" ]]; then
+  echo "Invalid --db value: $DB (must be postgres, mysql, mariadb, or mongo)" >&2
   exit 1
 fi
 

--- a/docker-compose.mariadb.yml
+++ b/docker-compose.mariadb.yml
@@ -1,0 +1,28 @@
+# Database overlay — MariaDB.
+#
+# Activates the mariadb service from docker-compose.yml (--profile mariadb) and
+# injects database settings as environment variables.  Composes freely with any auth
+# overlay (ldap, oidc, or the default static auth) — just add both -f flags.
+#
+# Examples:
+#   # Static auth + MariaDB
+#   docker compose --profile mariadb -f docker-compose.yml -f docker-compose.mariadb.yml up -d
+#
+#   # LDAP auth + MariaDB
+#   docker compose --profile mariadb -f docker-compose.yml -f docker-compose.ldap.yml -f docker-compose.mariadb.yml up -d
+#
+#   # OIDC auth + MariaDB
+#   docker compose --profile mariadb -f docker-compose.yml -f docker-compose.oidc.yml -f docker-compose.mariadb.yml up -d
+#
+# Adminer (database UI) is available at http://localhost:8082.
+services:
+  fogwall:
+    environment:
+      FOGWALL_DATABASE_TYPE: mariadb
+      FOGWALL_DATABASE_URL: "jdbc:mariadb://mariadb:3306/fogwall?useSsl=false"
+      FOGWALL_DATABASE_USERNAME: fogwall
+      FOGWALL_DATABASE_PASSWORD: fogwall
+      FOGWALL_SERVER_SESSION_STORE: jdbc
+    depends_on:
+      mariadb:
+        condition: service_healthy

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -1,0 +1,28 @@
+# Database overlay — MySQL.
+#
+# Activates the mysql service from docker-compose.yml (--profile mysql) and
+# injects database settings as environment variables.  Composes freely with any auth
+# overlay (ldap, oidc, or the default static auth) — just add both -f flags.
+#
+# Examples:
+#   # Static auth + MySQL
+#   docker compose --profile mysql -f docker-compose.yml -f docker-compose.mysql.yml up -d
+#
+#   # LDAP auth + MySQL
+#   docker compose --profile mysql -f docker-compose.yml -f docker-compose.ldap.yml -f docker-compose.mysql.yml up -d
+#
+#   # OIDC auth + MySQL
+#   docker compose --profile mysql -f docker-compose.yml -f docker-compose.oidc.yml -f docker-compose.mysql.yml up -d
+#
+# Adminer (database UI) is available at http://localhost:8082.
+services:
+  fogwall:
+    environment:
+      FOGWALL_DATABASE_TYPE: mysql
+      FOGWALL_DATABASE_URL: "jdbc:mysql://mysql:3306/fogwall?useSSL=false&allowPublicKeyRetrieval=true"
+      FOGWALL_DATABASE_USERNAME: fogwall
+      FOGWALL_DATABASE_PASSWORD: fogwall
+      FOGWALL_SERVER_SESSION_STORE: jdbc
+    depends_on:
+      mysql:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,44 @@ services:
       timeout: 5s
       retries: 10
 
+  # ── MySQL (optional — start with: docker compose --profile mysql up) ───────
+  mysql:
+    image: docker.io/mysql:8.4
+    profiles: [mysql]
+    environment:
+      MYSQL_DATABASE: fogwall
+      MYSQL_USER: fogwall
+      MYSQL_PASSWORD: fogwall
+      MYSQL_ROOT_PASSWORD: fogwall
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ufogwall", "-pfogwall"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # ── MariaDB (optional — start with: docker compose --profile mariadb up) ───
+  mariadb:
+    image: docker.io/mariadb:11.4
+    profiles: [mariadb]
+    environment:
+      MARIADB_DATABASE: fogwall
+      MARIADB_USER: fogwall
+      MARIADB_PASSWORD: fogwall
+      MARIADB_ROOT_PASSWORD: fogwall
+    ports:
+      - "3307:3306"
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ufogwall", "-pfogwall"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
   # ── MongoDB (optional — start with: docker compose --profile mongo up) ─────
   mongo:
     image: docker.io/mongo:7
@@ -104,13 +142,13 @@ services:
 
   adminer:
     image: docker.io/adminer:4
-    profiles: [postgres]
-    depends_on:
-      - postgres
+    profiles: [postgres, mysql, mariadb]
     ports:
       - "8082:8080"
 
 volumes:
   gitea-data:
   postgres-data:
+  mysql-data:
+  mariadb-data:
   mongo-data:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -262,27 +262,38 @@ This applies to both proxy modes:
 
 ```yaml
 database:
-  type: h2-mem # h2-mem | h2-file | postgres | mongo
+  type: h2-mem # h2-mem | h2-file | postgres | mysql | mariadb | mongo
 ```
 
 ### Database backends
 
-| Type       | Description            | Extra keys                                                           |
-| ---------- | ---------------------- | -------------------------------------------------------------------- |
-| `h2-mem`   | H2 in-memory (default) | `name` (default: `fogwall`)                                          |
-| `h2-file`  | H2 persisted to disk   | `path` (default: `./.data/fogwall`)                                  |
-| `sqlite`   | SQLite file            | `path` (default: `./.data/fogwall.db`)                               |
-| `postgres` | PostgreSQL             | `url` **or** `host`, `port`, `name`, `username`, `password`          |
-| `mongo`    | MongoDB                | `url` (required); `name` optional if the database is in the URI path |
+| Type       | Description            | Extra keys                                                                 |
+| ---------- | ---------------------- | -------------------------------------------------------------------------- |
+| `h2-mem`   | H2 in-memory (default) | `name` (default: `fogwall`)                                                |
+| `h2-file`  | H2 persisted to disk   | `path` (default: `./.data/fogwall`)                                        |
+| `postgres` | PostgreSQL             | `url` **or** `host`, `port`, `name`, `username`, `password`                |
+| `mysql`    | MySQL 8.0+             | `url` **or** `host`, `port` (default 3306), `name`, `username`, `password` |
+| `mariadb`  | MariaDB 10.5+          | `url` **or** `host`, `port` (default 3306), `name`, `username`, `password` |
+| `mongo`    | MongoDB                | `url` (required); `name` optional if the database is in the URI path       |
 
-For both `postgres` and `mongo`, setting `url` to a full connection string is the recommended approach when you need
-driver-specific options (TLS, SSL certificates, connection parameters) that are not exposed as individual config fields.
+SQLite is intentionally not supported — its single-writer file locking is unsuitable for a proxy that may run more than
+one instance against the same database.
+
+For `postgres`, `mysql`, `mariadb`, and `mongo`, setting `url` to a full connection string is the recommended approach
+when you need driver-specific options (TLS, SSL certificates, connection parameters) that are not exposed as individual
+config fields.
+
+MySQL and MariaDB use **separate JDBC drivers** (`mysql-connector-j` and `mariadb-java-client`, not one shared driver) —
+pick the `type` matching the actual engine you're running, even though the two are largely wire-compatible.
+`database.port` defaults to PostgreSQL's port (5432); for `mysql`/`mariadb` set it explicitly (typically `3306`) unless
+the server actually listens on 5432 — fogwall logs a startup warning if it detects the untouched default being used with
+either type.
 
 ### Connection pool tuning
 
-Applies to all JDBC backends (`h2-mem`, `h2-file`, `postgres`). The default pool size is deliberately small — git push
-workloads are sequential per user, so a large pool buys nothing and drives up aggregate connection counts when multiple
-instances share a database. The
+Applies to all JDBC backends (`h2-mem`, `h2-file`, `postgres`, `mysql`, `mariadb`). The default pool size is
+deliberately small — git push workloads are sequential per user, so a large pool buys nothing and drives up aggregate
+connection counts when multiple instances share a database. The
 [HikariCP pool sizing guide](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing) covers this in depth.
 
 ```yaml
@@ -315,6 +326,38 @@ database:
 database:
   type: postgres
   url: jdbc:postgresql://db.internal:5432/fogwall?sslmode=verify-full&sslrootcert=/certs/ca.crt
+  username: fogwall
+  password: secret
+
+# MySQL — individual fields
+database:
+  type: mysql
+  host: db.internal
+  port: 3306
+  name: fogwall
+  username: fogwall
+  password: secret
+
+# MySQL — connection string
+database:
+  type: mysql
+  url: jdbc:mysql://db.internal:3306/fogwall?useSSL=true&requireSSL=true
+  username: fogwall
+  password: secret
+
+# MariaDB — individual fields
+database:
+  type: mariadb
+  host: db.internal
+  port: 3306
+  name: fogwall
+  username: fogwall
+  password: secret
+
+# MariaDB — connection string
+database:
+  type: mariadb
+  url: jdbc:mariadb://db.internal:3306/fogwall?useSsl=true
   username: fogwall
   password: secret
 

--- a/fogwall-core/build.gradle
+++ b/fogwall-core/build.gradle
@@ -74,6 +74,8 @@ dependencies {
     // Database - JDBC drivers (optional at runtime, depending on which store is used)
     compileOnly "com.h2database:h2:${h2Version}"
     compileOnly "org.postgresql:postgresql:${postgresVersion}"
+    compileOnly "com.mysql:mysql-connector-j:${mysqlVersion}"
+    compileOnly "org.mariadb.jdbc:mariadb-java-client:${mariadbVersion}"
 
     // Database - MongoDB driver
     compileOnly "org.mongodb:mongodb-driver-sync:${mongoVersion}"
@@ -93,6 +95,10 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers:${testContainersVersion}"
     testImplementation "org.testcontainers:testcontainers-junit-jupiter:${testContainersVersion}"
     testImplementation "org.testcontainers:testcontainers-mongodb:${testContainersVersion}"
+    testImplementation "org.testcontainers:testcontainers-mysql:${testContainersVersion}"
+    testImplementation "org.testcontainers:testcontainers-mariadb:${testContainersVersion}"
+    testRuntimeOnly "com.mysql:mysql-connector-j:${mysqlVersion}"
+    testRuntimeOnly "org.mariadb.jdbc:mariadb-java-client:${mariadbVersion}"
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/db/jdbc/DataSourceFactory.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/db/jdbc/DataSourceFactory.java
@@ -54,6 +54,40 @@ public final class DataSourceFactory {
         return new HikariDataSource(config);
     }
 
+    /** MySQL database with default pool settings. */
+    public static DataSource mysql(String host, int port, String database, String username, String password) {
+        return mysql(host, port, database, username, password, new PoolConfig());
+    }
+
+    /** MySQL database. */
+    public static DataSource mysql(
+            String host, int port, String database, String username, String password, PoolConfig pool) {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:mysql://" + host + ":" + port + "/" + database);
+        config.setUsername(username);
+        config.setPassword(password);
+        config.setDriverClassName("com.mysql.cj.jdbc.Driver");
+        applyPool(config, pool);
+        return new HikariDataSource(config);
+    }
+
+    /** MariaDB database with default pool settings. */
+    public static DataSource mariadb(String host, int port, String database, String username, String password) {
+        return mariadb(host, port, database, username, password, new PoolConfig());
+    }
+
+    /** MariaDB database. */
+    public static DataSource mariadb(
+            String host, int port, String database, String username, String password, PoolConfig pool) {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:mariadb://" + host + ":" + port + "/" + database);
+        config.setUsername(username);
+        config.setPassword(password);
+        config.setDriverClassName("org.mariadb.jdbc.Driver");
+        applyPool(config, pool);
+        return new HikariDataSource(config);
+    }
+
     /** Generic datasource from a JDBC URL, with default pool settings. */
     public static DataSource fromUrl(String jdbcUrl, String username, String password) {
         return fromUrl(jdbcUrl, username, password, new PoolConfig());

--- a/fogwall-core/src/main/java/com/rbc/fogwall/db/jdbc/DatabaseMigrator.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/db/jdbc/DatabaseMigrator.java
@@ -19,9 +19,13 @@ import org.slf4j.LoggerFactory;
  * Minimal SQL migration runner — no external dependencies.
  *
  * <p>Migrations are applied in version order and tracked in a {@code schema_migrations} table. Vendor-specific
- * migrations (e.g. PostgreSQL-only column widening) are included only when the connected database matches. On first run
- * against an existing database that was previously managed by Flyway, the {@code flyway_schema_history} table is read
- * to seed {@code schema_migrations} so already-applied scripts are not re-run.
+ * migrations (e.g. PostgreSQL-only column widening, or MySQL/MariaDB rewrites of syntax Postgres/H2 accept but MySQL
+ * does not — {@code BYTEA}, {@code ALTER COLUMN ... SET NOT NULL}, {@code CREATE INDEX IF NOT EXISTS}) are included
+ * only when the connected database matches. Some shared migrations are consequently marked {@link Vendor#EXCEPT_MYSQL}
+ * — a MySQL/MariaDB-specific replacement of the same version exists under {@code db/migration-mysql/} and is selected
+ * instead via {@link Vendor#MYSQL_ONLY}. On first run against an existing database that was previously managed by
+ * Flyway, the {@code flyway_schema_history} table is read to seed {@code schema_migrations} so already-applied scripts
+ * are not re-run.
  */
 public class DatabaseMigrator {
 
@@ -29,27 +33,68 @@ public class DatabaseMigrator {
 
     // ---------------------------------------------------------------------------
     // Migration registry — add new entries here when adding migration files.
-    // Vendor-specific migrations are applied only when isPostgres is true.
     // ---------------------------------------------------------------------------
 
-    private record Migration(String version, String description, String resource, boolean postgresOnly) {}
+    /** Which database family a migration applies to. */
+    private enum Vendor {
+        /** Applies to every supported database. */
+        ANY,
+        /** PostgreSQL only. */
+        POSTGRES_ONLY,
+        /** MySQL or MariaDB only. */
+        MYSQL_ONLY,
+        /** Every database except MySQL/MariaDB — a MySQL-specific replacement of this version exists. */
+        EXCEPT_MYSQL
+    }
+
+    private record Migration(String version, String description, String resource, Vendor vendor) {}
 
     private static final List<Migration> MIGRATIONS = List.of(
-            new Migration("1", "initial schema", "db/migration/V1__initial_schema.sql", false),
-            new Migration("2", "provider id format", "db/migration/V2__provider_id_format.sql", false),
+            new Migration("1", "initial schema", "db/migration/V1__initial_schema.sql", Vendor.EXCEPT_MYSQL),
             new Migration(
-                    "2.1", "widen provider columns", "db/migration-postgresql/V2_1__widen_provider_columns.sql", true),
-            new Migration("3", "email unique constraint", "db/migration/V3__email_unique.sql", false),
-            new Migration("4", "spring session tables", "db/migration/V4__spring_session.sql", false),
-            new Migration("5", "unified rule shape", "db/migration/V5__unified_rule_shape.sql", false),
-            new Migration("6", "repo permissions FK", "db/migration/V6__repo_permissions_fk.sql", false),
+                    "1",
+                    "initial schema (mysql/mariadb)",
+                    "db/migration-mysql/V1__initial_schema.sql",
+                    Vendor.MYSQL_ONLY),
+            new Migration("2", "provider id format", "db/migration/V2__provider_id_format.sql", Vendor.ANY),
+            new Migration(
+                    "2.1",
+                    "widen provider columns",
+                    "db/migration-postgresql/V2_1__widen_provider_columns.sql",
+                    Vendor.POSTGRES_ONLY),
+            new Migration(
+                    "2.1",
+                    "widen provider columns (mysql/mariadb)",
+                    "db/migration-mysql/V2_1__widen_provider_columns.sql",
+                    Vendor.MYSQL_ONLY),
+            new Migration("3", "email unique constraint", "db/migration/V3__email_unique.sql", Vendor.ANY),
+            new Migration("4", "spring session tables", "db/migration/V4__spring_session.sql", Vendor.EXCEPT_MYSQL),
+            new Migration(
+                    "4",
+                    "spring session tables (mysql/mariadb)",
+                    "db/migration-mysql/V4__spring_session.sql",
+                    Vendor.MYSQL_ONLY),
+            new Migration("5", "unified rule shape", "db/migration/V5__unified_rule_shape.sql", Vendor.EXCEPT_MYSQL),
+            new Migration(
+                    "5",
+                    "unified rule shape (mysql/mariadb)",
+                    "db/migration-mysql/V5__unified_rule_shape.sql",
+                    Vendor.MYSQL_ONLY),
+            new Migration("6", "repo permissions FK", "db/migration/V6__repo_permissions_fk.sql", Vendor.ANY),
             new Migration(
                     "7",
                     "rename operations to operation",
                     "db/migration/V7__rename_operations_to_operation.sql",
-                    false),
-            new Migration("8", "user ssh keys", "db/migration/V8__ssh_keys.sql", false),
-            new Migration("9", "permission groups", "db/migration/V9__permission_groups.sql", false));
+                    Vendor.ANY),
+            new Migration("8", "user ssh keys", "db/migration/V8__ssh_keys.sql", Vendor.EXCEPT_MYSQL),
+            new Migration(
+                    "8", "user ssh keys (mysql/mariadb)", "db/migration-mysql/V8__ssh_keys.sql", Vendor.MYSQL_ONLY),
+            new Migration("9", "permission groups", "db/migration/V9__permission_groups.sql", Vendor.EXCEPT_MYSQL),
+            new Migration(
+                    "9",
+                    "permission groups (mysql/mariadb)",
+                    "db/migration-mysql/V9__permission_groups.sql",
+                    Vendor.MYSQL_ONLY));
 
     // ---------------------------------------------------------------------------
 
@@ -60,9 +105,10 @@ public class DatabaseMigrator {
         try (var conn = dataSource.getConnection()) {
             conn.setAutoCommit(false);
             boolean isPostgres = isPostgres(conn);
+            boolean isMysql = isMysqlFamily(conn);
             ensureMigrationsTable(conn);
             bootstrapFromFlyway(conn);
-            applyPending(conn, isPostgres);
+            applyPending(conn, isPostgres, isMysql);
             conn.commit();
         } catch (SQLException | IOException e) {
             throw new IllegalStateException("Database migration failed", e);
@@ -123,12 +169,13 @@ public class DatabaseMigrator {
     // Apply
     // ---------------------------------------------------------------------------
 
-    private static void applyPending(Connection conn, boolean isPostgres) throws SQLException, IOException {
+    private static void applyPending(Connection conn, boolean isPostgres, boolean isMysql)
+            throws SQLException, IOException {
         List<String> applied = appliedVersions(conn);
 
         List<Migration> pending = new ArrayList<>();
         for (Migration m : MIGRATIONS) {
-            if (m.postgresOnly() && !isPostgres) continue;
+            if (!applies(m.vendor(), isPostgres, isMysql)) continue;
             if (!applied.contains(m.version())) pending.add(m);
         }
         pending.sort((a, b) -> compareVersions(a.version(), b.version()));
@@ -170,9 +217,24 @@ public class DatabaseMigrator {
     // Utilities
     // ---------------------------------------------------------------------------
 
+    private static boolean applies(Vendor vendor, boolean isPostgres, boolean isMysql) {
+        return switch (vendor) {
+            case ANY -> true;
+            case POSTGRES_ONLY -> isPostgres;
+            case MYSQL_ONLY -> isMysql;
+            case EXCEPT_MYSQL -> !isMysql;
+        };
+    }
+
     private static boolean isPostgres(Connection conn) throws SQLException {
         String product = conn.getMetaData().getDatabaseProductName().toLowerCase(Locale.ROOT);
         return product.contains("postgresql");
+    }
+
+    /** MySQL and MariaDB are treated as one family for migration purposes — same schema, same DDL dialect. */
+    private static boolean isMysqlFamily(Connection conn) throws SQLException {
+        String product = conn.getMetaData().getDatabaseProductName().toLowerCase(Locale.ROOT);
+        return product.contains("mysql") || product.contains("mariadb");
     }
 
     private static boolean tableExists(Connection conn, String tableName) throws SQLException {

--- a/fogwall-core/src/main/resources/db/migration-mysql/V1__initial_schema.sql
+++ b/fogwall-core/src/main/resources/db/migration-mysql/V1__initial_schema.sql
@@ -1,0 +1,198 @@
+-- Initial schema for fogwall — MySQL/MariaDB variant.
+-- Identical to db/migration/V1__initial_schema.sql except standalone CREATE INDEX
+-- statements drop IF NOT EXISTS: MySQL never supported it on CREATE INDEX (only on
+-- ALTER TABLE ADD INDEX, since 8.0.29), and since this migration only ever runs once
+-- (tracked in schema_migrations) the guard isn't needed.
+
+CREATE TABLE IF NOT EXISTS push_records (
+    id              VARCHAR(36) PRIMARY KEY,
+    timestamp       TIMESTAMP NOT NULL,
+    url             VARCHAR(1024),
+    upstream_url    VARCHAR(1024),
+    provider        VARCHAR(100),
+    project         VARCHAR(255),
+    repo_name       VARCHAR(255),
+    branch          VARCHAR(512),
+    commit_from     VARCHAR(40),
+    commit_to       VARCHAR(40),
+    message         TEXT,
+    author          VARCHAR(255),
+    author_email    VARCHAR(255),
+    committer       VARCHAR(255),
+    committer_email VARCHAR(255),
+    push_user       VARCHAR(255),
+    resolved_user   VARCHAR(255),
+    user_email      VARCHAR(255),
+    method          VARCHAR(10),
+    status          VARCHAR(20) NOT NULL DEFAULT 'RECEIVED',
+    error_message   TEXT,
+    blocked_message TEXT,
+    auto_approved   BOOLEAN NOT NULL DEFAULT FALSE,
+    auto_rejected   BOOLEAN NOT NULL DEFAULT FALSE,
+    scm_username    VARCHAR(255),
+    forwarded_at    TIMESTAMP NULL
+);
+
+CREATE TABLE IF NOT EXISTS push_steps (
+    id              VARCHAR(36) PRIMARY KEY,
+    push_id         VARCHAR(36) NOT NULL REFERENCES push_records(id) ON DELETE CASCADE,
+    step_name       VARCHAR(255) NOT NULL,
+    step_order      INT NOT NULL,
+    status          VARCHAR(20) NOT NULL DEFAULT 'PASS',
+    content         TEXT,
+    error_message   TEXT,
+    blocked_message TEXT,
+    logs            TEXT,
+    timestamp       TIMESTAMP NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS push_commits (
+    push_id         VARCHAR(36) NOT NULL REFERENCES push_records(id) ON DELETE CASCADE,
+    sha             VARCHAR(40) NOT NULL,
+    parent_sha      VARCHAR(40),
+    author_name     VARCHAR(255),
+    author_email    VARCHAR(255),
+    committer_name  VARCHAR(255),
+    committer_email VARCHAR(255),
+    message         TEXT,
+    commit_date     TIMESTAMP NULL,
+    signature       TEXT,
+    signed_off_by   TEXT,
+    PRIMARY KEY (push_id, sha)
+);
+
+CREATE TABLE IF NOT EXISTS push_attestations (
+    push_id             VARCHAR(36) NOT NULL REFERENCES push_records(id) ON DELETE CASCADE,
+    type                VARCHAR(20) NOT NULL,
+    reviewer_username   VARCHAR(255),
+    reviewer_email      VARCHAR(255),
+    reason              TEXT,
+    automated           BOOLEAN NOT NULL DEFAULT FALSE,
+    self_approval       BOOLEAN NOT NULL DEFAULT FALSE,
+    timestamp           TIMESTAMP NOT NULL,
+    answers             TEXT,
+    PRIMARY KEY (push_id, type, timestamp)
+);
+
+-- ---------------------------------------------------------------------------
+-- User accounts
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS proxy_users (
+    username      VARCHAR(255) PRIMARY KEY,
+    password_hash VARCHAR(255),
+    roles         VARCHAR(255) NOT NULL DEFAULT 'USER'
+);
+
+CREATE TABLE IF NOT EXISTS user_emails (
+    username    VARCHAR(255) NOT NULL REFERENCES proxy_users(username) ON DELETE CASCADE,
+    email       VARCHAR(255) NOT NULL,
+    verified    BOOLEAN      NOT NULL DEFAULT FALSE,
+    auth_source VARCHAR(20)  NOT NULL DEFAULT 'local',
+    locked      BOOLEAN      NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (username, email)
+);
+
+CREATE TABLE IF NOT EXISTS user_scm_identities (
+    username         VARCHAR(255) NOT NULL REFERENCES proxy_users(username) ON DELETE CASCADE,
+    provider         VARCHAR(100) NOT NULL,
+    scm_username     VARCHAR(255) NOT NULL,
+    verified         BOOLEAN NOT NULL DEFAULT FALSE,
+    -- provider is VARCHAR(100) here (widened to 300 by V2_1, which also re-declares this PRIMARY
+    -- KEY with a prefix — see the comment there for why).
+    PRIMARY KEY (username, provider, scm_username),
+    UNIQUE (provider, scm_username)
+);
+
+CREATE INDEX idx_user_emails_email ON user_emails(email);
+
+-- ---------------------------------------------------------------------------
+-- Access control rules (allow/deny by provider, owner, name, or slug pattern)
+--
+-- owner/name/slug match the {owner}/{repo} URL shape used by GitHub, GitLab,
+-- Gitea, Codeberg, and Forgejo. Generic providers with arbitrary URL paths
+-- should use slug with a glob pattern and leave owner/name NULL.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS access_rules (
+    id          VARCHAR(36)  PRIMARY KEY,
+    provider    VARCHAR(100),               -- NULL = applies to all providers
+    slug        VARCHAR(512),               -- /owner/repo glob pattern; NULL = not used
+    owner       VARCHAR(255),               -- owner/org glob pattern; NULL = not used
+    name        VARCHAR(255),               -- repo name glob pattern; NULL = not used
+    access      VARCHAR(10)  NOT NULL DEFAULT 'ALLOW',  -- ALLOW or DENY
+    operations  VARCHAR(10)  NOT NULL DEFAULT 'BOTH',    -- FETCH, PUSH, or BOTH
+    description TEXT,
+    enabled     BOOLEAN      NOT NULL DEFAULT TRUE,
+    rule_order  INT          NOT NULL DEFAULT 100,
+    source      VARCHAR(10)  NOT NULL DEFAULT 'DB'      -- CONFIG (seeded from YAML) or DB (created via API)
+);
+
+-- ---------------------------------------------------------------------------
+-- Fetch activity log (lightweight; no steps/commits/attestations)
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS fetch_records (
+    id            VARCHAR(36)  PRIMARY KEY,
+    timestamp     TIMESTAMP    NOT NULL,
+    provider      VARCHAR(100),
+    owner         VARCHAR(255),
+    repo_name     VARCHAR(255),
+    result        VARCHAR(10)  NOT NULL,    -- ALLOWED or BLOCKED
+    push_username VARCHAR(255),             -- HTTP Basic username (arbitrary; see GIT_USERNAME memory)
+    resolved_user VARCHAR(255) REFERENCES proxy_users(username) ON DELETE SET NULL
+);
+
+-- ---------------------------------------------------------------------------
+-- SCM token identity cache
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS scm_token_cache (
+    token_hash      VARCHAR(128) NOT NULL,
+    provider        VARCHAR(100) NOT NULL,
+    proxy_username  VARCHAR(255) NOT NULL,
+    cached_at       TIMESTAMP    NOT NULL,
+    PRIMARY KEY (token_hash, provider)
+);
+
+-- ---------------------------------------------------------------------------
+-- Per-repo push and approval authorization (issue #47)
+--
+-- A grant says "username may perform operations on repos matching path at provider".
+-- path is a /owner/repo pattern; path_type controls matching: LITERAL, GLOB, or REGEX.
+-- operations: PUSH, REVIEW, PUSH_AND_REVIEW, or SELF_CERTIFY.
+-- Fail-closed: if no grant rows exist for a (provider, path) the request is denied.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS repo_permissions (
+    id          VARCHAR(36)  PRIMARY KEY,
+    username    VARCHAR(255) NOT NULL,
+    provider    VARCHAR(100) NOT NULL,
+    path        VARCHAR(512) NOT NULL,
+    path_type   VARCHAR(10)  NOT NULL DEFAULT 'LITERAL',      -- LITERAL | GLOB | REGEX
+    operations  VARCHAR(20)  NOT NULL DEFAULT 'PUSH',         -- PUSH | REVIEW | PUSH_AND_REVIEW | SELF_CERTIFY
+    source      VARCHAR(10)  NOT NULL DEFAULT 'DB'            -- CONFIG | DB
+);
+
+CREATE INDEX idx_repo_permissions_username ON repo_permissions(username);
+CREATE INDEX idx_repo_permissions_provider ON repo_permissions(provider);
+
+-- ---------------------------------------------------------------------------
+-- Indexes for common queries
+CREATE INDEX idx_push_records_status ON push_records(status);
+CREATE INDEX idx_push_records_project ON push_records(project);
+CREATE INDEX idx_push_records_repo ON push_records(repo_name);
+CREATE INDEX idx_push_records_user ON push_records(push_user);
+CREATE INDEX idx_push_records_timestamp ON push_records(timestamp);
+CREATE INDEX idx_push_steps_push_id ON push_steps(push_id);
+CREATE INDEX idx_push_commits_push_id ON push_commits(push_id);
+-- Prefix-indexed on branch: full (commit_to, branch, repo_name) exceeds InnoDB's 3072-byte key
+-- limit under utf8mb4 (40 + 512 + 255 chars * 4 bytes ~= 3228 bytes). 255 chars is ample for
+-- this index's purpose (narrowing by commit_to first; branch/repo_name add selectivity).
+CREATE INDEX idx_push_records_commit_to ON push_records(commit_to, branch(255), repo_name);
+CREATE INDEX idx_access_rules_provider ON access_rules(provider);
+CREATE INDEX idx_fetch_records_timestamp ON fetch_records(timestamp);
+-- Prefix-indexed on owner/repo_name, leaving headroom for V2_1's later widening of `provider`
+-- to VARCHAR(300) (100 -> 300 chars * 4 bytes/char under utf8mb4 alone is 1200 bytes; full
+-- unprefixed owner/repo_name would push the combined index past InnoDB's 3072-byte key limit).
+CREATE INDEX idx_fetch_records_provider_repo ON fetch_records(provider, owner(150), repo_name(150));

--- a/fogwall-core/src/main/resources/db/migration-mysql/V2_1__widen_provider_columns.sql
+++ b/fogwall-core/src/main/resources/db/migration-mysql/V2_1__widen_provider_columns.sql
@@ -1,0 +1,25 @@
+-- Widen provider columns to accommodate type/host values where host can be up
+-- to 253 characters (RFC 1035). MySQL/MariaDB variant of
+-- db/migration-postgresql/V2_1__widen_provider_columns.sql — MySQL has no
+-- ALTER COLUMN ... TYPE syntax, so the full column definition is restated via
+-- MODIFY COLUMN instead. H2 (dev/test) uses VARCHAR(100) from V1 and does not
+-- need widening (always a fresh schema).
+
+ALTER TABLE push_records        MODIFY COLUMN provider VARCHAR(300);
+
+-- user_scm_identities has a PRIMARY KEY spanning (username, provider, scm_username). At
+-- username(255) + scm_username(255), a full-width 300-char provider would push the key past
+-- InnoDB's 3072-byte key limit, so the PK is redeclared here with a 240-char prefix on provider.
+-- The UNIQUE(provider, scm_username) constraint stays full-width, so true duplicates are still
+-- always caught; a prefix collision on the PK alone would only cause a spurious duplicate-key
+-- rejection on insert (fails safe, no silent data mixing), and only for two providers identical
+-- in their first 240 characters — not realistic for type/host provider strings.
+ALTER TABLE user_scm_identities
+    DROP PRIMARY KEY,
+    MODIFY COLUMN provider VARCHAR(300) NOT NULL,
+    ADD PRIMARY KEY (username, provider(240), scm_username);
+
+ALTER TABLE access_rules        MODIFY COLUMN provider VARCHAR(300);
+ALTER TABLE fetch_records       MODIFY COLUMN provider VARCHAR(300);
+ALTER TABLE scm_token_cache     MODIFY COLUMN provider VARCHAR(300) NOT NULL;
+ALTER TABLE repo_permissions    MODIFY COLUMN provider VARCHAR(300) NOT NULL;

--- a/fogwall-core/src/main/resources/db/migration-mysql/V4__spring_session.sql
+++ b/fogwall-core/src/main/resources/db/migration-mysql/V4__spring_session.sql
@@ -1,0 +1,30 @@
+-- Spring Session JDBC store tables — MySQL/MariaDB variant of db/migration/V4__spring_session.sql.
+-- Mirrors Spring Session's own schema-mysql.sql: BLOB instead of BYTEA (MySQL/MariaDB have no BYTEA
+-- type), and CREATE INDEX without IF NOT EXISTS (unsupported by MySQL as a standalone statement;
+-- not needed since this migration only ever runs once, tracked in schema_migrations).
+-- Created unconditionally on all JDBC backends so the schema is consistent regardless of whether
+-- server.session-store=jdbc is currently configured. Tables are unused when another store is selected.
+
+CREATE TABLE IF NOT EXISTS SPRING_SESSION (
+    PRIMARY_ID            CHAR(36)     NOT NULL,
+    SESSION_ID             CHAR(36)     NOT NULL,
+    CREATION_TIME          BIGINT       NOT NULL,
+    LAST_ACCESS_TIME       BIGINT       NOT NULL,
+    MAX_INACTIVE_INTERVAL  INT          NOT NULL,
+    EXPIRY_TIME            BIGINT       NOT NULL,
+    PRINCIPAL_NAME         VARCHAR(100) DEFAULT NULL,
+    CONSTRAINT SPRING_SESSION_PK PRIMARY KEY (PRIMARY_ID)
+) ENGINE=InnoDB ROW_FORMAT=DYNAMIC;
+
+CREATE UNIQUE INDEX SPRING_SESSION_IX1 ON SPRING_SESSION (SESSION_ID);
+CREATE INDEX SPRING_SESSION_IX2 ON SPRING_SESSION (EXPIRY_TIME);
+CREATE INDEX SPRING_SESSION_IX3 ON SPRING_SESSION (PRINCIPAL_NAME);
+
+CREATE TABLE IF NOT EXISTS SPRING_SESSION_ATTRIBUTES (
+    SESSION_PRIMARY_ID CHAR(36)     NOT NULL,
+    ATTRIBUTE_NAME     VARCHAR(200) NOT NULL,
+    ATTRIBUTE_BYTES    BLOB         NOT NULL,
+    CONSTRAINT SPRING_SESSION_ATTRIBUTES_PK PRIMARY KEY (SESSION_PRIMARY_ID, ATTRIBUTE_NAME),
+    CONSTRAINT SPRING_SESSION_ATTRIBUTES_FK FOREIGN KEY (SESSION_PRIMARY_ID)
+        REFERENCES SPRING_SESSION (PRIMARY_ID) ON DELETE CASCADE
+) ENGINE=InnoDB ROW_FORMAT=DYNAMIC;

--- a/fogwall-core/src/main/resources/db/migration-mysql/V5__unified_rule_shape.sql
+++ b/fogwall-core/src/main/resources/db/migration-mysql/V5__unified_rule_shape.sql
@@ -1,0 +1,50 @@
+-- Unify access_rules and repo_permissions onto a common (target, match_value, match_type) shape.
+-- MySQL/MariaDB variant of db/migration/V5__unified_rule_shape.sql — MySQL has no
+-- ALTER COLUMN ... SET NOT NULL syntax, so the full column definition is restated via
+-- MODIFY COLUMN instead, after the data migration populates every row.
+
+-- ---------------------------------------------------------------------------
+-- access_rules
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE access_rules ADD COLUMN target      VARCHAR(10);
+ALTER TABLE access_rules ADD COLUMN match_value VARCHAR(512);
+ALTER TABLE access_rules ADD COLUMN match_type  VARCHAR(10);
+
+-- Migrate slug rows
+UPDATE access_rules SET target = 'SLUG',  match_value = slug  WHERE slug  IS NOT NULL;
+UPDATE access_rules SET target = 'OWNER', match_value = owner WHERE owner IS NOT NULL;
+UPDATE access_rules SET target = 'NAME',  match_value = name  WHERE name  IS NOT NULL;
+
+-- Rows with a 'regex:' prefix become REGEX; strip the prefix from match_value
+UPDATE access_rules
+    SET match_type = 'REGEX', match_value = SUBSTRING(match_value, 8)
+    WHERE match_value LIKE 'regex:%';
+
+-- Everything else was implicitly glob
+UPDATE access_rules SET match_type = 'GLOB' WHERE match_type IS NULL;
+
+-- Apply NOT NULL after data migration
+ALTER TABLE access_rules MODIFY COLUMN target      VARCHAR(10)  NOT NULL;
+ALTER TABLE access_rules MODIFY COLUMN match_value VARCHAR(512) NOT NULL;
+ALTER TABLE access_rules MODIFY COLUMN match_type  VARCHAR(10)  NOT NULL;
+
+ALTER TABLE access_rules DROP COLUMN slug;
+ALTER TABLE access_rules DROP COLUMN owner;
+ALTER TABLE access_rules DROP COLUMN name;
+
+-- ---------------------------------------------------------------------------
+-- repo_permissions
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE repo_permissions ADD COLUMN target      VARCHAR(10)  NOT NULL DEFAULT 'SLUG';
+ALTER TABLE repo_permissions ADD COLUMN match_value VARCHAR(512);
+ALTER TABLE repo_permissions ADD COLUMN match_type  VARCHAR(10);
+
+UPDATE repo_permissions SET match_value = path, match_type = path_type;
+
+ALTER TABLE repo_permissions MODIFY COLUMN match_value VARCHAR(512) NOT NULL;
+ALTER TABLE repo_permissions MODIFY COLUMN match_type  VARCHAR(10)  NOT NULL;
+
+ALTER TABLE repo_permissions DROP COLUMN path;
+ALTER TABLE repo_permissions DROP COLUMN path_type;

--- a/fogwall-core/src/main/resources/db/migration-mysql/V8__ssh_keys.sql
+++ b/fogwall-core/src/main/resources/db/migration-mysql/V8__ssh_keys.sql
@@ -1,0 +1,25 @@
+-- SSH public keys associated with proxy users — MySQL/MariaDB variant of db/migration/V8__ssh_keys.sql.
+-- Identical except standalone CREATE INDEX statements drop IF NOT EXISTS (unsupported by MySQL; not
+-- needed since this migration only ever runs once, tracked in schema_migrations).
+CREATE TABLE IF NOT EXISTS user_ssh_keys (
+    id          VARCHAR(36)  PRIMARY KEY,
+    username    VARCHAR(255) NOT NULL REFERENCES proxy_users(username) ON DELETE CASCADE,
+    fingerprint VARCHAR(255) NOT NULL UNIQUE,
+    public_key  TEXT         NOT NULL,
+    label       VARCHAR(255),
+    created_at  TIMESTAMP    NOT NULL
+);
+
+CREATE INDEX idx_user_ssh_keys_username ON user_ssh_keys(username);
+
+-- Cache of SSH public key fingerprints fetched from upstream SCM providers.
+-- Keyed by (provider, scm_login); the fingerprints column stores a comma-separated
+-- list of SHA-256 fingerprint strings. Entries are re-fetched after cached_at exceeds
+-- the configured TTL (default 7 days).
+CREATE TABLE IF NOT EXISTS ssh_fingerprint_cache (
+    provider    VARCHAR(100) NOT NULL,
+    scm_login   VARCHAR(255) NOT NULL,
+    fingerprints TEXT        NOT NULL,
+    cached_at   TIMESTAMP    NOT NULL,
+    PRIMARY KEY (provider, scm_login)
+);

--- a/fogwall-core/src/main/resources/db/migration-mysql/V9__permission_groups.sql
+++ b/fogwall-core/src/main/resources/db/migration-mysql/V9__permission_groups.sql
@@ -1,0 +1,31 @@
+-- Named permission groups — MySQL/MariaDB variant of db/migration/V9__permission_groups.sql.
+-- Identical except standalone CREATE INDEX statements drop IF NOT EXISTS (unsupported by MySQL; not
+-- needed since this migration only ever runs once, tracked in schema_migrations).
+CREATE TABLE IF NOT EXISTS permission_groups (
+    id          VARCHAR(36)  PRIMARY KEY,
+    name        VARCHAR(255) NOT NULL UNIQUE,
+    description VARCHAR(512),
+    source      VARCHAR(10)  NOT NULL DEFAULT 'DB'   -- CONFIG | DB
+);
+
+-- Repository permission rules attached to a group (same shape as repo_permissions but group-scoped).
+CREATE TABLE IF NOT EXISTS group_permissions (
+    id          VARCHAR(36)  PRIMARY KEY,
+    group_id    VARCHAR(36)  NOT NULL REFERENCES permission_groups(id) ON DELETE CASCADE,
+    provider    VARCHAR(100) NOT NULL,
+    target      VARCHAR(20)  NOT NULL DEFAULT 'SLUG',
+    match_value VARCHAR(512) NOT NULL,
+    match_type  VARCHAR(10)  NOT NULL DEFAULT 'GLOB',
+    operation   VARCHAR(20)  NOT NULL DEFAULT 'PUSH'
+);
+
+-- Group membership: which users belong to which groups.
+CREATE TABLE IF NOT EXISTS group_members (
+    group_id    VARCHAR(36)  NOT NULL REFERENCES permission_groups(id) ON DELETE CASCADE,
+    username    VARCHAR(255) NOT NULL REFERENCES proxy_users(username) ON DELETE CASCADE,
+    PRIMARY KEY (group_id, username)
+);
+
+CREATE INDEX idx_group_permissions_group_id ON group_permissions(group_id);
+CREATE INDEX idx_group_permissions_provider ON group_permissions(provider);
+CREATE INDEX idx_group_members_username ON group_members(username);

--- a/fogwall-core/src/test/java/com/rbc/fogwall/db/jdbc/DatabaseMigratorTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/db/jdbc/DatabaseMigratorTest.java
@@ -1,0 +1,53 @@
+package com.rbc.fogwall.db.jdbc;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for the H2/Postgres migration selection after {@link DatabaseMigrator} was generalized to support
+ * MySQL/MariaDB (adding a {@code Vendor} tag alongside the existing postgres-only flag). Adding new
+ * {@code MYSQL_ONLY}/{@code EXCEPT_MYSQL} entries must not change which migrations a non-MySQL connection (H2 here,
+ * standing in for H2/Postgres) selects or applies.
+ */
+class DatabaseMigratorTest {
+
+    @Test
+    void migrate_onH2_appliesOnlySharedAndExceptMysqlMigrations() throws Exception {
+        DataSource dataSource = DataSourceFactory.h2InMemory("migrator-test-" + UUID.randomUUID());
+        DatabaseMigrator.migrate(dataSource);
+
+        assertEquals(
+                Set.of("1", "2", "3", "4", "5", "6", "7", "8", "9"),
+                appliedVersions(dataSource),
+                "H2 must never select MYSQL_ONLY entries, and the 2.1 postgres-only widening migration must not "
+                        + "apply to H2 either");
+    }
+
+    @Test
+    void migrate_calledTwice_isIdempotent() throws Exception {
+        DataSource dataSource = DataSourceFactory.h2InMemory("migrator-test-" + UUID.randomUUID());
+        DatabaseMigrator.migrate(dataSource);
+        Set<String> firstRun = appliedVersions(dataSource);
+
+        assertDoesNotThrow(() -> DatabaseMigrator.migrate(dataSource));
+        assertEquals(firstRun, appliedVersions(dataSource));
+    }
+
+    private static Set<String> appliedVersions(DataSource dataSource) throws Exception {
+        Set<String> versions = new HashSet<>();
+        try (Connection conn = dataSource.getConnection();
+                Statement st = conn.createStatement();
+                ResultSet rs = st.executeQuery("SELECT version FROM schema_migrations")) {
+            while (rs.next()) versions.add(rs.getString(1));
+        }
+        return versions;
+    }
+}

--- a/fogwall-core/src/test/java/com/rbc/fogwall/db/jdbc/JdbcMariadbSmokeTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/db/jdbc/JdbcMariadbSmokeTest.java
@@ -1,0 +1,104 @@
+package com.rbc.fogwall.db.jdbc;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.rbc.fogwall.db.PushStore;
+import com.rbc.fogwall.db.PushStoreFactory;
+import com.rbc.fogwall.db.model.PushRecord;
+import com.rbc.fogwall.db.model.PushStatus;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Smoke test proving the MySQL-family migration files ({@code db/migration-mysql/}) apply cleanly against a real
+ * MariaDB server and that {@link JdbcPushStore} works on top of the resulting schema.
+ *
+ * <p>MariaDB and MySQL share one migration family ({@link DatabaseMigrator}'s {@code MYSQL_ONLY} vendor tag covers
+ * both), but the two engines diverge on some DDL details (e.g. MariaDB supports {@code CREATE INDEX IF NOT EXISTS};
+ * MySQL does not) — this test exists specifically to catch a case where the shared mysql-family SQL happens to work on
+ * one engine but not the other. See {@link JdbcMysqlSmokeTest} for the MySQL counterpart.
+ */
+@Testcontainers
+@Tag("integration")
+class JdbcMariadbSmokeTest {
+
+    @Container
+    static final MariaDBContainer<?> MARIADB = new MariaDBContainer<>(
+            DockerImageName.parse("docker.io/mariadb:11.4").asCompatibleSubstituteFor("mariadb"));
+
+    DataSource dataSource;
+    PushStore store;
+
+    @BeforeEach
+    void setUp() {
+        dataSource = DataSourceFactory.fromUrl(MARIADB.getJdbcUrl(), MARIADB.getUsername(), MARIADB.getPassword());
+        store = PushStoreFactory.fromDataSource(dataSource);
+    }
+
+    @Test
+    void migrate_appliesCleanlyAndPushStoreRoundTrips() {
+        String id = UUID.randomUUID().toString();
+        store.save(PushRecord.builder()
+                .id(id)
+                .project("org")
+                .repoName("repo")
+                .branch("refs/heads/main")
+                .status(PushStatus.RECEIVED)
+                .timestamp(Instant.now())
+                .build());
+
+        var found = store.findById(id);
+        assertTrue(found.isPresent());
+        assertEquals("repo", found.get().getRepoName());
+    }
+
+    @Test
+    void migrate_widenedProviderColumn_acceptsLongValue() {
+        String longProvider = "github/" + "a".repeat(280);
+        String id = UUID.randomUUID().toString();
+        store.save(PushRecord.builder()
+                .id(id)
+                .provider(longProvider)
+                .project("org")
+                .repoName("repo")
+                .branch("refs/heads/main")
+                .status(PushStatus.RECEIVED)
+                .timestamp(Instant.now())
+                .build());
+
+        assertEquals(longProvider, store.findById(id).orElseThrow().getProvider());
+    }
+
+    @Test
+    void migrate_springSessionTables_exist() throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                Statement st = conn.createStatement();
+                ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM SPRING_SESSION_ATTRIBUTES")) {
+            assertTrue(rs.next());
+            assertEquals(0, rs.getInt(1));
+        }
+    }
+
+    @Test
+    void migrate_unifiedRuleShapeColumns_areNotNull() throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                Statement st = conn.createStatement()) {
+            assertThrows(
+                    SQLException.class,
+                    () -> st.executeUpdate("INSERT INTO access_rules (id, access, operation) VALUES ('"
+                            + UUID.randomUUID() + "', 'ALLOW', 'BOTH')"));
+        }
+    }
+}

--- a/fogwall-core/src/test/java/com/rbc/fogwall/db/jdbc/JdbcMysqlSmokeTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/db/jdbc/JdbcMysqlSmokeTest.java
@@ -1,0 +1,107 @@
+package com.rbc.fogwall.db.jdbc;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.rbc.fogwall.db.PushStore;
+import com.rbc.fogwall.db.PushStoreFactory;
+import com.rbc.fogwall.db.model.PushRecord;
+import com.rbc.fogwall.db.model.PushStatus;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Smoke test proving the MySQL-family migration files ({@code db/migration-mysql/}) apply cleanly against a real MySQL
+ * server and that {@link JdbcPushStore} works on top of the resulting schema.
+ *
+ * <p>Not a full contract test — {@link JdbcPushStoreIntegrationTest} covers CRUD semantics exhaustively against H2;
+ * this only needs to prove MySQL-specific SQL (BLOB instead of BYTEA, MODIFY COLUMN instead of ALTER COLUMN ... SET NOT
+ * NULL, plain CREATE INDEX instead of CREATE INDEX IF NOT EXISTS) doesn't break on the real engine.
+ */
+@Testcontainers
+@Tag("integration")
+class JdbcMysqlSmokeTest {
+
+    @Container
+    static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>(DockerImageName.parse("docker.io/mysql:8.4").asCompatibleSubstituteFor("mysql"));
+
+    DataSource dataSource;
+    PushStore store;
+
+    @BeforeEach
+    void setUp() {
+        dataSource = DataSourceFactory.fromUrl(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword());
+        store = PushStoreFactory.fromDataSource(dataSource);
+    }
+
+    @Test
+    void migrate_appliesCleanlyAndPushStoreRoundTrips() {
+        String id = UUID.randomUUID().toString();
+        store.save(PushRecord.builder()
+                .id(id)
+                .project("org")
+                .repoName("repo")
+                .branch("refs/heads/main")
+                .status(PushStatus.RECEIVED)
+                .timestamp(Instant.now())
+                .build());
+
+        var found = store.findById(id);
+        assertTrue(found.isPresent());
+        assertEquals("repo", found.get().getRepoName());
+    }
+
+    @Test
+    void migrate_widenedProviderColumn_acceptsLongValue() {
+        // V2.1 (mysql variant) widens `provider` to VARCHAR(300) via MODIFY COLUMN; a fresh V1 schema alone caps
+        // it at VARCHAR(100).
+        String longProvider = "github/" + "a".repeat(280);
+        String id = UUID.randomUUID().toString();
+        store.save(PushRecord.builder()
+                .id(id)
+                .provider(longProvider)
+                .project("org")
+                .repoName("repo")
+                .branch("refs/heads/main")
+                .status(PushStatus.RECEIVED)
+                .timestamp(Instant.now())
+                .build());
+
+        assertEquals(longProvider, store.findById(id).orElseThrow().getProvider());
+    }
+
+    @Test
+    void migrate_springSessionTables_exist() throws SQLException {
+        // V4 (mysql variant) replaces Postgres's BYTEA with BLOB — confirm the table actually got created.
+        try (Connection conn = dataSource.getConnection();
+                Statement st = conn.createStatement();
+                ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM SPRING_SESSION_ATTRIBUTES")) {
+            assertTrue(rs.next());
+            assertEquals(0, rs.getInt(1));
+        }
+    }
+
+    @Test
+    void migrate_unifiedRuleShapeColumns_areNotNull() throws SQLException {
+        // V5 (mysql variant) uses MODIFY COLUMN to apply NOT NULL after backfill — confirm it stuck.
+        try (Connection conn = dataSource.getConnection();
+                Statement st = conn.createStatement()) {
+            assertThrows(
+                    SQLException.class,
+                    () -> st.executeUpdate("INSERT INTO access_rules (id, access, operation) VALUES ('"
+                            + UUID.randomUUID() + "', 'ALLOW', 'BOTH')"));
+        }
+    }
+}

--- a/fogwall-dashboard/build.gradle
+++ b/fogwall-dashboard/build.gradle
@@ -181,6 +181,8 @@ dependencies {
     // Database drivers at runtime (whichever store is configured)
     runtimeOnly "com.h2database:h2:${h2Version}"
     runtimeOnly "org.postgresql:postgresql:${postgresVersion}"
+    runtimeOnly "com.mysql:mysql-connector-j:${mysqlVersion}"
+    runtimeOnly "org.mariadb.jdbc:mariadb-java-client:${mariadbVersion}"
     // MongoDB driver — compile-scoped because MongoSessionRepository uses the sync client directly.
     implementation "org.mongodb:mongodb-driver-sync:${mongoVersion}"
 

--- a/fogwall-server/build.gradle
+++ b/fogwall-server/build.gradle
@@ -73,6 +73,8 @@ dependencies {
     // Database drivers - include all so standalone Jetty server can use any backend
     runtimeOnly "com.h2database:h2:${h2Version}"
     runtimeOnly "org.postgresql:postgresql:${postgresVersion}"
+    runtimeOnly "com.mysql:mysql-connector-j:${mysqlVersion}"
+    runtimeOnly "org.mariadb.jdbc:mariadb-java-client:${mariadbVersion}"
     runtimeOnly "org.mongodb:mongodb-driver-sync:${mongoVersion}"
 
     // Lombok

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/DatabaseConfig.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/DatabaseConfig.java
@@ -7,18 +7,27 @@ import lombok.Data;
 @Data
 public class DatabaseConfig {
 
-    /** Storage backend. Values: {@code h2-mem} (default), {@code h2-file}, {@code postgres}, {@code mongo}. */
+    /**
+     * Storage backend. Values: {@code h2-mem} (default), {@code h2-file}, {@code postgres}, {@code mysql},
+     * {@code mariadb}, {@code mongo}.
+     */
     private String type = "h2-mem";
 
-    /** Database name. Used by h2-mem, h2-file, postgres, mongo. */
+    /** Database name. Used by h2-mem, h2-file, postgres, mysql, mariadb, mongo. */
     private String name = "fogwall";
 
     /** File path. Used by h2-file (no extension). */
     private String path = "";
 
-    // --- postgres ---
+    // --- postgres / mysql / mariadb ---
     private String host = "localhost";
+
+    /**
+     * Default is PostgreSQL's port (5432). MySQL and MariaDB default to 3306 — set this explicitly when {@code type} is
+     * {@code mysql} or {@code mariadb} unless the server actually listens on 5432.
+     */
     private int port = 5432;
+
     private String username = "";
     private String password = "";
 
@@ -28,6 +37,8 @@ public class DatabaseConfig {
      *
      * <ul>
      *   <li><b>postgres</b> — JDBC URL, e.g. {@code jdbc:postgresql://host:5432/db?sslmode=verify-full}
+     *   <li><b>mysql</b> — JDBC URL, e.g. {@code jdbc:mysql://host:3306/db?useSSL=true}
+     *   <li><b>mariadb</b> — JDBC URL, e.g. {@code jdbc:mariadb://host:3306/db?useSsl=true}
      *   <li><b>mongo</b> — MongoDB connection URI, e.g. {@code mongodb://user:pass@host:27017/db?tls=true}
      * </ul>
      *
@@ -36,6 +47,6 @@ public class DatabaseConfig {
      */
     private String url = "";
 
-    /** HikariCP connection pool tuning. Applies to all JDBC backends (h2-mem, h2-file, postgres). */
+    /** HikariCP connection pool tuning. Applies to all JDBC backends (h2-mem, h2-file, postgres, mysql, mariadb). */
     private PoolConfig pool = new PoolConfig();
 }

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
@@ -534,11 +534,12 @@ public class JettyConfigurationBuilder {
         DatabaseConfig db = config.getDatabase();
         log.info("Initializing push store: type={}", db.getType());
         cachedPushStore = switch (db.getType()) {
-            case "h2-mem", "h2-file", "postgres" -> PushStoreFactory.fromDataSource(requireJdbcDataSource());
+            case "h2-mem", "h2-file", "postgres", "mysql", "mariadb" ->
+                PushStoreFactory.fromDataSource(requireJdbcDataSource());
             case "mongo" -> requireMongoStoreFactory().pushStore();
             default ->
-                throw new IllegalArgumentException(
-                        "Unknown database type: " + db.getType() + ". Supported: h2-mem, h2-file, postgres, mongo");
+                throw new IllegalArgumentException("Unknown database type: " + db.getType()
+                        + ". Supported: h2-mem, h2-file, postgres, mysql, mariadb, mongo");
         };
         return cachedPushStore;
     }
@@ -860,10 +861,42 @@ public class JettyConfigurationBuilder {
                     yield DataSourceFactory.postgres(
                             db.getHost(), db.getPort(), db.getName(), db.getUsername(), db.getPassword(), pool);
                 }
+                case "mysql" -> {
+                    if (!db.getUrl().isBlank()) {
+                        log.info("MySQL: using connection URL (individual host/port/name fields ignored)");
+                        yield DataSourceFactory.fromUrl(db.getUrl(), db.getUsername(), db.getPassword(), pool);
+                    }
+                    warnIfDefaultPostgresPort(db, "mysql");
+                    yield DataSourceFactory.mysql(
+                            db.getHost(), db.getPort(), db.getName(), db.getUsername(), db.getPassword(), pool);
+                }
+                case "mariadb" -> {
+                    if (!db.getUrl().isBlank()) {
+                        log.info("MariaDB: using connection URL (individual host/port/name fields ignored)");
+                        yield DataSourceFactory.fromUrl(db.getUrl(), db.getUsername(), db.getPassword(), pool);
+                    }
+                    warnIfDefaultPostgresPort(db, "mariadb");
+                    yield DataSourceFactory.mariadb(
+                            db.getHost(), db.getPort(), db.getName(), db.getUsername(), db.getPassword(), pool);
+                }
                 default -> throw new IllegalStateException("No JDBC DataSource for db type: " + db.getType());
             };
         }
         return cachedDataSource;
+    }
+
+    /**
+     * {@code database.port} defaults to PostgreSQL's port (5432). Warn when that untouched default is about to be used
+     * for MySQL/MariaDB, which normally listen on 3306 — likely an operator oversight, not intent.
+     */
+    private static void warnIfDefaultPostgresPort(DatabaseConfig db, String type) {
+        if (db.getPort() == 5432) {
+            log.warn(
+                    "database.port is left at the PostgreSQL default (5432) for database.type={}; set it explicitly"
+                            + " (typically 3306) unless {} is actually listening on 5432.",
+                    type,
+                    type);
+        }
     }
 
     /**

--- a/gradle-allowed-licenses.json
+++ b/gradle-allowed-licenses.json
@@ -85,6 +85,8 @@
     { "moduleLicense": "GPL2 w/ CPE" },
     { "moduleLicense": "GNU General Public License, version 2 with the GNU Classpath Exception" },
     { "moduleLicense": "GNU General Public License, version 2, with the Classpath Exception" },
-    { "moduleLicense": "Classpath-exception" }
+    { "moduleLicense": "Classpath-exception" },
+
+    { "moduleLicense": "LGPL-2.1-or-later" }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `mysql` and `mariadb` as distinct `database.type` values, each with its own JDBC driver (`mysql-connector-j` / `mariadb-java-client`) — the two engines diverge in DDL syntax (e.g. MariaDB supports `CREATE INDEX IF NOT EXISTS`; MySQL does not) even though largely wire-compatible.
- `DatabaseMigrator` gains a `Vendor` tag (`ANY`, `POSTGRES_ONLY`, `MYSQL_ONLY`, `EXCEPT_MYSQL`) alongside the existing postgres-only flag, so MySQL/MariaDB-specific migration variants run without touching any already-applied migration file (verified via a regression test that H2/Postgres migration selection is unchanged).
- New `db/migration-mysql/` variants fix real MySQL/MariaDB incompatibilities found and fixed against live containers: `BYTEA` → `BLOB`, `ALTER COLUMN ... SET NOT NULL` → `MODIFY COLUMN`, `CREATE INDEX IF NOT EXISTS` → plain `CREATE INDEX`, and two InnoDB 3072-byte index key overflows (one composite index, one composite primary key) fixed with prefix indexes.
- Docker Compose overlays (`docker-compose.mysql.yml`, `docker-compose.mariadb.yml`) + services in the base compose file; `compose.sh --db mysql|mariadb` wrapper support.
- `docs/CONFIGURATION.md` updated with connection examples and a note that `database.port` defaults to Postgres's 5432 and needs to be set explicitly for MySQL/MariaDB.
- Testcontainers smoke tests against real MySQL and MariaDB engines, plus a regression test for the migrator's vendor selection.

## Test plan
- [x] `./gradlew build` — full multi-module build, spotless, jacoco coverage verification
- [x] `./gradlew :fogwall-core:test --tests "com.rbc.fogwall.db.jdbc.*"` — MySQL/MariaDB Testcontainers smoke tests pass
- [x] All 10 migrations applied manually against real `mysql:8.4` and `mariadb:11.4` containers
- [x] `docker compose --profile mysql|mariadb -f docker-compose.yml -f docker-compose.mysql.yml config` validates

closes #328

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>