### PR TITLE
fix: merge config-sourced user data on SSH fingerprint lookup, fix SSH key removal 403

### DIFF
--- a/fogwall-core/src/main/java/com/rbc/fogwall/user/CompositeUserStore.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/user/CompositeUserStore.java
@@ -200,7 +200,58 @@ public class CompositeUserStore implements UserStore {
     @Override
     public Optional<UserEntry> findBySshFingerprint(String fingerprint) {
         Optional<UserEntry> fromConfig = configStore.findBySshFingerprint(fingerprint);
-        return fromConfig.isPresent() ? fromConfig : mutableStore.findBySshFingerprint(fingerprint);
+        if (fromConfig.isPresent()) {
+            return fromConfig;
+        }
+        return mutableStore.findBySshFingerprint(fingerprint).map(this::mergeConfigFields);
+    }
+
+    /**
+     * Merges config-sourced emails/scmIdentities/sshKeys onto a {@link UserEntry} resolved from the mutable store, for
+     * a username that is also config-defined.
+     *
+     * <p>Needed because lookups keyed by something other than username (e.g. an SSH key fingerprint added via the
+     * dashboard, not YAML) can resolve a config-defined user via the mutable store's own fingerprint index — but the
+     * raw mutable-store record doesn't carry that username's config-only supplemental data (e.g.
+     * {@code scm-identities}), unlike {@link #findScmIdentitiesWithVerified} and friends which already merge correctly
+     * by username. Without this, e.g. SSH auth via a dashboard-added key resolves a user with no linked SCM identities
+     * even though the config declares them.
+     */
+    private UserEntry mergeConfigFields(UserEntry fromMutable) {
+        Optional<UserEntry> configUser = configStore.findByUsername(fromMutable.getUsername());
+        if (configUser.isEmpty()) {
+            return fromMutable;
+        }
+        UserEntry cfg = configUser.get();
+
+        List<String> mergedEmails = new ArrayList<>(cfg.getEmails());
+        fromMutable.getEmails().stream()
+                .filter(e -> !cfg.getEmails().contains(e))
+                .forEach(mergedEmails::add);
+
+        Set<String> configScmKeys = cfg.getScmIdentities().stream()
+                .map(id -> id.getProvider() + ":" + id.getUsername())
+                .collect(Collectors.toSet());
+        List<ScmIdentity> mergedScmIdentities = new ArrayList<>(cfg.getScmIdentities());
+        fromMutable.getScmIdentities().stream()
+                .filter(id -> !configScmKeys.contains(id.getProvider() + ":" + id.getUsername()))
+                .forEach(mergedScmIdentities::add);
+
+        Set<String> configFingerprints =
+                cfg.getSshKeys().stream().map(SshKeyEntry::getFingerprint).collect(Collectors.toSet());
+        List<SshKeyEntry> mergedSshKeys = new ArrayList<>(cfg.getSshKeys());
+        fromMutable.getSshKeys().stream()
+                .filter(k -> !configFingerprints.contains(k.getFingerprint()))
+                .forEach(mergedSshKeys::add);
+
+        return UserEntry.builder()
+                .username(fromMutable.getUsername())
+                .passwordHash(fromMutable.getPasswordHash())
+                .emails(mergedEmails)
+                .scmIdentities(mergedScmIdentities)
+                .sshKeys(mergedSshKeys)
+                .roles(fromMutable.getRoles())
+                .build();
     }
 
     @Override
@@ -222,7 +273,7 @@ public class CompositeUserStore implements UserStore {
         // Block removal of config-locked keys
         configStore.findByUsername(username).ifPresent(u -> {
             boolean inConfig = u.getSshKeys().stream().anyMatch(k -> k.getId().equals(keyId));
-            if (inConfig) throw new IllegalStateException("SSH key is locked by config and cannot be removed");
+            if (inConfig) throw new LockedByConfigException(username);
         });
         mutableStore.removeSshKey(username, keyId);
     }

--- a/fogwall-core/src/test/java/com/rbc/fogwall/user/CompositeUserStoreTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/user/CompositeUserStoreTest.java
@@ -92,6 +92,35 @@ class CompositeUserStoreTest {
         assertTrue(store.findByScmIdentity("github", "bob-gh").isPresent());
     }
 
+    @Test
+    void findBySshFingerprint_unknown_returnsEmpty() {
+        assertTrue(store.findBySshFingerprint("SHA256:nope").isEmpty());
+    }
+
+    @Test
+    void findBySshFingerprint_dbOnlyUser_returnsDbVersion() {
+        jdbcStore.createUser("bob", "{noop}pw", "USER");
+        jdbcStore.addSshKey("bob", "SHA256:bobkey", "ssh-ed25519 AAAAbob", "bob's key");
+        var result = store.findBySshFingerprint("SHA256:bobkey");
+        assertTrue(result.isPresent());
+        assertEquals("bob", result.get().getUsername());
+    }
+
+    @Test
+    void findBySshFingerprint_configUserWithDbAddedKey_mergesConfigScmIdentities() {
+        // alice is config-defined with a config scmIdentity, but adds her SSH key via the dashboard (DB-only) —
+        // resolving her by that key's fingerprint must still surface her config-declared scmIdentities (#429).
+        store.addSshKey("alice", "SHA256:alicekey", "ssh-ed25519 AAAAalice", "alice's key");
+
+        var result = store.findBySshFingerprint("SHA256:alicekey");
+
+        assertTrue(result.isPresent());
+        assertEquals("alice", result.get().getUsername());
+        assertEquals(1, result.get().getScmIdentities().size());
+        assertEquals("alice-config", result.get().getScmIdentities().get(0).getUsername());
+        assertEquals(List.of("alice@config.com"), result.get().getEmails());
+    }
+
     // ── findAll merges both ──────────────────────────────────────────────────────
 
     @Test

--- a/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/ProfileController.java
+++ b/fogwall-dashboard/src/main/java/com/rbc/fogwall/dashboard/controller/ProfileController.java
@@ -181,7 +181,11 @@ public class ProfileController {
     @DeleteMapping("/ssh-keys/{id}")
     public ResponseEntity<?> removeSshKey(@PathVariable String id) {
         if (!(userStore instanceof UserStore mutable)) return NOT_MUTABLE;
-        mutable.removeSshKey(currentUsername(), id);
+        try {
+            mutable.removeSshKey(currentUsername(), id);
+        } catch (LockedByConfigException e) {
+            return LOCKED_BY_CONFIG;
+        }
         return ResponseEntity.noContent().build();
     }
 

--- a/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/ProfileControllerTest.java
+++ b/fogwall-dashboard/src/test/java/com/rbc/fogwall/dashboard/controller/ProfileControllerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -16,7 +17,10 @@ import com.rbc.fogwall.user.EmailConflictException;
 import com.rbc.fogwall.user.LockedByConfigException;
 import com.rbc.fogwall.user.LockedEmailException;
 import com.rbc.fogwall.user.ScmIdentityConflictException;
+import com.rbc.fogwall.user.SshKeyConflictException;
+import com.rbc.fogwall.user.SshKeyEntry;
 import com.rbc.fogwall.user.UserStore;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,9 +51,9 @@ class ProfileControllerTest {
     @BeforeEach
     void setupSecurityContext() {
         Authentication auth = mock(Authentication.class);
-        when(auth.getName()).thenReturn("alice");
+        lenient().when(auth.getName()).thenReturn("alice");
         SecurityContext ctx = mock(SecurityContext.class);
-        when(ctx.getAuthentication()).thenReturn(auth);
+        lenient().when(ctx.getAuthentication()).thenReturn(auth);
         SecurityContextHolder.setContext(ctx);
     }
 
@@ -163,6 +167,93 @@ class ProfileControllerTest {
     void removeScmIdentity_success_returns204() {
         var resp = controller.removeScmIdentity("github", "alice-gh");
         assertEquals(HttpStatus.NO_CONTENT, resp.getStatusCode());
+    }
+
+    // ── SSH key management (GET/POST/DELETE /api/me/ssh-keys) ───────────────────
+    // Regression coverage for #429-adjacent DELETE /api/me/ssh-keys/{id} returning an unhandled 400/500 instead of
+    // a clean 403 when removing a config-locked key - CompositeUserStore.removeSshKey now throws
+    // LockedByConfigException (matching removeEmail/removeScmIdentity) instead of a bare IllegalStateException.
+
+    private static final String TEST_SSH_KEY =
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIQiTzhWg82OVGUGpUMctA7FoBSZteJQ5R/TPaVfCC95";
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void listSshKeys_returnsRegisteredKeys() {
+        SshKeyEntry key = SshKeyEntry.builder()
+                .id("key-1")
+                .username("alice")
+                .fingerprint("SHA256:abc")
+                .publicKey(TEST_SSH_KEY)
+                .label("laptop")
+                .createdAt(Instant.EPOCH)
+                .build();
+        when(userStore.findSshKeys("alice")).thenReturn(List.of(key));
+
+        var resp = controller.listSshKeys();
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        var body = (List<Map<String, String>>) resp.getBody();
+        assertEquals(1, body.size());
+        assertEquals("key-1", body.get(0).get("id"));
+        assertEquals("SHA256:abc", body.get(0).get("fingerprint"));
+    }
+
+    @Test
+    void addSshKey_missingPublicKey_returns400() {
+        var resp = controller.addSshKey(Map.of());
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void addSshKey_malformedPublicKey_returns400() {
+        var resp = controller.addSshKey(Map.of("publicKey", "not-an-ssh-key"));
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+    }
+
+    @Test
+    void addSshKey_conflict_returns409() {
+        when(userStore.addSshKey(eq("alice"), any(), any(), any()))
+                .thenThrow(new SshKeyConflictException("SHA256:abc", "bob"));
+
+        var resp = controller.addSshKey(Map.of("publicKey", TEST_SSH_KEY, "label", "laptop"));
+
+        assertEquals(HttpStatus.CONFLICT, resp.getStatusCode());
+    }
+
+    @Test
+    void addSshKey_success_returns200() {
+        SshKeyEntry entry = SshKeyEntry.builder()
+                .id("key-1")
+                .username("alice")
+                .fingerprint("SHA256:abc")
+                .publicKey(TEST_SSH_KEY)
+                .label("laptop")
+                .createdAt(Instant.EPOCH)
+                .build();
+        when(userStore.addSshKey(eq("alice"), any(), any(), eq("laptop"))).thenReturn(entry);
+
+        var resp = controller.addSshKey(Map.of("publicKey", TEST_SSH_KEY, "label", "laptop"));
+
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        verify(userStore).addSshKey(eq("alice"), any(), any(), eq("laptop"));
+    }
+
+    @Test
+    void removeSshKey_configLocked_returns403() {
+        doThrow(new LockedByConfigException("alice")).when(userStore).removeSshKey(eq("alice"), eq("key-1"));
+
+        var resp = controller.removeSshKey("key-1");
+
+        assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+    }
+
+    @Test
+    void removeSshKey_success_returns204() {
+        var resp = controller.removeSshKey("key-1");
+
+        assertEquals(HttpStatus.NO_CONTENT, resp.getStatusCode());
+        verify(userStore).removeSshKey("alice", "key-1");
     }
 
     // ── GET /api/me/permissions ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`CompositeUserStore.findBySshFingerprint()` returned either the config store's or the mutable store's `UserEntry` with no merge, unlike every other enriched lookup in the class (`findEmailsWithVerified`, `findScmIdentitiesWithVerified`, `findSshKeys`). A config-defined user who adds an additional SSH key via the dashboard (DB-only, invisible to the config store) resolves via the mutable store on that key's fingerprint — returning a `UserEntry` missing all config-sourced `scmIdentities`, `emails`, and `sshKeys`.

In practice this broke SSH push identity verification: `SshScmIdentityEnricher` saw an empty `scmIdentities` list and rejected the push, even though the user's SCM identity was correctly declared in config. Root-caused and reproduced locally while testing #385.

## Changes

- `CompositeUserStore.findBySshFingerprint()` now merges config-sourced fields onto a mutable-store-resolved `UserEntry`, mirroring the merge pattern already used elsewhere in the class.
- **Also fixes** `DELETE /api/me/ssh-keys/{id}` returning an unhandled 400 instead of a clean 403 when removing a config-locked key — `CompositeUserStore.removeSshKey` threw a bare `IllegalStateException` instead of the `LockedByConfigException` that `removeEmail`/`removeScmIdentity` already use, and `ProfileController.removeSshKey` had no catch block for it at all. Discovered while testing the fingerprint fix; same class of gap, same fix shape.
- Full CRUD test coverage added for `/api/me/ssh-keys` (list, add success/conflict/validation, remove success/config-locked) — there was no prior coverage for that endpoint group at all.

closes #429

## Test plan

- [x] New unit tests in `CompositeUserStoreTest` for the fingerprint-merge path (DB-only user, config user with DB-added key, unknown fingerprint)
- [x] New unit tests in `ProfileControllerTest` covering full SSH key CRUD, including the config-locked removal 403 regression case
- [x] `./gradlew :fogwall-core:test :fogwall-dashboard:test` — full suite green