### PR TITLE
feat: outbound proxy YAML config with Basic/Kerberos auth

### DIFF
--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -627,14 +627,11 @@ export NO_PROXY=localhost,127.0.0.1,*.internal.example.com
 
 fogwall reads these at startup and configures all three outbound paths accordingly. No YAML config is needed.
 
-Many organisations run a local proxy relay (cntlm, Alpaca) that handles NTLM/Kerberos authentication to the corporate
-proxy transparently. Point `HTTPS_PROXY` at the relay (e.g. `http://localhost:3128`) and fogwall will work without any
-auth configuration.
-
-<!-- prettier-ignore-start -->
-> [!NOTE]
-> Full proxy authentication (Basic, NTLM) in YAML config is tracked in [#158](https://github.com/RBC/fogwall/issues/158).
-<!-- prettier-ignore-end -->
+When the configured proxy requires authentication, set `server.outbound-proxy.auth` in YAML — see
+[Outbound proxy](CONFIGURATION.md#outbound-proxy) in the configuration reference for Basic and Kerberos options. NTLM is
+not supported as a scheme fogwall speaks directly: it's a deprecated protocol, and Jetty's HTTP client (used for
+transparent-proxy forwarding) has no NTLM support at all. Kerberos/Negotiate is the modern successor in Active-Directory
+environments and is supported natively across all three outbound paths.
 
 ### Connectivity diagnostics (dashboard)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -258,6 +258,59 @@ This applies to both proxy modes:
 - **Transparent proxy** — Jetty's `HttpClient` used for upstream forwarding
 - **Store-and-forward** — JGit's HTTP transport used for forwarding after local receipt
 
+## Outbound proxy
+
+For environments without direct internet access, fogwall can route its own outbound connections through a corporate HTTP
+proxy. This covers all three places fogwall makes outbound connections: store-and-forward upstream pushes (JGit
+Transport), transparent-proxy forwarding (Jetty `HttpClient`), and provider REST API calls (identity resolution, SSH key
+listing).
+
+```yaml
+server:
+  outbound-proxy:
+    https-proxy: http://proxy.example.com:8080
+    no-proxy: localhost,*.internal.example.com
+    auth:
+      type: none # none (default) | basic | kerberos
+```
+
+`http-proxy`, `https-proxy`, and `no-proxy` fall back to the `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` environment variables
+when left unset in YAML — an explicit YAML value always takes precedence. Leave `auth.type` at `none` (the default) when
+the configured proxy doesn't require fogwall to authenticate itself.
+
+### Proxy authentication
+
+When the configured proxy requires authentication, two schemes are supported:
+
+```yaml
+server:
+  outbound-proxy:
+    https-proxy: http://proxy.example.com:8080
+    auth:
+      type: basic
+      username: ${PROXY_USER}
+      password: ${PROXY_PASS}
+```
+
+```yaml
+server:
+  outbound-proxy:
+    https-proxy: http://proxy.example.com:8080
+    auth:
+      type: kerberos
+      # keytab-path and principal are both optional. Omitted (the default): fogwall authenticates using
+      # whatever Kerberos ticket is already in the OS's ticket cache — the common case on a machine that
+      # already has a live ticket from domain/SSO login. Set both only when fogwall should authenticate
+      # as its own service identity instead (e.g. a long-running headless deployment with no live session).
+      # keytab-path: /etc/fogwall/proxy.keytab
+      # principal: fogwall/host@CORP.EXAMPLE.COM
+```
+
+NTLM is intentionally not supported as a scheme fogwall speaks directly — it's a deprecated protocol, and Jetty's HTTP
+client (the transparent-proxy path) has no NTLM support at all and can't cleanly add it, since the reference NTLM
+implementation (jcifs) is LGPL-licensed and Jetty won't bundle it. Kerberos/Negotiate is the modern successor in Active
+Directory environments and is natively supported across all three outbound paths.
+
 ## Database
 
 ```yaml

--- a/fogwall-core/src/main/java/com/rbc/fogwall/net/FogwallHttpExecutor.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/net/FogwallHttpExecutor.java
@@ -1,0 +1,102 @@
+package com.rbc.fogwall.net;
+
+import org.apache.hc.client5.http.auth.AuthSchemeFactory;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.auth.SPNegoSchemeFactory;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.routing.DefaultProxyRoutePlanner;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.config.Lookup;
+import org.apache.hc.core5.http.config.RegistryBuilder;
+
+/**
+ * Shared HC5 client used by every {@link com.rbc.fogwall.provider.FogwallProvider} that makes REST API calls via the
+ * {@code org.apache.hc.client5.http.fluent} API (identity resolution, SSH key listing, etc.) — call sites use
+ * {@code Request.get(url).execute(FogwallHttpExecutor.instance())}.
+ *
+ * <p>Defaults to a plain unconfigured client (no proxy) so providers work unchanged when outbound proxying isn't
+ * configured. {@link #configure} is called once at startup by fogwall-server when an outbound proxy is present.
+ *
+ * <p>For Kerberos auth, the actual ticket acquisition (ticket-cache vs. keytab) is a JVM-wide JAAS concern set up once
+ * at startup — see {@code OutboundProxySystemProperties} in fogwall-server. This class only registers the SPNEGO auth
+ * scheme and a placeholder credential to trigger it; the GSS context itself is established from whatever Subject that
+ * startup wiring configured.
+ */
+public final class FogwallHttpExecutor {
+
+    private static volatile CloseableHttpClient client =
+            HttpClientBuilder.create().build();
+
+    private FogwallHttpExecutor() {}
+
+    /** Returns the shared client. */
+    public static CloseableHttpClient instance() {
+        return client;
+    }
+
+    /**
+     * Rebuilds the shared client from a resolved outbound proxy. Call once at startup.
+     *
+     * <p>{@code SPNegoSchemeFactory} is {@code @Deprecated} in HC5 ("no longer supported, use Basic or Bearer with TLS
+     * instead") but still performs a genuine GSS handshake — Apache stopped maintaining it, it didn't stop working.
+     * Kept for parity with the JGit and Jetty outbound paths, which both have non-deprecated native Kerberos/SPNEGO
+     * support.
+     */
+    @SuppressWarnings("deprecation")
+    public static void configure(ResolvedOutboundProxy proxy) {
+        if (proxy == null || !proxy.isConfigured()) {
+            client = HttpClientBuilder.create().build();
+            return;
+        }
+
+        String proxyHost = proxy.httpsProxyHost() != null ? proxy.httpsProxyHost() : proxy.httpProxyHost();
+        int proxyPort = proxy.httpsProxyHost() != null ? proxy.httpsProxyPort() : proxy.httpProxyPort();
+        var proxyHttpHost = new HttpHost(proxyHost, proxyPort);
+
+        var clientBuilder = HttpClientBuilder.create().setRoutePlanner(new DefaultProxyRoutePlanner(proxyHttpHost));
+
+        switch (proxy.authType()) {
+            case BASIC ->
+                clientBuilder.setDefaultCredentialsProvider(
+                        basicCredentials(proxyHttpHost, proxy.username(), proxy.password()));
+            case KERBEROS -> {
+                clientBuilder.setDefaultAuthSchemeRegistry(kerberosSchemeRegistry());
+                clientBuilder.setDefaultCredentialsProvider(kerberosPlaceholderCredentials(proxyHttpHost));
+            }
+            case NONE -> {
+                // no credentials — proxy is either open or handles auth upstream itself
+            }
+        }
+
+        client = clientBuilder.build();
+    }
+
+    private static CredentialsProvider basicCredentials(HttpHost proxyHost, String username, String password) {
+        var provider = new BasicCredentialsProvider();
+        provider.setCredentials(
+                new AuthScope(proxyHost), new UsernamePasswordCredentials(username, password.toCharArray()));
+        return provider;
+    }
+
+    private static Lookup<AuthSchemeFactory> kerberosSchemeRegistry() {
+        return RegistryBuilder.<AuthSchemeFactory>create()
+                .register(StandardAuthScheme.SPNEGO, SPNegoSchemeFactory.DEFAULT)
+                .build();
+    }
+
+    /**
+     * SPNEGO's actual handshake is driven by the JVM's GSS/JAAS Subject (see class javadoc), not by these credentials —
+     * HC5 still requires a non-null {@link org.apache.hc.client5.http.auth.Credentials} registered for the auth scope
+     * to select the scheme at all, so this is a placeholder rather than a real secret.
+     */
+    private static CredentialsProvider kerberosPlaceholderCredentials(HttpHost proxyHost) {
+        var provider = new BasicCredentialsProvider();
+        provider.setCredentials(new AuthScope(proxyHost), new UsernamePasswordCredentials("", new char[0]));
+        return provider;
+    }
+}

--- a/fogwall-core/src/main/java/com/rbc/fogwall/net/OutboundProxyJetty.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/net/OutboundProxyJetty.java
@@ -1,0 +1,48 @@
+package com.rbc.fogwall.net;
+
+import java.net.URI;
+import org.eclipse.jetty.client.BasicAuthentication;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpProxy;
+import org.eclipse.jetty.client.Origin;
+import org.eclipse.jetty.client.SPNEGOAuthentication;
+
+/**
+ * Wires a resolved outbound proxy into a Jetty {@link HttpClient} — used by {@code FogwallServlet} for
+ * transparent-proxy forwarding.
+ *
+ * <p>Jetty's client has no NTLM support (see the {@code server.outbound-proxy} docs for why); Basic and Kerberos/SPNEGO
+ * are the two supported auth types here. As with {@link FogwallHttpExecutor}, Kerberos's ticket acquisition is a
+ * JVM-wide JAAS concern configured once at startup, not here.
+ */
+public final class OutboundProxyJetty {
+
+    private OutboundProxyJetty() {}
+
+    /** No-op when {@code proxy} is null or unconfigured. */
+    public static void configure(HttpClient client, ResolvedOutboundProxy proxy) {
+        if (proxy == null || !proxy.isConfigured()) {
+            return;
+        }
+
+        String host = proxy.httpsProxyHost() != null ? proxy.httpsProxyHost() : proxy.httpProxyHost();
+        int port = proxy.httpsProxyHost() != null ? proxy.httpsProxyPort() : proxy.httpProxyPort();
+
+        client.getProxyConfiguration().addProxy(new HttpProxy(new Origin.Address(host, port), false));
+
+        URI proxyUri = URI.create("http://" + host + ":" + port);
+        switch (proxy.authType()) {
+            case BASIC ->
+                client.getAuthenticationStore()
+                        .addAuthentication(new BasicAuthentication(
+                                proxyUri,
+                                org.eclipse.jetty.client.Authentication.ANY_REALM,
+                                proxy.username(),
+                                proxy.password()));
+            case KERBEROS -> client.getAuthenticationStore().addAuthentication(new SPNEGOAuthentication(proxyUri));
+            case NONE -> {
+                // no credentials — proxy is either open or handles auth upstream itself
+            }
+        }
+    }
+}

--- a/fogwall-core/src/main/java/com/rbc/fogwall/net/ResolvedOutboundProxy.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/net/ResolvedOutboundProxy.java
@@ -1,0 +1,42 @@
+package com.rbc.fogwall.net;
+
+import java.util.Set;
+
+/**
+ * Fully-resolved outbound proxy configuration — YAML-vs-env-var precedence and URL parsing already applied — shared
+ * across the three outbound paths (JGit Transport, Jetty HttpClient, Apache HC5). Kept as primitive fields rather than
+ * exposing the fogwall-server {@code OutboundProxyConfig} YAML DTO directly, mirroring how upstream TLS trust is
+ * threaded into fogwall-core as resolved trust managers rather than a config type.
+ */
+public record ResolvedOutboundProxy(
+        String httpProxyHost,
+        int httpProxyPort,
+        String httpsProxyHost,
+        int httpsProxyPort,
+        Set<String> noProxyHosts,
+        AuthType authType,
+        String username,
+        String password,
+        String keytabPath,
+        String principal) {
+
+    public static final ResolvedOutboundProxy NONE =
+            new ResolvedOutboundProxy(null, 0, null, 0, Set.of(), AuthType.NONE, null, null, null, null);
+
+    /** Returns true if either an HTTP or HTTPS proxy host is configured. */
+    public boolean isConfigured() {
+        return httpProxyHost != null || httpsProxyHost != null;
+    }
+
+    /** Returns true if Kerberos auth is configured with a keytab, rather than the default ticket-cache mode. */
+    public boolean isKeytabMode() {
+        return keytabPath != null && !keytabPath.isBlank();
+    }
+
+    /** Proxy authentication scheme. */
+    public enum AuthType {
+        NONE,
+        BASIC,
+        KERBEROS
+    }
+}

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/BitbucketProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/BitbucketProvider.java
@@ -2,6 +2,7 @@ package com.rbc.fogwall.provider;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.rbc.fogwall.git.GitRequestDetails;
+import com.rbc.fogwall.net.FogwallHttpExecutor;
 import java.net.URI;
 import java.util.Base64;
 import java.util.Optional;
@@ -95,7 +96,7 @@ public class BitbucketProvider extends AbstractFogwallProvider implements HttpTo
             String credentials = Base64.getEncoder().encodeToString((pushUsername + ":" + token).getBytes());
             var response = Request.get(getApiUrl() + "/user")
                     .addHeader("Authorization", "Basic " + credentials)
-                    .execute()
+                    .execute(FogwallHttpExecutor.instance())
                     .returnContent()
                     .asString();
             var info = new JsonMapper().readValue(response, BitbucketUserInfo.class);

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/ForgejoProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/ForgejoProvider.java
@@ -1,5 +1,6 @@
 package com.rbc.fogwall.provider;
 
+import com.rbc.fogwall.net.FogwallHttpExecutor;
 import com.rbc.fogwall.ssh.SshKeyUtils;
 import java.net.URI;
 import java.util.Arrays;
@@ -76,7 +77,7 @@ public class ForgejoProvider extends AbstractFogwallProvider implements HttpToke
         try {
             var response = Request.get(getApiUrl() + "/user")
                     .addHeader("Authorization", "token " + token)
-                    .execute()
+                    .execute(FogwallHttpExecutor.instance())
                     .returnContent()
                     .asString();
             var info = new JsonMapper().readValue(response, ForgejoUserInfo.class);
@@ -101,7 +102,9 @@ public class ForgejoProvider extends AbstractFogwallProvider implements HttpToke
             if (apiToken != null && !apiToken.isBlank()) {
                 request = request.addHeader("Authorization", "token " + apiToken);
             }
-            var response = request.execute().returnContent().asString();
+            var response = request.execute(FogwallHttpExecutor.instance())
+                    .returnContent()
+                    .asString();
             var keys = new JsonMapper().readValue(response, ForgejoPublicKey[].class);
             return Arrays.stream(keys)
                     .map(k -> {

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/GitHubProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/GitHubProvider.java
@@ -2,6 +2,7 @@ package com.rbc.fogwall.provider;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import com.rbc.fogwall.net.FogwallHttpExecutor;
 import com.rbc.fogwall.ssh.SshKeyUtils;
 import java.net.URI;
 import java.util.Arrays;
@@ -65,7 +66,7 @@ public class GitHubProvider extends AbstractFogwallProvider implements HttpToken
         try {
             var response = Request.get(getApiUrl() + "/user")
                     .addHeader("Authorization", "token " + token)
-                    .execute()
+                    .execute(FogwallHttpExecutor.instance())
                     .returnContent()
                     .asString();
             var info = new JsonMapper().readValue(response, GitHubUserInfo.class);
@@ -89,7 +90,7 @@ public class GitHubProvider extends AbstractFogwallProvider implements HttpToken
             var response = Request.get(getApiUrl() + "/users/" + login + "/keys")
                     .connectTimeout(Timeout.ofSeconds(10))
                     .responseTimeout(Timeout.ofSeconds(10))
-                    .execute()
+                    .execute(FogwallHttpExecutor.instance())
                     .returnContent()
                     .asString();
             var keys = new JsonMapper().readValue(response, GitHubPublicKey[].class);

--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/GitLabProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/GitLabProvider.java
@@ -1,5 +1,6 @@
 package com.rbc.fogwall.provider;
 
+import com.rbc.fogwall.net.FogwallHttpExecutor;
 import com.rbc.fogwall.ssh.SshKeyUtils;
 import java.net.URI;
 import java.util.Arrays;
@@ -67,7 +68,7 @@ public class GitLabProvider extends AbstractFogwallProvider implements HttpToken
         try {
             var response = Request.get(getApiUrl() + "/user")
                     .addHeader("Authorization", "Bearer " + token)
-                    .execute()
+                    .execute(FogwallHttpExecutor.instance())
                     .returnContent()
                     .asString();
             var info = new JsonMapper().readValue(response, GitLabUserInfo.class);
@@ -100,7 +101,9 @@ public class GitLabProvider extends AbstractFogwallProvider implements HttpToken
             if (apiToken != null && !apiToken.isBlank()) {
                 userReq = userReq.addHeader("Authorization", "Bearer " + apiToken);
             }
-            var userResponse = userReq.execute().returnContent().asString();
+            var userResponse = userReq.execute(FogwallHttpExecutor.instance())
+                    .returnContent()
+                    .asString();
             var users = new JsonMapper().readValue(userResponse, GitLabUserSearchResult[].class);
             if (users.length == 0) {
                 log.warn("GitLab user '{}' not found", login);
@@ -115,7 +118,9 @@ public class GitLabProvider extends AbstractFogwallProvider implements HttpToken
             if (apiToken != null && !apiToken.isBlank()) {
                 keysReq = keysReq.addHeader("Authorization", "Bearer " + apiToken);
             }
-            var keysResponse = keysReq.execute().returnContent().asString();
+            var keysResponse = keysReq.execute(FogwallHttpExecutor.instance())
+                    .returnContent()
+                    .asString();
             var keys = new JsonMapper().readValue(keysResponse, GitLabPublicKey[].class);
             return Arrays.stream(keys)
                     .map(k -> {

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/FogwallServlet.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/FogwallServlet.java
@@ -3,6 +3,8 @@ package com.rbc.fogwall.servlet;
 import com.rbc.fogwall.db.PushStore;
 import com.rbc.fogwall.db.model.PushStatus;
 import com.rbc.fogwall.git.GitRequestDetails;
+import com.rbc.fogwall.net.OutboundProxyJetty;
+import com.rbc.fogwall.net.ResolvedOutboundProxy;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -32,26 +34,36 @@ public class FogwallServlet extends AsyncProxyServlet.Transparent {
 
     private final PushStore pushStore;
     private final SSLContext upstreamSslContext;
+    private final ResolvedOutboundProxy outboundProxy;
 
     public FogwallServlet(PushStore pushStore) {
-        this(pushStore, null);
+        this(pushStore, null, null);
     }
 
     public FogwallServlet(PushStore pushStore, SSLContext upstreamSslContext) {
+        this(pushStore, upstreamSslContext, null);
+    }
+
+    public FogwallServlet(PushStore pushStore, SSLContext upstreamSslContext, ResolvedOutboundProxy outboundProxy) {
         this.pushStore = pushStore;
         this.upstreamSslContext = upstreamSslContext;
+        this.outboundProxy = outboundProxy;
     }
 
     @Override
     protected HttpClient newHttpClient() {
+        HttpClient client;
         if (upstreamSslContext != null) {
             var sslFactory = new SslContextFactory.Client();
             sslFactory.setSslContext(upstreamSslContext);
             var connector = new ClientConnector();
             connector.setSslContextFactory(sslFactory);
-            return new HttpClient(new HttpClientTransportOverHTTP(connector));
+            client = new HttpClient(new HttpClientTransportOverHTTP(connector));
+        } else {
+            client = super.newHttpClient();
         }
-        return super.newHttpClient();
+        OutboundProxyJetty.configure(client, outboundProxy);
+        return client;
     }
 
     @Override

--- a/fogwall-core/src/test/java/com/rbc/fogwall/net/FogwallHttpExecutorTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/net/FogwallHttpExecutorTest.java
@@ -1,0 +1,63 @@
+package com.rbc.fogwall.net;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class FogwallHttpExecutorTest {
+
+    @AfterEach
+    void resetToUnconfigured() {
+        FogwallHttpExecutor.configure(null);
+    }
+
+    @Test
+    void configure_nullProxy_leavesUsableDefaultClient() {
+        FogwallHttpExecutor.configure(null);
+        assertNotNull(FogwallHttpExecutor.instance());
+    }
+
+    @Test
+    void configure_unconfiguredProxy_leavesUsableDefaultClient() {
+        FogwallHttpExecutor.configure(ResolvedOutboundProxy.NONE);
+        assertNotNull(FogwallHttpExecutor.instance());
+    }
+
+    @Test
+    void configure_basicAuthProxy_rebuildsClientWithoutError() {
+        var proxy = new ResolvedOutboundProxy(
+                null,
+                0,
+                "proxy.example.com",
+                8080,
+                Set.of(),
+                ResolvedOutboundProxy.AuthType.BASIC,
+                "user",
+                "pass",
+                null,
+                null);
+
+        assertDoesNotThrow(() -> FogwallHttpExecutor.configure(proxy));
+        assertNotNull(FogwallHttpExecutor.instance());
+    }
+
+    @Test
+    void configure_kerberosProxy_rebuildsClientWithoutError() {
+        var proxy = new ResolvedOutboundProxy(
+                null,
+                0,
+                "proxy.example.com",
+                8080,
+                Set.of(),
+                ResolvedOutboundProxy.AuthType.KERBEROS,
+                null,
+                null,
+                null,
+                null);
+
+        assertDoesNotThrow(() -> FogwallHttpExecutor.configure(proxy));
+        assertNotNull(FogwallHttpExecutor.instance());
+    }
+}

--- a/fogwall-core/src/test/java/com/rbc/fogwall/net/OutboundProxyJettyTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/net/OutboundProxyJettyTest.java
@@ -1,0 +1,74 @@
+package com.rbc.fogwall.net;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import java.util.Set;
+import org.eclipse.jetty.client.Authentication;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http.HttpHeader;
+import org.junit.jupiter.api.Test;
+
+class OutboundProxyJettyTest {
+
+    @Test
+    void configure_nullProxy_doesNotTouchClient() {
+        var client = new HttpClient();
+        assertDoesNotThrow(() -> OutboundProxyJetty.configure(client, null));
+        assertTrue(client.getProxyConfiguration().getProxies().isEmpty());
+    }
+
+    @Test
+    void configure_unconfiguredProxy_doesNotAddProxy() {
+        var client = new HttpClient();
+        OutboundProxyJetty.configure(client, ResolvedOutboundProxy.NONE);
+        assertTrue(client.getProxyConfiguration().getProxies().isEmpty());
+    }
+
+    @Test
+    void configure_basicAuthProxy_addsProxyAndAuthentication() {
+        var client = new HttpClient();
+        var proxy = new ResolvedOutboundProxy(
+                null,
+                0,
+                "proxy.example.com",
+                8080,
+                Set.of(),
+                ResolvedOutboundProxy.AuthType.BASIC,
+                "user",
+                "pass",
+                null,
+                null);
+
+        OutboundProxyJetty.configure(client, proxy);
+
+        assertEquals(1, client.getProxyConfiguration().getProxies().size());
+        assertNotNull(client.getAuthenticationStore()
+                .findAuthentication("Basic", URI.create("http://proxy.example.com:8080"), Authentication.ANY_REALM));
+    }
+
+    @Test
+    void configure_kerberosProxy_addsProxyAndAuthentication() {
+        var client = new HttpClient();
+        var proxy = new ResolvedOutboundProxy(
+                null,
+                0,
+                "proxy.example.com",
+                8080,
+                Set.of(),
+                ResolvedOutboundProxy.AuthType.KERBEROS,
+                null,
+                null,
+                null,
+                null);
+
+        OutboundProxyJetty.configure(client, proxy);
+
+        assertEquals(1, client.getProxyConfiguration().getProxies().size());
+        assertNotNull(client.getAuthenticationStore()
+                .findAuthentication(
+                        HttpHeader.NEGOTIATE.asString(),
+                        URI.create("http://proxy.example.com:8080"),
+                        Authentication.ANY_REALM));
+    }
+}

--- a/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/FogwallDashboardApplication.java
+++ b/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/FogwallDashboardApplication.java
@@ -57,6 +57,7 @@ public class FogwallDashboardApplication {
         var fogwallConfig = FogwallConfigLoader.load();
         var configBuilder = new JettyConfigurationBuilder(fogwallConfig);
         configBuilder.validateProviderReferences(); // fail fast before any DB or port setup
+        configBuilder.applyOutboundProxySystemWiring(); // before any outbound connection is made
 
         var threadPool = new QueuedThreadPool();
         threadPool.setName("fogwall-dashboard");

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
@@ -20,6 +20,10 @@ import com.rbc.fogwall.git.LocalRepositoryCache;
 import com.rbc.fogwall.jetty.FogwallContext;
 import com.rbc.fogwall.jetty.reload.ConfigHolder;
 import com.rbc.fogwall.jetty.reload.LiveConfigLoader;
+import com.rbc.fogwall.net.FogwallHttpExecutor;
+import com.rbc.fogwall.net.OutboundProxyResolver;
+import com.rbc.fogwall.net.OutboundProxySystemProperties;
+import com.rbc.fogwall.net.ResolvedOutboundProxy;
 import com.rbc.fogwall.permission.GroupPermissionRule;
 import com.rbc.fogwall.permission.GroupPermissionStore;
 import com.rbc.fogwall.permission.JdbcGroupPermissionStore;
@@ -85,6 +89,7 @@ public class JettyConfigurationBuilder {
     private GroupPermissionStore cachedGroupPermissionStore;
     private UrlRuleRegistry cachedUrlRuleRegistry;
     private ConfigHolder cachedConfigHolder;
+    private ResolvedOutboundProxy cachedOutboundProxy;
 
     public JettyConfigurationBuilder(FogwallConfig config) {
         this.config = config;
@@ -118,6 +123,29 @@ public class JettyConfigurationBuilder {
     /** Returns the transparent-proxy connect timeout in seconds (0 = no timeout). */
     public int getProxyConnectTimeoutSeconds() {
         return config.getServer().getProxyConnectTimeoutSeconds();
+    }
+
+    /**
+     * Resolves {@code server.outbound-proxy} (with env-var fallback). Result is cached — the underlying config is only
+     * re-read on a full process restart, not hot-reloaded.
+     */
+    public ResolvedOutboundProxy getResolvedOutboundProxy() {
+        if (cachedOutboundProxy == null) {
+            cachedOutboundProxy =
+                    OutboundProxyResolver.resolve(config.getServer().getOutboundProxy());
+        }
+        return cachedOutboundProxy;
+    }
+
+    /**
+     * Applies the resolved outbound proxy at the JVM level (JGit Transport system properties/Authenticator/JAAS) and to
+     * the shared HC5 client used by provider REST API calls. Call once at startup, before any outbound connection is
+     * made. The Jetty HttpClient path is wired separately per-servlet via {@link #getResolvedOutboundProxy()}.
+     */
+    public void applyOutboundProxySystemWiring() {
+        var resolved = getResolvedOutboundProxy();
+        OutboundProxySystemProperties.apply(resolved);
+        FogwallHttpExecutor.configure(resolved);
     }
 
     /**

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/OutboundProxyConfig.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/OutboundProxyConfig.java
@@ -1,0 +1,96 @@
+package com.rbc.fogwall.config;
+
+import lombok.Data;
+
+/**
+ * Binds the {@code server.outbound-proxy:} block in fogwall.yml.
+ *
+ * <p>Covers outbound connections fogwall itself makes: store-and-forward upstream pushes (JGit Transport),
+ * transparent-proxy forwarding (Jetty HttpClient), and provider REST API calls (Apache HttpClient 5). All three are
+ * wired from the single resolved proxy here rather than configured independently.
+ *
+ * <p>{@link #httpProxy}, {@link #httpsProxy}, and {@link #noProxy} fall back to the {@code HTTP_PROXY},
+ * {@code HTTPS_PROXY}, and {@code NO_PROXY} environment variables (respected by most CLI tooling) when left unset here.
+ * An explicit YAML value always takes precedence over the environment variable.
+ *
+ * <p>Example (authenticating proxy):
+ *
+ * <pre>{@code
+ * server:
+ *   outbound-proxy:
+ *     https-proxy: http://proxy.example.com:8080
+ *     no-proxy: localhost,*.internal.example.com
+ *     auth:
+ *       type: basic
+ *       username: ${PROXY_USER}
+ *       password: ${PROXY_PASS}
+ * }</pre>
+ *
+ * <p>Example (proxy that doesn't require fogwall to authenticate itself — env vars only, no YAML needed):
+ *
+ * <pre>{@code
+ * # HTTP_PROXY=http://proxy.example.com:8080
+ * # HTTPS_PROXY=http://proxy.example.com:8080
+ * server:
+ *   outbound-proxy:
+ *     auth:
+ *       type: none   # default
+ * }</pre>
+ */
+@Data
+public class OutboundProxyConfig {
+
+    /** Proxy for plain HTTP requests. Falls back to the {@code HTTP_PROXY} env var when unset. */
+    private String httpProxy;
+
+    /** Proxy for HTTPS requests. Falls back to the {@code HTTPS_PROXY} env var when unset. */
+    private String httpsProxy;
+
+    /** Comma-separated hosts to bypass the proxy for. Falls back to the {@code NO_PROXY} env var when unset. */
+    private String noProxy;
+
+    /** Authentication against the proxy itself. Defaults to no auth. */
+    private AuthConfig auth = new AuthConfig();
+
+    /** Binds the {@code server.outbound-proxy.auth:} block. */
+    @Data
+    public static class AuthConfig {
+
+        /**
+         * Proxy authentication scheme. One of:
+         *
+         * <ul>
+         *   <li>{@code none} (default) — no auth sent by fogwall; use when the configured proxy doesn't require fogwall
+         *       to authenticate itself
+         *   <li>{@code basic} — HTTP Basic auth against the proxy
+         *   <li>{@code kerberos} — SPNEGO/Kerberos (Negotiate) against the proxy
+         * </ul>
+         */
+        private String type = "none";
+
+        /** Proxy username. Required when {@link #type} is {@code basic}. */
+        private String username;
+
+        /** Proxy password. Required when {@link #type} is {@code basic}. */
+        private String password;
+
+        /**
+         * Path to a Kerberos keytab file. Only used when {@link #type} is {@code kerberos}. When unset (the default),
+         * fogwall authenticates using an existing OS Kerberos ticket cache instead of a keytab — the common case when
+         * fogwall runs on a machine that already carries a ticket from domain/SSO login, rather than as a headless
+         * service with its own identity.
+         */
+        private String keytabPath;
+
+        /**
+         * Kerberos principal (e.g. {@code fogwall/host@CORP.EXAMPLE.COM}). Required when {@link #keytabPath} is set;
+         * ignored in ticket-cache mode, where the cache's own principal is used.
+         */
+        private String principal;
+
+        /** Returns true if a keytab-based service identity is configured, rather than the default ticket-cache mode. */
+        public boolean isKeytabMode() {
+            return keytabPath != null && !keytabPath.isBlank();
+        }
+    }
+}

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/ServerConfig.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/ServerConfig.java
@@ -88,6 +88,13 @@ public class ServerConfig {
     private SshConfig ssh = new SshConfig();
 
     /**
+     * Outbound proxy configuration for connections fogwall itself makes (upstream pushes, transparent-proxy forwarding,
+     * provider API calls). Omit entirely to rely on {@code HTTP_PROXY}/{@code HTTPS_PROXY}/{@code NO_PROXY} environment
+     * variables with no auth, or unset to disable outbound proxying altogether.
+     */
+    private OutboundProxyConfig outboundProxy = new OutboundProxyConfig();
+
+    /**
      * HTTP session persistence backend. Values:
      *
      * <ul>

--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallJettyApplication.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallJettyApplication.java
@@ -44,6 +44,7 @@ public class FogwallJettyApplication {
         var fogwallConfig = FogwallConfigLoader.load();
         var configBuilder = new JettyConfigurationBuilder(fogwallConfig);
         configBuilder.validateProviderReferences(); // fail fast before any DB or port setup
+        configBuilder.applyOutboundProxySystemWiring(); // before any outbound connection is made
 
         var threadPool = new QueuedThreadPool();
         threadPool.setName("fogwall-server");

--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallServletRegistrar.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallServletRegistrar.java
@@ -17,6 +17,7 @@ import com.rbc.fogwall.git.StoreAndForwardReceivePackFactory;
 import com.rbc.fogwall.git.StoreAndForwardRepositoryResolver;
 import com.rbc.fogwall.git.StoreAndForwardUploadPackFactory;
 import com.rbc.fogwall.jetty.reload.ConfigHolder;
+import com.rbc.fogwall.net.ResolvedOutboundProxy;
 import com.rbc.fogwall.permission.RepoPermissionService;
 import com.rbc.fogwall.provider.BitbucketProvider;
 import com.rbc.fogwall.provider.FogwallProvider;
@@ -109,7 +110,8 @@ public final class FogwallServletRegistrar {
                         provider,
                         fogwallContext.pushStore(),
                         fogwallContext.proxyConnectTimeoutSeconds(),
-                        fogwallContext.upstreamTls());
+                        fogwallContext.upstreamTls(),
+                        configBuilder.getResolvedOutboundProxy());
                 registerCoreFilters(
                         context,
                         provider,
@@ -241,11 +243,13 @@ public final class FogwallServletRegistrar {
             FogwallProvider provider,
             PushStore pushStore,
             int connectTimeoutSeconds,
-            SslUtil.UpstreamTls upstreamTls) {
+            SslUtil.UpstreamTls upstreamTls,
+            ResolvedOutboundProxy outboundProxy) {
         String proxyPath = PROXY_PATH_PREFIX + provider.servletPath();
         String proxyMapping = proxyPath + "/*";
 
-        var proxyServlet = new FogwallServlet(pushStore, upstreamTls != null ? upstreamTls.sslContext() : null);
+        var proxyServlet =
+                new FogwallServlet(pushStore, upstreamTls != null ? upstreamTls.sslContext() : null, outboundProxy);
         var proxyHolder = new ServletHolder(proxyServlet);
         proxyHolder.setName("proxy-" + provider.getName());
         proxyHolder.setInitParameter("proxyTo", provider.getUri().toString());

--- a/fogwall-server/src/main/java/com/rbc/fogwall/net/OutboundProxyResolver.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/net/OutboundProxyResolver.java
@@ -1,0 +1,101 @@
+package com.rbc.fogwall.net;
+
+import com.rbc.fogwall.config.OutboundProxyConfig;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Resolves {@link OutboundProxyConfig} — a YAML value always wins; an unset YAML value falls back to the corresponding
+ * {@code HTTP_PROXY}/{@code HTTPS_PROXY}/{@code NO_PROXY} environment variable — into the fogwall-core-visible
+ * {@link ResolvedOutboundProxy}.
+ */
+public final class OutboundProxyResolver {
+
+    private OutboundProxyResolver() {}
+
+    /** Resolves using real environment variables. */
+    public static ResolvedOutboundProxy resolve(OutboundProxyConfig config) {
+        return resolve(config, System::getenv);
+    }
+
+    /** Resolves using a supplied env-var lookup — the seam tests use to avoid depending on process environment. */
+    public static ResolvedOutboundProxy resolve(OutboundProxyConfig config, Function<String, String> env) {
+        String httpProxy = firstNonBlank(config.getHttpProxy(), env.apply("HTTP_PROXY"));
+        String httpsProxy = firstNonBlank(config.getHttpsProxy(), env.apply("HTTPS_PROXY"));
+        String noProxy = firstNonBlank(config.getNoProxy(), env.apply("NO_PROXY"));
+
+        if (httpProxy == null && httpsProxy == null) {
+            return ResolvedOutboundProxy.NONE;
+        }
+
+        URI http = parse(httpProxy, "HTTP_PROXY");
+        URI https = parse(httpsProxy, "HTTPS_PROXY");
+        Set<String> noProxyHosts = parseNoProxy(noProxy);
+
+        var auth = config.getAuth();
+        var authType = ResolvedOutboundProxy.AuthType.valueOf(auth.getType().toUpperCase());
+        if (authType == ResolvedOutboundProxy.AuthType.BASIC
+                && (auth.getUsername() == null || auth.getPassword() == null)) {
+            throw new IllegalArgumentException(
+                    "server.outbound-proxy.auth.type is 'basic' but username/password is not set");
+        }
+        if (authType == ResolvedOutboundProxy.AuthType.KERBEROS && auth.isKeytabMode() && auth.getPrincipal() == null) {
+            throw new IllegalArgumentException(
+                    "server.outbound-proxy.auth.keytab-path is set but principal is missing");
+        }
+
+        return new ResolvedOutboundProxy(
+                http != null ? http.getHost() : null,
+                http != null ? http.getPort() : 0,
+                https != null ? https.getHost() : null,
+                https != null ? https.getPort() : 0,
+                noProxyHosts,
+                authType,
+                auth.getUsername(),
+                auth.getPassword(),
+                auth.getKeytabPath(),
+                auth.getPrincipal());
+    }
+
+    private static String firstNonBlank(String yamlValue, String envValue) {
+        if (yamlValue != null && !yamlValue.isBlank()) return yamlValue;
+        if (envValue != null && !envValue.isBlank()) return envValue;
+        return null;
+    }
+
+    private static URI parse(String value, String label) {
+        if (value == null) return null;
+        try {
+            URI uri = URI.create(value);
+            if (uri.getHost() == null || uri.getPort() < 0) {
+                throw new IllegalArgumentException(label + " must include a host and port, got: " + value);
+            }
+            return uri;
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(label + " is not a valid proxy URL: " + value, e);
+        }
+    }
+
+    /**
+     * Splits a comma-separated {@code NO_PROXY}-style value into JDK {@code nonProxyHosts} patterns. Entries without a
+     * {@code *} wildcard are expanded to also match subdomains (the common {@code NO_PROXY} convention of a bare domain
+     * meaning "this host and everything under it"), since the JDK's own matching is exact-or-wildcard only.
+     */
+    private static Set<String> parseNoProxy(String value) {
+        if (value == null || value.isBlank()) return Set.of();
+        Set<String> result = new LinkedHashSet<>();
+        Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .forEach(host -> {
+                    result.add(host);
+                    if (!host.contains("*")) {
+                        result.add("*." + host);
+                    }
+                });
+        return result;
+    }
+}

--- a/fogwall-server/src/main/java/com/rbc/fogwall/net/OutboundProxySystemProperties.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/net/OutboundProxySystemProperties.java
@@ -1,0 +1,101 @@
+package com.rbc.fogwall.net;
+
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.util.Map;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Applies a {@link ResolvedOutboundProxy} at the JVM level so JGit's {@code Transport} — which uses the JDK's built-in
+ * {@code HttpURLConnection} and respects standard {@code http(s).proxyHost/Port} system properties rather than any
+ * fogwall-specific config — picks it up. Call once at startup, before any outbound connection is made.
+ *
+ * <p>Kerberos ticket acquisition: {@code useSubjectCredsOnly=false} (set unconditionally in Kerberos mode) lets the
+ * JDK's GSS provider use the OS's existing ticket cache directly — the default, keytab-free path, matching how a
+ * developer machine already has a live ticket from domain/SSO login. Keytab mode installs an in-memory JAAS
+ * {@link Configuration} instead, so the JVM authenticates as its own service identity with no external
+ * {@code login.conf} file needed.
+ */
+@Slf4j
+public final class OutboundProxySystemProperties {
+
+    private OutboundProxySystemProperties() {}
+
+    public static void apply(ResolvedOutboundProxy proxy) {
+        if (proxy == null || !proxy.isConfigured()) {
+            log.info("Outbound proxy: not configured (direct connections)");
+            return;
+        }
+
+        if (proxy.httpProxyHost() != null) {
+            System.setProperty("http.proxyHost", proxy.httpProxyHost());
+            System.setProperty("http.proxyPort", String.valueOf(proxy.httpProxyPort()));
+        }
+        if (proxy.httpsProxyHost() != null) {
+            System.setProperty("https.proxyHost", proxy.httpsProxyHost());
+            System.setProperty("https.proxyPort", String.valueOf(proxy.httpsProxyPort()));
+        }
+        if (!proxy.noProxyHosts().isEmpty()) {
+            System.setProperty("http.nonProxyHosts", String.join("|", proxy.noProxyHosts()));
+        }
+
+        switch (proxy.authType()) {
+            case BASIC -> applyBasicAuthenticator(proxy);
+            case KERBEROS -> applyKerberos(proxy);
+            case NONE -> {
+                // no credentials — proxy is either open or handles auth upstream itself
+            }
+        }
+
+        log.info(
+                "Outbound proxy configured: http={} https={} auth={}",
+                proxy.httpProxyHost() != null ? proxy.httpProxyHost() + ":" + proxy.httpProxyPort() : "-",
+                proxy.httpsProxyHost() != null ? proxy.httpsProxyHost() + ":" + proxy.httpsProxyPort() : "-",
+                proxy.authType());
+    }
+
+    private static void applyBasicAuthenticator(ResolvedOutboundProxy proxy) {
+        Authenticator.setDefault(new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                if (getRequestorType() != RequestorType.PROXY) {
+                    return null;
+                }
+                return new PasswordAuthentication(
+                        proxy.username(), proxy.password().toCharArray());
+            }
+        });
+    }
+
+    private static void applyKerberos(ResolvedOutboundProxy proxy) {
+        // Lets the JDK's GSS provider negotiate using whatever the OS ticket cache already holds, with no
+        // explicit Subject required — the ticket-cache (keytab-free) default mode.
+        System.setProperty("javax.security.auth.useSubjectCredsOnly", "false");
+
+        if (!proxy.isKeytabMode()) {
+            return;
+        }
+
+        var options = Map.<String, Object>of(
+                "useKeyTab", "true",
+                "keyTab", proxy.keytabPath(),
+                "principal", proxy.principal(),
+                "storeKey", "true",
+                "doNotPrompt", "true",
+                "isInitiator", "true");
+        var entry = new AppConfigurationEntry(
+                "com.sun.security.auth.module.Krb5LoginModule",
+                AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+                options);
+
+        Configuration.setConfiguration(new Configuration() {
+            @Override
+            public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+                return new AppConfigurationEntry[] {entry};
+            }
+        });
+        log.info("Kerberos keytab configured for outbound proxy auth: principal={}", proxy.principal());
+    }
+}

--- a/fogwall-server/src/main/resources/fogwall.yml
+++ b/fogwall-server/src/main/resources/fogwall.yml
@@ -49,6 +49,26 @@ server:
 #    port: 2222
 #    host-key-path: .ssh/fogwall_host_key    # generated on first start if absent
 
+# Outbound proxy for connections fogwall itself makes: store-and-forward upstream pushes,
+# transparent-proxy forwarding, and provider REST API calls (identity resolution, SSH key listing).
+#
+# Unset here, http-proxy/https-proxy/no-proxy fall back to the HTTP_PROXY/HTTPS_PROXY/NO_PROXY env vars.
+# Leave auth.type at "none" (the default) when the configured proxy doesn't require fogwall to
+# authenticate itself.
+#
+# outbound-proxy:
+#   https-proxy: http://proxy.example.com:8080
+#   no-proxy: localhost,*.internal.example.com
+#   auth:
+#     type: none        # none (default) | basic | kerberos
+#     # basic:
+#     # username: ${PROXY_USER}
+#     # password: ${PROXY_PASS}
+#     # kerberos: omit keytab-path to use the existing OS ticket cache (e.g. from domain/SSO login);
+#     # set it only when fogwall should authenticate as its own service identity.
+#     # keytab-path: /etc/fogwall/proxy.keytab
+#     # principal: fogwall/host@CORP.EXAMPLE.COM
+
 # Database configuration for push audit storage.
 # Supported types: h2-mem, h2-file, postgres, mongo
 # h2-file persists to ./.data/fogwall.mv.db relative to the working directory.

--- a/fogwall-server/src/test/java/com/rbc/fogwall/net/OutboundProxyResolverTest.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/net/OutboundProxyResolverTest.java
@@ -1,0 +1,114 @@
+package com.rbc.fogwall.net;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.rbc.fogwall.config.OutboundProxyConfig;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OutboundProxyResolverTest {
+
+    private static Map<String, String> noEnv() {
+        return Map.of();
+    }
+
+    @Test
+    void resolve_noProxyConfiguredAndNoEnvVars_returnsNone() {
+        var resolved = OutboundProxyResolver.resolve(new OutboundProxyConfig(), noEnv()::get);
+        assertEquals(ResolvedOutboundProxy.NONE, resolved);
+        assertFalse(resolved.isConfigured());
+    }
+
+    @Test
+    void resolve_yamlValueSet_takesPrecedenceOverEnvVar() {
+        var config = new OutboundProxyConfig();
+        config.setHttpsProxy("http://yaml-proxy.example.com:8080");
+        var env = Map.of("HTTPS_PROXY", "http://env-proxy.example.com:9090");
+
+        var resolved = OutboundProxyResolver.resolve(config, env::get);
+
+        assertEquals("yaml-proxy.example.com", resolved.httpsProxyHost());
+        assertEquals(8080, resolved.httpsProxyPort());
+    }
+
+    @Test
+    void resolve_noYamlValue_fallsBackToEnvVar() {
+        var env = Map.of("HTTPS_PROXY", "http://env-proxy.example.com:9090");
+
+        var resolved = OutboundProxyResolver.resolve(new OutboundProxyConfig(), env::get);
+
+        assertEquals("env-proxy.example.com", resolved.httpsProxyHost());
+        assertEquals(9090, resolved.httpsProxyPort());
+        assertTrue(resolved.isConfigured());
+    }
+
+    @Test
+    void resolve_noProxyList_expandsBareHostsToAlsoMatchSubdomains() {
+        var config = new OutboundProxyConfig();
+        config.setHttpsProxy("http://proxy.example.com:8080");
+        config.setNoProxy("localhost,*.already-wild.example.com,internal.example.com");
+
+        var resolved = OutboundProxyResolver.resolve(config, noEnv()::get);
+
+        assertTrue(resolved.noProxyHosts().contains("localhost"));
+        assertTrue(resolved.noProxyHosts().contains("*.localhost"));
+        assertTrue(resolved.noProxyHosts().contains("*.already-wild.example.com"));
+        assertFalse(resolved.noProxyHosts().contains("**.already-wild.example.com"));
+        assertTrue(resolved.noProxyHosts().contains("internal.example.com"));
+        assertTrue(resolved.noProxyHosts().contains("*.internal.example.com"));
+    }
+
+    @Test
+    void resolve_basicAuthMissingCredentials_throws() {
+        var config = new OutboundProxyConfig();
+        config.setHttpsProxy("http://proxy.example.com:8080");
+        config.getAuth().setType("basic");
+
+        assertThrows(IllegalArgumentException.class, () -> OutboundProxyResolver.resolve(config, noEnv()::get));
+    }
+
+    @Test
+    void resolve_basicAuthWithCredentials_resolvesSuccessfully() {
+        var config = new OutboundProxyConfig();
+        config.setHttpsProxy("http://proxy.example.com:8080");
+        config.getAuth().setType("basic");
+        config.getAuth().setUsername("user");
+        config.getAuth().setPassword("pass");
+
+        var resolved = OutboundProxyResolver.resolve(config, noEnv()::get);
+
+        assertEquals(ResolvedOutboundProxy.AuthType.BASIC, resolved.authType());
+        assertEquals("user", resolved.username());
+        assertEquals("pass", resolved.password());
+    }
+
+    @Test
+    void resolve_kerberosWithKeytabPathButNoPrincipal_throws() {
+        var config = new OutboundProxyConfig();
+        config.setHttpsProxy("http://proxy.example.com:8080");
+        config.getAuth().setType("kerberos");
+        config.getAuth().setKeytabPath("/etc/fogwall/proxy.keytab");
+
+        assertThrows(IllegalArgumentException.class, () -> OutboundProxyResolver.resolve(config, noEnv()::get));
+    }
+
+    @Test
+    void resolve_kerberosWithNoKeytab_resolvesInTicketCacheMode() {
+        var config = new OutboundProxyConfig();
+        config.setHttpsProxy("http://proxy.example.com:8080");
+        config.getAuth().setType("kerberos");
+
+        var resolved = OutboundProxyResolver.resolve(config, noEnv()::get);
+
+        assertEquals(ResolvedOutboundProxy.AuthType.KERBEROS, resolved.authType());
+        assertFalse(resolved.isKeytabMode());
+    }
+
+    @Test
+    void resolve_invalidProxyUrl_throws() {
+        var config = new OutboundProxyConfig();
+        config.setHttpsProxy("not-a-valid-url-missing-host");
+
+        assertThrows(IllegalArgumentException.class, () -> OutboundProxyResolver.resolve(config, noEnv()::get));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `server.outbound-proxy` YAML config, wired across all three outbound paths fogwall uses: JGit Transport (store-and-forward upstream pushes), Jetty HttpClient (transparent-proxy forwarding), and Apache HC5 (provider REST API calls — identity resolution, SSH key listing)
- `http-proxy`/`https-proxy`/`no-proxy` fall back to `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` env vars when unset in YAML — this is the env-var wiring #83 was originally scoped to deliver but never actually implemented (see below)
- Two proxy auth schemes: Basic and Kerberos/Negotiate (SPNEGO). Kerberos defaults to using the OS's existing ticket cache; a keytab path is an explicit opt-in for headless service deployments with no live session

## Why no NTLM

NTLM is intentionally out of scope as a scheme fogwall speaks directly:
- It's a deprecated protocol
- Jetty's HTTP client (the transparent-proxy path) has no NTLM support at all and can't cleanly add it — the reference implementation (jcifs) is LGPL-licensed and Jetty won't bundle it

Kerberos/Negotiate is the modern successor in Active Directory environments and has native support across all three outbound paths. HC5's own `SPNegoSchemeFactory` is `@Deprecated` upstream ("no longer supported, use Basic or Bearer with TLS instead") but still performs a genuine GSS handshake — kept for parity with the other two paths, which both have non-deprecated native support.

## #83 was mis-closed

While scoping this, found that #83 (outbound proxy env-var wiring, supposedly landed in 1.0.0) was closed by PR #160 — but that PR only added documentation and unrelated docker-compose fixes, never the actual proxy code. Reopened #83 and folded its scope into this PR since both touch the same call sites.

closes #158
resolves #83

## Test plan

- [x] Unit tests for config resolution (env fallback precedence, URL parsing, no-proxy wildcard expansion, validation errors) — `OutboundProxyResolverTest`
- [x] Unit tests for Jetty and HC5 wiring (proxy + auth registration) — `OutboundProxyJettyTest`, `FogwallHttpExecutorTest`
- [x] Full build + jacoco coverage gate passing locally
- [ ] Manual verification against a real corporate authenticating proxy (in progress)