### PR TITLE
fix: reliably cancel PENDING pushes on client disconnect or gateway error over SSH

### DIFF
--- a/fogwall-core/src/main/java/com/rbc/fogwall/approval/ApprovalGateway.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/approval/ApprovalGateway.java
@@ -9,9 +9,11 @@ import java.time.Duration;
 public interface ApprovalGateway {
     /**
      * Wait until the push is approved, rejected, or canceled, or until timeout expires. Implementations should send
-     * heartbeat progress messages to keep the git client alive.
+     * heartbeat progress messages to keep the git client alive, and should treat a {@code false} result from
+     * {@code liveness} as an immediate {@link ApprovalResult#CANCELED}.
      */
-    ApprovalResult waitForApproval(String pushId, ProgressSender progress, Duration timeout);
+    ApprovalResult waitForApproval(
+            String pushId, ProgressSender progress, ClientLivenessCheck liveness, Duration timeout);
 
     /**
      * Returns {@code true} if this gateway approves pushes immediately without requiring human review.

--- a/fogwall-core/src/main/java/com/rbc/fogwall/approval/AutoApprovalGateway.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/approval/AutoApprovalGateway.java
@@ -27,7 +27,8 @@ public class AutoApprovalGateway implements ApprovalGateway {
     }
 
     @Override
-    public ApprovalResult waitForApproval(String pushId, ProgressSender progress, Duration timeout) {
+    public ApprovalResult waitForApproval(
+            String pushId, ProgressSender progress, ClientLivenessCheck liveness, Duration timeout) {
         try {
             pushStore.approve(
                     pushId,

--- a/fogwall-core/src/main/java/com/rbc/fogwall/approval/ClientLivenessCheck.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/approval/ClientLivenessCheck.java
@@ -1,0 +1,19 @@
+package com.rbc.fogwall.approval;
+
+/**
+ * Passive, read-side check for whether the git client on the other end of a store-and-forward push is still connected.
+ * Unlike the write-triggered {@link ClientDisconnectedException} path (which only surfaces a disconnect once a sideband
+ * message fails to flush), this is a cheap state read backed by the transport's own connection tracking, where such a
+ * signal exists - see {@link com.rbc.fogwall.git.PushTransport#livenessCheck()} for which transports actually have one.
+ */
+@FunctionalInterface
+public interface ClientLivenessCheck {
+
+    /** Returns {@code true} if the client connection is still believed to be open. */
+    boolean isConnected();
+
+    /** Always reports connected - used where no transport-level signal is available (e.g. HTTP, tests). */
+    static ClientLivenessCheck alwaysConnected() {
+        return () -> true;
+    }
+}

--- a/fogwall-core/src/main/java/com/rbc/fogwall/approval/UiApprovalGateway.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/approval/UiApprovalGateway.java
@@ -1,6 +1,7 @@
 package com.rbc.fogwall.approval;
 
 import com.rbc.fogwall.db.PushStore;
+import com.rbc.fogwall.db.model.PushRecord;
 import com.rbc.fogwall.db.model.PushStatus;
 import java.time.Duration;
 import java.util.Set;
@@ -24,12 +25,19 @@ public class UiApprovalGateway implements ApprovalGateway {
     }
 
     @Override
-    public ApprovalResult waitForApproval(String pushId, ProgressSender progress, Duration timeout) {
+    public ApprovalResult waitForApproval(
+            String pushId, ProgressSender progress, ClientLivenessCheck liveness, Duration timeout) {
         long deadlineMs = System.currentTimeMillis() + timeout.toMillis();
         long elapsedSecs = 0;
 
         while (System.currentTimeMillis() < deadlineMs) {
-            var record = pushStore.findById(pushId).orElse(null);
+            PushRecord record;
+            try {
+                record = pushStore.findById(pushId).orElse(null);
+            } catch (Exception e) {
+                log.error("Failed to poll push store for push {} - will retry next interval", pushId, e);
+                record = null;
+            }
             if (record != null && TERMINAL_STATUSES.contains(record.getStatus())) {
                 return switch (record.getStatus()) {
                     case APPROVED -> ApprovalResult.APPROVED;
@@ -39,11 +47,27 @@ public class UiApprovalGateway implements ApprovalGateway {
                 };
             }
 
+            if (!liveness.isConnected()) {
+                log.debug("Client connection already gone during approval wait for push {}", pushId);
+                return ApprovalResult.CANCELED;
+            }
+
             try {
                 //noinspection BusyWait
                 Thread.sleep(POLL_INTERVAL.toMillis());
                 elapsedSecs += POLL_INTERVAL.toSeconds();
+
+                if (!liveness.isConnected()) {
+                    log.debug("Client disconnected during approval wait for push {}", pushId);
+                    return ApprovalResult.CANCELED;
+                }
+
                 long remainingSecs = (deadlineMs - System.currentTimeMillis()) / 1000;
+                log.debug(
+                        "Approval poll tick for push {} ({}s elapsed, ~{}s remaining)",
+                        pushId,
+                        elapsedSecs,
+                        remainingSecs);
                 progress.send(
                         String.format("Awaiting review... (%ds elapsed, ~%ds remaining)", elapsedSecs, remainingSecs));
             } catch (ClientDisconnectedException e) {
@@ -55,6 +79,7 @@ public class UiApprovalGateway implements ApprovalGateway {
             }
         }
 
+        log.debug("Approval deadline reached for push {} - returning TIMED_OUT", pushId);
         return ApprovalResult.TIMED_OUT;
     }
 }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/ApprovalPreReceiveHook.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/ApprovalPreReceiveHook.java
@@ -8,6 +8,7 @@ import static com.rbc.fogwall.git.GitClientUtils.sym;
 import com.rbc.fogwall.approval.ApprovalGateway;
 import com.rbc.fogwall.approval.ApprovalResult;
 import com.rbc.fogwall.approval.ClientDisconnectedException;
+import com.rbc.fogwall.approval.ClientLivenessCheck;
 import com.rbc.fogwall.db.PushStore;
 import com.rbc.fogwall.db.model.Attestation;
 import com.rbc.fogwall.db.model.Attestation.Type;
@@ -41,6 +42,17 @@ import org.eclipse.jgit.transport.ReceivePack;
 public class ApprovalPreReceiveHook implements PreReceiveHook {
 
     private static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(30);
+
+    /**
+     * Grace period added on top of {@code timeout} before the outer wait gives up on the approval-gateway task. The
+     * gateway's own internal deadline uses the same {@code timeout} value, but its clock starts slightly later (once
+     * the submitted task is actually scheduled), so without this buffer the outer wait would race ahead and interrupt
+     * the gateway before it ever reaches its own deadline check — discarding whatever it was about to conclude (a clean
+     * timeout, a detected disconnect, anything) in favor of a generic, undiagnosable TIMED_OUT. This buffer makes the
+     * outer wait a true last-resort safety net for a genuinely hung task, not the thing that normally fires.
+     */
+    private static final Duration OUTER_WAIT_GRACE_PERIOD = Duration.ofSeconds(10);
+
     private static final ExecutorService APPROVAL_EXECUTOR = Executors.newVirtualThreadPerTaskExecutor();
 
     private final PushStore pushStore;
@@ -138,9 +150,13 @@ public class ApprovalPreReceiveHook implements PreReceiveHook {
 
         // All clean pushes are PENDING human review
         if (record.getStatus() == PushStatus.PENDING) {
+            ClientLivenessCheck liveness = pushContext != null
+                    ? pushContext.getTransport().livenessCheck()
+                    : ClientLivenessCheck.alwaysConnected();
+
             if (approvalGateway.approvesImmediately()) {
                 // Auto-approval: approve silently, no waiting messages or dashboard links
-                approvalGateway.waitForApproval(validationRecordId, msg -> {}, timeout);
+                approvalGateway.waitForApproval(validationRecordId, msg -> {}, liveness, timeout);
                 return;
             }
 
@@ -154,11 +170,11 @@ public class ApprovalPreReceiveHook implements PreReceiveHook {
                 sendAndFlush(rp, msgOut, color(YELLOW, "   Reason: " + record.getBlockedMessage()));
             }
 
-            Future<ApprovalResult> future = APPROVAL_EXECUTOR.submit(() ->
-                    approvalGateway.waitForApproval(validationRecordId, msg -> sendAndFlush(rp, msgOut, msg), timeout));
+            Future<ApprovalResult> future = APPROVAL_EXECUTOR.submit(() -> approvalGateway.waitForApproval(
+                    validationRecordId, msg -> sendAndFlush(rp, msgOut, msg), liveness, timeout));
             ApprovalResult result;
             try {
-                result = future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+                result = future.get(timeout.plus(OUTER_WAIT_GRACE_PERIOD).toMillis(), TimeUnit.MILLISECONDS);
             } catch (TimeoutException e) {
                 future.cancel(true);
                 result = ApprovalResult.TIMED_OUT;
@@ -167,7 +183,12 @@ public class ApprovalPreReceiveHook implements PreReceiveHook {
                 future.cancel(true);
                 result = ApprovalResult.CANCELED;
             } catch (ExecutionException e) {
-                log.error("Unexpected error in approval gateway", e.getCause());
+                log.error("Unexpected error in approval gateway for push {}", validationRecordId, e.getCause());
+                Throwable cause = e.getCause();
+                pushStore.updateForwardStatus(
+                        validationRecordId,
+                        PushStatus.ERROR,
+                        "Approval gateway error: " + (cause != null ? cause.getMessage() : e.getMessage()));
                 rejectAll(commands, "Approval error");
                 return;
             }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/GitClientUtils.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/GitClientUtils.java
@@ -2,6 +2,7 @@ package com.rbc.fogwall.git;
 
 import com.rbc.fogwall.db.model.PushStep;
 import com.rbc.fogwall.db.model.StepStatus;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -235,33 +236,35 @@ public class GitClientUtils {
      */
     public static String buildValidationSummary(List<PushStep> steps) {
         // Pure data / infrastructure steps that don't represent a user-visible check
-        Set<String> skipSteps = Set.of("diff", "diff:default-branch", "forward", "inspection");
+        Set<String> skipSteps = Set.of("diff", "diff:default-branch", "forward", "inspection", "commitEnrichment");
 
         // Human-readable label for each step name (header line)
-        Map<String, String> labels = new java.util.HashMap<>(Map.of(
-                "checkUrlRules", "Checking URL allow rules",
-                "checkUserPermission", "Checking user permission",
-                "identityVerification", "Verifying commit identity",
-                "checkEmptyBranch", "Checking branch",
-                "checkHiddenCommits", "Checking for hidden commits",
-                "checkAuthorEmails", "Checking author emails",
-                "checkCommitMessages", "Checking commit messages",
-                "scanDiff", "Scanning diff content",
-                "checkSignatures", "Checking GPG signatures",
-                "scanSecrets", "Scanning for secrets"));
+        Map<String, String> labels = new HashMap<>(Map.ofEntries(
+                Map.entry("checkUrlRules", "Checking URL allow rules"),
+                Map.entry("checkUserPermission", "Checking user permission"),
+                Map.entry("identityVerification", "Verifying commit identity"),
+                Map.entry("checkEmptyBranch", "Checking branch"),
+                Map.entry("checkHiddenCommits", "Checking for hidden commits"),
+                Map.entry("checkAuthorEmails", "Checking author emails"),
+                Map.entry("checkCommitMessages", "Checking commit messages"),
+                Map.entry("scanDiff", "Scanning diff content"),
+                Map.entry("checkSignatures", "Checking GPG signatures"),
+                Map.entry("scanSecrets", "Scanning for secrets"),
+                Map.entry("binaryBlob", "Scanning for binary blobs")));
 
         // Short pass-result text shown on the second line
-        Map<String, String> passResults = new java.util.HashMap<>(Map.of(
-                "checkUrlRules", "repository allowed",
-                "checkUserPermission", "user authorized",
-                "identityVerification", "identity verified",
-                "checkEmptyBranch", "branch OK",
-                "checkHiddenCommits", "no hidden commits",
-                "checkAuthorEmails", "emails OK",
-                "checkCommitMessages", "messages OK",
-                "scanDiff", "clean",
-                "checkSignatures", "signatures OK",
-                "scanSecrets", "no secrets detected"));
+        Map<String, String> passResults = new HashMap<>(Map.ofEntries(
+                Map.entry("checkUrlRules", "repository allowed"),
+                Map.entry("checkUserPermission", "user authorized"),
+                Map.entry("identityVerification", "identity verified"),
+                Map.entry("checkEmptyBranch", "branch OK"),
+                Map.entry("checkHiddenCommits", "no hidden commits"),
+                Map.entry("checkAuthorEmails", "emails OK"),
+                Map.entry("checkCommitMessages", "messages OK"),
+                Map.entry("scanDiff", "clean"),
+                Map.entry("checkSignatures", "signatures OK"),
+                Map.entry("scanSecrets", "no secrets detected"),
+                Map.entry("binaryBlob", "no blocked binary content")));
 
         List<PushStep> relevant = steps.stream()
                 .filter(s -> s.getStepOrder() >= 100 && s.getStepOrder() <= 400)

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/PushTransport.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/PushTransport.java
@@ -1,5 +1,6 @@
 package com.rbc.fogwall.git;
 
+import com.rbc.fogwall.approval.ClientLivenessCheck;
 import com.rbc.fogwall.user.UserEntry;
 import java.util.Optional;
 import org.eclipse.jgit.api.TransportConfigCallback;
@@ -38,6 +39,18 @@ public sealed interface PushTransport permits PushTransport.Http, PushTransport.
      */
     TransportConfigCallback transportConfigCallback();
 
+    /**
+     * Passive check for whether the client on this transport is still connected — see {@link ClientLivenessCheck}. Used
+     * by the approval-wait poll loop to detect a client disconnect (e.g. Ctrl+C) without depending solely on an
+     * outbound sideband write failing.
+     *
+     * <p>HTTP has no reliable signal here: Jetty doesn't watch a connection's read side while the request thread is
+     * blocked in the approval-wait poll loop, so a Jetty-{@code EndPoint}-backed check was tried and empirically
+     * confirmed to never fire (see #385) — {@link Http} always reports connected. SSH's MINA {@code ServerSession} is
+     * watched by its own independent read loop regardless of the command thread, so {@link Ssh} has a real signal.
+     */
+    ClientLivenessCheck livenessCheck();
+
     /** HTTP store-and-forward: no pre-authenticated user, upstream auth via credentials. */
     record Http() implements PushTransport {
         @Override
@@ -59,6 +72,11 @@ public sealed interface PushTransport permits PushTransport.Http, PushTransport.
         public TransportConfigCallback transportConfigCallback() {
             return null;
         }
+
+        @Override
+        public ClientLivenessCheck livenessCheck() {
+            return ClientLivenessCheck.alwaysConnected();
+        }
     }
 
     /**
@@ -68,8 +86,13 @@ public sealed interface PushTransport permits PushTransport.Http, PushTransport.
      * @param connectingFingerprint SHA-256 fingerprint of the key the client authenticated with — used by
      *     {@link com.rbc.fogwall.service.SshScmIdentityEnricher} to match against SCM-registered keys
      * @param transportConfig per-push SSH session factory injected into the upstream JGit transport
+     * @param livenessCheck backed by the MINA {@code ServerSession}'s close state
      */
-    record Ssh(UserEntry user, String connectingFingerprint, TransportConfigCallback transportConfig)
+    record Ssh(
+            UserEntry user,
+            String connectingFingerprint,
+            TransportConfigCallback transportConfig,
+            ClientLivenessCheck livenessCheck)
             implements PushTransport {
         @Override
         public String name() {
@@ -96,7 +119,11 @@ public sealed interface PushTransport permits PushTransport.Http, PushTransport.
         return new Http();
     }
 
-    static PushTransport ssh(UserEntry user, String connectingFingerprint, TransportConfigCallback transportConfig) {
-        return new Ssh(user, connectingFingerprint, transportConfig);
+    static PushTransport ssh(
+            UserEntry user,
+            String connectingFingerprint,
+            TransportConfigCallback transportConfig,
+            ClientLivenessCheck livenessCheck) {
+        return new Ssh(user, connectingFingerprint, transportConfig, livenessCheck);
     }
 }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/StoreAndForwardReceivePackFactory.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/StoreAndForwardReceivePackFactory.java
@@ -40,6 +40,7 @@ import org.eclipse.jgit.transport.resolver.ServiceNotEnabledException;
 public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<HttpServletRequest> {
 
     private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofSeconds(10);
+    private static final Duration DEFAULT_APPROVAL_TIMEOUT = Duration.ofMinutes(30);
 
     private final FogwallProvider provider;
     private final Supplier<CommitConfig> commitConfigSupplier;
@@ -63,6 +64,9 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
     /** Connect timeout in seconds passed to the JGit {@link org.eclipse.jgit.transport.Transport} (0 = no timeout). */
     private int connectTimeoutSeconds = 0;
 
+    /** Maximum time a push waits for human review before being marked timed out (see {@link ServerConfig}). */
+    private Duration approvalTimeout = DEFAULT_APPROVAL_TIMEOUT;
+
     /** Enable fail-fast mode. Call after construction before the factory handles any requests. */
     public void setFailFast(boolean failFast) {
         this.failFast = failFast;
@@ -80,6 +84,11 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
 
     public void setSshScmIdentityEnricher(SshScmIdentityEnricher enricher) {
         this.sshScmIdentityEnricher = enricher;
+    }
+
+    /** Set the approval-wait timeout. Call after construction before the factory handles any requests. */
+    public void setApprovalTimeout(Duration approvalTimeout) {
+        this.approvalTimeout = approvalTimeout != null ? approvalTimeout : DEFAULT_APPROVAL_TIMEOUT;
     }
 
     /** Fixed-config constructors for use in tests and simple setups (no URL rule enforcement). */
@@ -184,7 +193,7 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
             repoSlug = slug;
         }
 
-        return buildReceivePack(db, creds, pushUser, pushToken, repoSlug);
+        return buildReceivePack(db, creds, pushUser, pushToken, repoSlug, PushTransport.http());
     }
 
     /**
@@ -194,12 +203,6 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
     public ReceivePack createForSsh(Repository db, String pushUser, String repoSlug, PushTransport.Ssh transport)
             throws ServiceNotEnabledException, ServiceNotAuthorizedException {
         return buildReceivePack(db, null, pushUser, null, repoSlug, transport);
-    }
-
-    private ReceivePack buildReceivePack(
-            Repository db, CredentialsProvider creds, String pushUser, String pushToken, String repoSlug)
-            throws ServiceNotEnabledException, ServiceNotAuthorizedException {
-        return buildReceivePack(db, creds, pushUser, pushToken, repoSlug, PushTransport.http());
     }
 
     private ReceivePack buildReceivePack(
@@ -306,7 +309,7 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
             hooks.addAll(validationHooks);
             hooks.add(persistenceHook.validationResultHook(validationContext));
             hooks.add(new ApprovalPreReceiveHook(
-                    pushStore, approvalGateway, serviceUrl, repoPermissionService, pushContext));
+                    pushStore, approvalGateway, approvalTimeout, serviceUrl, repoPermissionService, pushContext));
             preHooks = hooks.toArray(PreReceiveHook[]::new);
         } else {
             preHooks = validationHooks.toArray(PreReceiveHook[]::new);

--- a/fogwall-core/src/test/java/com/rbc/fogwall/approval/AutoApprovalGatewayTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/approval/AutoApprovalGatewayTest.java
@@ -33,7 +33,8 @@ class AutoApprovalGatewayTest {
     void returnsApproved_immediately() {
         PushRecord r = blockedRecord();
 
-        ApprovalResult result = gateway.waitForApproval(r.getId(), msg -> {}, Duration.ofSeconds(30));
+        ApprovalResult result = gateway.waitForApproval(
+                r.getId(), msg -> {}, ClientLivenessCheck.alwaysConnected(), Duration.ofSeconds(30));
 
         assertEquals(ApprovalResult.APPROVED, result);
     }
@@ -42,7 +43,7 @@ class AutoApprovalGatewayTest {
     void recordsApprovalInStore() {
         PushRecord r = blockedRecord();
 
-        gateway.waitForApproval(r.getId(), msg -> {}, Duration.ofSeconds(30));
+        gateway.waitForApproval(r.getId(), msg -> {}, ClientLivenessCheck.alwaysConnected(), Duration.ofSeconds(30));
 
         PushRecord updated = pushStore.findById(r.getId()).orElseThrow();
         assertEquals(PushStatus.APPROVED, updated.getStatus());
@@ -52,7 +53,7 @@ class AutoApprovalGatewayTest {
     void attestation_isMarkedAutomated() {
         PushRecord r = blockedRecord();
 
-        gateway.waitForApproval(r.getId(), msg -> {}, Duration.ofSeconds(30));
+        gateway.waitForApproval(r.getId(), msg -> {}, ClientLivenessCheck.alwaysConnected(), Duration.ofSeconds(30));
 
         PushRecord updated = pushStore.findById(r.getId()).orElseThrow();
         assertNotNull(updated.getAttestation(), "Attestation should be set");
@@ -65,7 +66,8 @@ class AutoApprovalGatewayTest {
         PushRecord r = blockedRecord();
         List<String> messages = new ArrayList<>();
 
-        gateway.waitForApproval(r.getId(), messages::add, Duration.ofSeconds(30));
+        gateway.waitForApproval(
+                r.getId(), messages::add, ClientLivenessCheck.alwaysConnected(), Duration.ofSeconds(30));
 
         assertTrue(messages.isEmpty(), "AutoApprovalGateway should not send any progress messages");
     }
@@ -73,7 +75,8 @@ class AutoApprovalGatewayTest {
     @Test
     void returnsApproved_evenWhenStoreUpdateFails() {
         // Gateway should still return APPROVED if the store throws (e.g. record not found)
-        ApprovalResult result = gateway.waitForApproval("no-such-id", msg -> {}, Duration.ofSeconds(30));
+        ApprovalResult result = gateway.waitForApproval(
+                "no-such-id", msg -> {}, ClientLivenessCheck.alwaysConnected(), Duration.ofSeconds(30));
 
         assertEquals(ApprovalResult.APPROVED, result);
     }

--- a/fogwall-core/src/test/java/com/rbc/fogwall/approval/UiApprovalGatewayTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/approval/UiApprovalGatewayTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -49,7 +50,8 @@ class UiApprovalGatewayTest {
         r.setStatus(PushStatus.APPROVED);
         pushStore.save(r);
 
-        ApprovalResult result = gateway.waitForApproval(r.getId(), msg -> {}, Duration.ofSeconds(10));
+        ApprovalResult result = gateway.waitForApproval(
+                r.getId(), msg -> {}, ClientLivenessCheck.alwaysConnected(), Duration.ofSeconds(10));
 
         assertEquals(ApprovalResult.APPROVED, result);
     }
@@ -60,7 +62,8 @@ class UiApprovalGatewayTest {
         r.setStatus(PushStatus.REJECTED);
         pushStore.save(r);
 
-        ApprovalResult result = gateway.waitForApproval(r.getId(), msg -> {}, Duration.ofSeconds(10));
+        ApprovalResult result = gateway.waitForApproval(
+                r.getId(), msg -> {}, ClientLivenessCheck.alwaysConnected(), Duration.ofSeconds(10));
 
         assertEquals(ApprovalResult.REJECTED, result);
     }
@@ -71,7 +74,8 @@ class UiApprovalGatewayTest {
         r.setStatus(PushStatus.CANCELED);
         pushStore.save(r);
 
-        ApprovalResult result = gateway.waitForApproval(r.getId(), msg -> {}, Duration.ofSeconds(10));
+        ApprovalResult result = gateway.waitForApproval(
+                r.getId(), msg -> {}, ClientLivenessCheck.alwaysConnected(), Duration.ofSeconds(10));
 
         assertEquals(ApprovalResult.CANCELED, result);
     }
@@ -79,7 +83,8 @@ class UiApprovalGatewayTest {
     @Test
     void returnsTimedOut_whenPushIdNotFound() {
         // Non-existent record - should time out immediately since no record ever becomes terminal
-        ApprovalResult result = gateway.waitForApproval("no-such-id", msg -> {}, Duration.ofMillis(50));
+        ApprovalResult result = gateway.waitForApproval(
+                "no-such-id", msg -> {}, ClientLivenessCheck.alwaysConnected(), Duration.ofMillis(50));
 
         assertEquals(ApprovalResult.TIMED_OUT, result);
     }
@@ -88,7 +93,8 @@ class UiApprovalGatewayTest {
     void returnsTimedOut_whenRecordStaysBlocked() {
         PushRecord r = blockedRecord();
 
-        ApprovalResult result = gateway.waitForApproval(r.getId(), msg -> {}, Duration.ofMillis(60));
+        ApprovalResult result = gateway.waitForApproval(
+                r.getId(), msg -> {}, ClientLivenessCheck.alwaysConnected(), Duration.ofMillis(60));
 
         assertEquals(ApprovalResult.TIMED_OUT, result);
     }
@@ -112,7 +118,8 @@ class UiApprovalGatewayTest {
             });
             latch.countDown();
 
-            ApprovalResult result = gateway.waitForApproval(r.getId(), msg -> {}, Duration.ofSeconds(10));
+            ApprovalResult result = gateway.waitForApproval(
+                    r.getId(), msg -> {}, ClientLivenessCheck.alwaysConnected(), Duration.ofSeconds(10));
 
             assertEquals(ApprovalResult.APPROVED, result);
         } finally {
@@ -143,7 +150,8 @@ class UiApprovalGatewayTest {
             });
             latch.countDown();
 
-            ApprovalResult result = gateway.waitForApproval(r.getId(), msg -> {}, Duration.ofSeconds(10));
+            ApprovalResult result = gateway.waitForApproval(
+                    r.getId(), msg -> {}, ClientLivenessCheck.alwaysConnected(), Duration.ofSeconds(10));
 
             assertEquals(ApprovalResult.REJECTED, result);
         } finally {
@@ -159,7 +167,7 @@ class UiApprovalGatewayTest {
         List<String> messages = new ArrayList<>();
 
         // Short timeout with multiple poll intervals - should capture at least one progress message
-        gateway.waitForApproval(r.getId(), messages::add, Duration.ofMillis(60));
+        gateway.waitForApproval(r.getId(), messages::add, ClientLivenessCheck.alwaysConnected(), Duration.ofMillis(60));
 
         // After timeout, at least one heartbeat was sent
         assertFalse(messages.isEmpty(), "Expected at least one heartbeat message during polling");
@@ -178,7 +186,37 @@ class UiApprovalGatewayTest {
             throw new ClientDisconnectedException(new java.io.IOException("Broken pipe"));
         };
 
-        ApprovalResult result = gateway.waitForApproval(r.getId(), disconnectingSender, Duration.ofSeconds(10));
+        ApprovalResult result = gateway.waitForApproval(
+                r.getId(), disconnectingSender, ClientLivenessCheck.alwaysConnected(), Duration.ofSeconds(10));
+
+        assertEquals(ApprovalResult.CANCELED, result);
+    }
+
+    @Test
+    void returnsCanceled_whenLivenessCheckIsFalseBeforeFirstPoll() {
+        PushRecord r = blockedRecord();
+        List<String> messages = new ArrayList<>();
+
+        ApprovalResult result = gateway.waitForApproval(r.getId(), messages::add, () -> false, Duration.ofSeconds(10));
+
+        assertEquals(ApprovalResult.CANCELED, result);
+        assertTrue(messages.isEmpty(), "No progress message should be sent once the client is already gone");
+    }
+
+    @Test
+    void returnsCanceled_whenLivenessCheckFlipsFalseMidWait() {
+        PushRecord r = blockedRecord();
+        var connected = new AtomicBoolean(true);
+        List<String> messages = new ArrayList<>();
+
+        // Simulate the client vanishing partway through the poll loop, ahead of any write attempt.
+        ClientLivenessCheck liveness = () -> {
+            boolean wasConnected = connected.get();
+            connected.set(false);
+            return wasConnected;
+        };
+
+        ApprovalResult result = gateway.waitForApproval(r.getId(), messages::add, liveness, Duration.ofSeconds(10));
 
         assertEquals(ApprovalResult.CANCELED, result);
     }
@@ -190,7 +228,8 @@ class UiApprovalGatewayTest {
         PushRecord r = blockedRecord();
         var resultHolder = new ApprovalResult[1];
         var thread = new Thread(() -> {
-            resultHolder[0] = gateway.waitForApproval(r.getId(), msg -> {}, Duration.ofSeconds(30));
+            resultHolder[0] = gateway.waitForApproval(
+                    r.getId(), msg -> {}, ClientLivenessCheck.alwaysConnected(), Duration.ofSeconds(30));
         });
         thread.start();
 

--- a/fogwall-core/src/test/java/com/rbc/fogwall/git/ApprovalPreReceiveHookTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/git/ApprovalPreReceiveHookTest.java
@@ -121,7 +121,7 @@ class ApprovalPreReceiveHookTest {
         PushRecord record =
                 PushRecord.builder().id(recordId).status(PushStatus.PENDING).build();
         when(pushStore.findById(recordId)).thenReturn(Optional.of(record));
-        when(approvalGateway.waitForApproval(eq(recordId), any(), any(Duration.class)))
+        when(approvalGateway.waitForApproval(eq(recordId), any(), any(), any(Duration.class)))
                 .thenReturn(ApprovalResult.APPROVED);
 
         RevCommit c1 = createCommit("init");
@@ -145,7 +145,7 @@ class ApprovalPreReceiveHookTest {
         PushRecord updatedRecord =
                 PushRecord.builder().id(recordId).status(PushStatus.REJECTED).build();
         when(pushStore.findById(recordId)).thenReturn(Optional.of(record)).thenReturn(Optional.of(updatedRecord));
-        when(approvalGateway.waitForApproval(eq(recordId), any(), any(Duration.class)))
+        when(approvalGateway.waitForApproval(eq(recordId), any(), any(), any(Duration.class)))
                 .thenReturn(ApprovalResult.REJECTED);
 
         RevCommit c1 = createCommit("init");
@@ -256,7 +256,7 @@ class ApprovalPreReceiveHookTest {
                 .attestation(att)
                 .build();
         when(pushStore.findById(recordId)).thenReturn(Optional.of(pending)).thenReturn(Optional.of(approved));
-        when(approvalGateway.waitForApproval(eq(recordId), any(), any(Duration.class)))
+        when(approvalGateway.waitForApproval(eq(recordId), any(), any(), any(Duration.class)))
                 .thenReturn(ApprovalResult.APPROVED);
         RepoPermissionService perms = mock(RepoPermissionService.class);
         when(perms.isBypassReviewAllowed("alice", "github", "/owner/repo")).thenReturn(false);
@@ -315,7 +315,7 @@ class ApprovalPreReceiveHookTest {
         PushRecord record =
                 PushRecord.builder().id(recordId).status(PushStatus.PENDING).build();
         when(pushStore.findById(recordId)).thenReturn(Optional.of(record));
-        when(approvalGateway.waitForApproval(eq(recordId), any(), any(Duration.class)))
+        when(approvalGateway.waitForApproval(eq(recordId), any(), any(), any(Duration.class)))
                 .thenReturn(ApprovalResult.TIMED_OUT);
 
         RevCommit c1 = createCommit("init");
@@ -339,7 +339,7 @@ class ApprovalPreReceiveHookTest {
                 PushRecord.builder().id(recordId).status(PushStatus.PENDING).build();
         // First call: initial fetch; second call: re-fetch inside CANCELED branch
         when(pushStore.findById(recordId)).thenReturn(Optional.of(pending));
-        when(approvalGateway.waitForApproval(eq(recordId), any(), any(Duration.class)))
+        when(approvalGateway.waitForApproval(eq(recordId), any(), any(), any(Duration.class)))
                 .thenReturn(ApprovalResult.CANCELED);
 
         RevCommit c1 = createCommit("init");
@@ -365,7 +365,7 @@ class ApprovalPreReceiveHookTest {
                 PushRecord.builder().id(recordId).status(PushStatus.CANCELED).build();
         // First call returns PENDING (hook start), second call returns CANCELED (re-fetch in CANCELED branch)
         when(pushStore.findById(recordId)).thenReturn(Optional.of(pending)).thenReturn(Optional.of(alreadyCanceled));
-        when(approvalGateway.waitForApproval(eq(recordId), any(), any(Duration.class)))
+        when(approvalGateway.waitForApproval(eq(recordId), any(), any(), any(Duration.class)))
                 .thenReturn(ApprovalResult.CANCELED);
 
         RevCommit c1 = createCommit("init");

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
@@ -100,6 +100,11 @@ public class JettyConfigurationBuilder {
         return config.getServer().getHeartbeatIntervalSeconds();
     }
 
+    /** Returns the store-and-forward approval wait timeout in seconds. */
+    public int getApprovalTimeoutSeconds() {
+        return config.getServer().getApprovalTimeoutSeconds();
+    }
+
     /** Returns whether fail-fast validation is enabled (stop after first failure). */
     public boolean isFailFast() {
         return config.getServer().isFailFast();
@@ -442,6 +447,7 @@ public class JettyConfigurationBuilder {
                 buildCommitConfig(),
                 getServiceUrl(),
                 getHeartbeatIntervalSeconds(),
+                getApprovalTimeoutSeconds(),
                 isFailFast(),
                 getUpstreamConnectTimeoutSeconds(),
                 getProxyConnectTimeoutSeconds(),

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/ServerConfig.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/ServerConfig.java
@@ -36,6 +36,12 @@ public class ServerConfig {
     private int heartbeatIntervalSeconds = 10;
 
     /**
+     * Maximum time in seconds a store-and-forward push waits for human review before the record is marked timed out.
+     * Only applies to {@code ui}/{@code servicenow} approval modes — {@code auto} approves immediately and never waits.
+     */
+    private int approvalTimeoutSeconds = 1800;
+
+    /**
      * When {@code true}, the validation pipeline stops after the first failed check rather than collecting all issues.
      * The developer sees only the first problem per push. Defaults to {@code false} (collect all issues).
      */

--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallContext.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallContext.java
@@ -34,6 +34,7 @@ public record FogwallContext(
         CommitConfig commitConfig,
         String serviceUrl,
         int heartbeatIntervalSeconds,
+        int approvalTimeoutSeconds,
         boolean failFast,
         int upstreamConnectTimeoutSeconds,
         int proxyConnectTimeoutSeconds,

--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallServletRegistrar.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallServletRegistrar.java
@@ -99,6 +99,7 @@ public final class FogwallServletRegistrar {
                         fogwallContext.pushIdentityResolver(),
                         fogwallContext.repoPermissionService(),
                         fogwallContext.heartbeatIntervalSeconds(),
+                        fogwallContext.approvalTimeoutSeconds(),
                         fogwallContext.failFast(),
                         fogwallContext.upstreamConnectTimeoutSeconds(),
                         fogwallContext.urlRuleRegistry(),
@@ -163,6 +164,7 @@ public final class FogwallServletRegistrar {
                 fogwallContext.urlRuleRegistry());
         factory.setFailFast(configBuilder.isFailFast());
         factory.setConnectTimeoutSeconds(fogwallContext.upstreamConnectTimeoutSeconds());
+        factory.setApprovalTimeout(Duration.ofSeconds(fogwallContext.approvalTimeoutSeconds()));
         factory.setCache(fogwallContext.storeForwardCache());
         factory.setSshScmIdentityEnricher(fogwallContext.sshScmIdentityEnricher());
         return factory;
@@ -182,6 +184,7 @@ public final class FogwallServletRegistrar {
             PushIdentityResolver pushIdentityResolver,
             RepoPermissionService repoPermissionService,
             int heartbeatIntervalSeconds,
+            int approvalTimeoutSeconds,
             boolean failFast,
             int connectTimeoutSeconds,
             UrlRuleRegistry urlRuleRegistry,
@@ -204,6 +207,7 @@ public final class FogwallServletRegistrar {
                 urlRuleRegistry);
         factory.setFailFast(failFast);
         factory.setConnectTimeoutSeconds(connectTimeoutSeconds);
+        factory.setApprovalTimeout(Duration.ofSeconds(approvalTimeoutSeconds));
         factory.setCache(cache);
 
         var gitServlet = new GitServlet();

--- a/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitReceiveCommand.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitReceiveCommand.java
@@ -1,5 +1,6 @@
 package com.rbc.fogwall.ssh;
 
+import com.rbc.fogwall.approval.ClientLivenessCheck;
 import com.rbc.fogwall.git.LocalRepositoryCache;
 import com.rbc.fogwall.git.PushTransport;
 import com.rbc.fogwall.git.StoreAndForwardReceivePackFactory;
@@ -18,6 +19,8 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.sshd.agent.SshAgent;
 import org.apache.sshd.agent.SshAgentConstants;
+import org.apache.sshd.common.Closeable;
+import org.apache.sshd.common.channel.exception.SshChannelClosedException;
 import org.apache.sshd.common.config.keys.KeyUtils;
 import org.apache.sshd.common.util.buffer.Buffer;
 import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
@@ -26,6 +29,7 @@ import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
 import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
+import org.apache.sshd.server.session.ServerSession;
 import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.CredentialsProvider;
@@ -99,15 +103,20 @@ public class SshGitReceiveCommand implements Command {
         String sshUser = channel.getSession().getUsername();
         // Resolved during public-key auth — may be absent if the store returned empty (shouldn't happen
         // since auth would have been rejected, but guard defensively).
-        var serverSession = (org.apache.sshd.server.session.ServerSession) channel.getSession();
+        var serverSession = (ServerSession) channel.getSession();
         UserEntry resolvedUser = SshGitServer.getResolvedUser(serverSession).orElse(null);
         String connectingFingerprint =
                 SshGitServer.getConnectingFingerprint(serverSession).orElse(null);
         // SSH_AUTH_SOCK is set on the channel env by MINA SSHD when the client's ssh -A forwarding
         // channel is established. Capture it here before handing off to the worker thread.
         String authSocket = env.getEnv().get(SshAgent.SSH_AUTHSOCKET_ENV_NAME);
+        // The session's own close state is maintained by MINA's read loop independent of this worker
+        // thread, so it reflects a client disconnect even while the worker sits in the approval-wait poll.
+        ClientLivenessCheck liveness = serverSession instanceof Closeable closeable
+                ? () -> !closeable.isClosing()
+                : ClientLivenessCheck.alwaysConnected();
         Thread worker = new Thread(
-                () -> runReceivePack(sshUser, resolvedUser, connectingFingerprint, authSocket),
+                () -> runReceivePack(sshUser, resolvedUser, connectingFingerprint, authSocket, liveness),
                 "ssh-git-receive-" + repoPath);
         worker.setDaemon(true);
         worker.start();
@@ -145,7 +154,11 @@ public class SshGitReceiveCommand implements Command {
     record RepoRoute(String owner, String repo, String upstreamUrl, String repoSlug) {}
 
     private void runReceivePack(
-            String sshUser, UserEntry resolvedUser, String connectingFingerprint, String authSocket) {
+            String sshUser,
+            UserEntry resolvedUser,
+            String connectingFingerprint,
+            String authSocket,
+            ClientLivenessCheck liveness) {
         int exitCode = 0;
         SshAgent agent = null;
         try {
@@ -242,7 +255,7 @@ public class SshGitReceiveCommand implements Command {
                 }
             };
 
-            var pushTransport = new PushTransport.Ssh(resolvedUser, connectingFingerprint, transportConfig);
+            var pushTransport = new PushTransport.Ssh(resolvedUser, connectingFingerprint, transportConfig, liveness);
 
             Repository localRepo = cache.getOrClone(upstreamUrl, null, transportConfig);
             localRepo.getConfig().setString("fogwall", null, "upstreamUrl", upstreamUrl);
@@ -252,6 +265,11 @@ public class SshGitReceiveCommand implements Command {
             rp.setBiDirectionalPipe(true); // factory defaults to false for HTTP; SSH is bidirectional
             rp.receive(in, out, err);
 
+        } catch (SshChannelClosedException e) {
+            // Expected when the client disconnects mid-wait: ReceivePack.close() tries to flush final sideband
+            // data after we've already detected the disconnect and canceled the push. Nothing left to report to.
+            log.debug("SSH channel already closed for {} (client disconnected)", repoPath);
+            exitCode = 1;
         } catch (Exception e) {
             log.error("SSH git-receive-pack failed for {}", repoPath, e);
             writeError("Internal error: " + e.getMessage());

--- a/fogwall-server/src/main/resources/fogwall.yml
+++ b/fogwall-server/src/main/resources/fogwall.yml
@@ -10,6 +10,9 @@ server:
   # Sends a "." progress packet periodically to prevent idle-timeout disconnects during long validation steps
   # (e.g. secret scanning, approval polling). Set to 0 to disable.
   heartbeat-interval-seconds: 10
+  # Maximum time in seconds a store-and-forward push waits for human review before the record is marked
+  # timed out (and canceled). Only applies to 'ui'/'servicenow' approval modes.
+  approval-timeout-seconds: 1800
   # HTTP session persistence backend. Options:
   #   none   — in-memory sessions (default); sessions are lost on restart and not shared across instances
   #   jdbc   — persisted to the configured JDBC database (h2-file or postgres);

--- a/fogwall-server/src/test/java/com/rbc/fogwall/e2e/AutoApproveGateway.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/e2e/AutoApproveGateway.java
@@ -2,6 +2,7 @@ package com.rbc.fogwall.e2e;
 
 import com.rbc.fogwall.approval.ApprovalGateway;
 import com.rbc.fogwall.approval.ApprovalResult;
+import com.rbc.fogwall.approval.ClientLivenessCheck;
 import com.rbc.fogwall.approval.ProgressSender;
 import com.rbc.fogwall.db.PushStore;
 import com.rbc.fogwall.db.model.Attestation;
@@ -20,7 +21,8 @@ class AutoApproveGateway implements ApprovalGateway {
     }
 
     @Override
-    public ApprovalResult waitForApproval(String pushId, ProgressSender progress, Duration timeout) {
+    public ApprovalResult waitForApproval(
+            String pushId, ProgressSender progress, ClientLivenessCheck liveness, Duration timeout) {
         pushStore.approve(
                 pushId,
                 Attestation.builder()


### PR DESCRIPTION
## Summary

`#356` mitigated but didn't solve #385: it only detected a client disconnect via a sideband write failing, which doesn't fire reliably in practice — OS-level buffering lets writes to a half-open socket succeed long after the client is gone. Reproduced locally with an actual client Ctrl+C: on the HTTP store-and-forward path, no disconnect was ever detected across multiple poll cycles, and the push only resolved via the wall-clock timeout fallback.

Two more silent gaps in `ApprovalPreReceiveHook` compounded the problem, both confirmed via local logging/DB inspection during this investigation:
- An outer/inner timeout race — `future.get(timeout, ...)`'s clock starts slightly before the submitted approval-wait task's own clock, so the outer wrapper would interrupt the inner loop before it ever got to log or report what it found.
- Any exception escaping the poll loop (e.g. a transient `PushStore` lookup failure) was silently discarded without writing any terminal status, leaving the record `PENDING` forever with no trace besides a log line.

## Changes

- **`ClientLivenessCheck`** — a passive per-transport liveness signal, threaded through `PushTransport` → `ApprovalGateway` → `UiApprovalGateway`.
  - **SSH**: backed by the MINA `ServerSession`'s own close state, watched by MINA's independent read loop regardless of the blocked command thread. Confirmed via local testing to detect a disconnect within one 5s poll cycle, with the push record correctly landing on `CANCELED` / `"Client disconnected"`.
  - **HTTP**: a Jetty `EndPoint`-backed equivalent was built and tested, then removed — confirmed empirically to never fire, since Jetty doesn't watch a connection's read side while the request thread is blocked in the approval-wait loop. HTTP intentionally has no liveness signal; it still relies on the existing write-failure detection plus the wall-clock timeout fallback.
- Fixed the outer/inner timeout race with a grace-period buffer so the poll loop always finishes and reports its own result first.
- `ExecutionException` from the poll loop now writes `PushStatus.ERROR` instead of silently discarding the result.
- Catch-all around the poll loop's `PushStore` lookup so a transient failure retries next tick instead of killing the wait.
- `server.approval-timeout-seconds` is now a real config key (was hardcoded) — needed to test any of this without a 30-minute wait.
- Cleaned up two client-facing step labels that were falling back to raw internal step names (`commitEnrichment`, `binaryBlob`).

Filed as follow-ups, not fixed here: [#428](https://github.com/RBC/fogwall/issues/428) (SSH `git-upload-pack`/clone not implemented — discovered while testing this) and [#429](https://github.com/RBC/fogwall/issues/429) (`CompositeUserStore.findBySshFingerprint` doesn't merge config + DB user data — discovered while testing this). Both milestoned to 1.3.0 alongside this fix.

closes #385

## Test plan

- [x] `./gradlew :fogwall-core:test :fogwall-server:test` — full suite green (one unrelated local Testcontainers/Podman failure in `MongoGroupPermissionStoreIntegrationTest`, not reproducible in CI with Docker)
- [x] New unit tests in `UiApprovalGatewayTest` for the liveness-triggered cancellation path
- [x] Manual local reproduction: HTTP push + Ctrl+C mid-approval-wait — confirmed no disconnect detected (expected, documented limitation), record still resolves correctly via timeout
- [x] Manual local reproduction: SSH push + Ctrl+C mid-approval-wait — confirmed `CANCELED` / `"Client disconnected"` written within ~5s, verified via DB record inspection