### PR TITLE
feat: implement git-upload-pack (clone/fetch) over SSH store-and-forward

### DIFF
--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/SshServerRegistrar.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/SshServerRegistrar.java
@@ -51,8 +51,8 @@ public class SshServerRegistrar {
 
         FogwallProvider sshProvider = sshProviders.get(0);
         var factory = FogwallServletRegistrar.buildReceivePackFactory(ctx, configBuilder, sshProvider);
-        SshGitServer server =
-                SshGitServer.create(sshConfig, sshProvider, ctx.storeForwardCache(), factory, ctx.userStore());
+        SshGitServer server = SshGitServer.create(
+                sshConfig, sshProvider, ctx.storeForwardCache(), factory, ctx.userStore(), ctx.urlRuleRegistry());
         server.start();
         return server;
     }

--- a/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitCommandFactory.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitCommandFactory.java
@@ -1,5 +1,6 @@
 package com.rbc.fogwall.ssh;
 
+import com.rbc.fogwall.db.UrlRuleRegistry;
 import com.rbc.fogwall.git.LocalRepositoryCache;
 import com.rbc.fogwall.git.StoreAndForwardReceivePackFactory;
 import com.rbc.fogwall.provider.FogwallProvider;
@@ -11,9 +12,8 @@ import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.command.CommandFactory;
 
 /**
- * MINA SSHD {@link CommandFactory} that maps {@code git-receive-pack} SSH commands to {@link SshGitReceiveCommand}.
- * Only store-and-forward push is supported in this initial implementation; {@code git-upload-pack} (clone/fetch) is not
- * yet implemented.
+ * MINA SSHD {@link CommandFactory} that maps {@code git-receive-pack} SSH commands to {@link SshGitReceiveCommand} and
+ * {@code git-upload-pack} commands to {@link SshGitUploadCommand}.
  */
 @Slf4j
 @RequiredArgsConstructor
@@ -23,21 +23,31 @@ public class SshGitCommandFactory implements CommandFactory {
     private final LocalRepositoryCache cache;
     private final StoreAndForwardReceivePackFactory receivePackFactory;
     private final FogwallProxyAgentFactory agentFactory;
+    private final UrlRuleRegistry urlRuleRegistry;
 
     @Override
     public Command createCommand(ChannelSession channel, String command) throws IOException {
         log.debug("SSH command received: {}", command);
 
         if (command.startsWith("git-receive-pack ")) {
-            String rawPath = command.substring("git-receive-pack ".length()).trim();
-            // Strip surrounding single or double quotes added by the git client
-            String repoPath = rawPath.replaceAll("^['\"]|['\"]$", "");
+            String repoPath =
+                    stripQuotes(command.substring("git-receive-pack ".length()).trim());
             return new SshGitReceiveCommand(repoPath, provider, cache, receivePackFactory, agentFactory);
         }
 
-        // git-upload-pack (clone/fetch) not yet implemented
+        if (command.startsWith("git-upload-pack ")) {
+            String repoPath =
+                    stripQuotes(command.substring("git-upload-pack ".length()).trim());
+            return new SshGitUploadCommand(repoPath, provider, cache, agentFactory, urlRuleRegistry);
+        }
+
         log.warn("Unsupported SSH git command: {}", command);
-        throw new IOException(
-                "Unsupported command: " + command + " (only git-receive-pack is currently supported over SSH)");
+        throw new IOException("Unsupported command: " + command
+                + " (only git-receive-pack and git-upload-pack are supported over SSH)");
+    }
+
+    /** Strips surrounding single or double quotes added by the git client. */
+    private static String stripQuotes(String rawPath) {
+        return rawPath.replaceAll("^['\"]|['\"]$", "");
     }
 }

--- a/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitReceiveCommand.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitReceiveCommand.java
@@ -6,25 +6,13 @@ import com.rbc.fogwall.git.PushTransport;
 import com.rbc.fogwall.git.StoreAndForwardReceivePackFactory;
 import com.rbc.fogwall.provider.FogwallProvider;
 import com.rbc.fogwall.user.UserEntry;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.InetSocketAddress;
-import java.nio.file.Path;
-import java.security.PublicKey;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.sshd.agent.SshAgent;
-import org.apache.sshd.agent.SshAgentConstants;
 import org.apache.sshd.common.Closeable;
 import org.apache.sshd.common.channel.exception.SshChannelClosedException;
-import org.apache.sshd.common.config.keys.KeyUtils;
-import org.apache.sshd.common.util.buffer.Buffer;
-import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
-import org.apache.sshd.common.util.buffer.keys.BufferPublicKeyParser;
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
 import org.apache.sshd.server.channel.ChannelSession;
@@ -32,24 +20,14 @@ import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.session.ServerSession;
 import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.ReceivePack;
-import org.eclipse.jgit.transport.SshTransport;
-import org.eclipse.jgit.transport.sshd.DefaultProxyDataFactory;
-import org.eclipse.jgit.transport.sshd.JGitKeyCache;
-import org.eclipse.jgit.transport.sshd.ServerKeyDatabase;
-import org.eclipse.jgit.transport.sshd.SshdSessionFactory;
-import org.eclipse.jgit.transport.sshd.agent.Connector;
-import org.eclipse.jgit.transport.sshd.agent.ConnectorFactory;
-import org.eclipse.jgit.transport.sshd.agent.ConnectorFactory.ConnectorDescriptor;
 
 /**
  * MINA SSHD {@link Command} that handles {@code git-receive-pack} over SSH. Delegates to the same
  * {@link StoreAndForwardReceivePackFactory} hook chain used by the HTTP push path.
  *
- * <p>Upstream authentication uses the client's forwarded SSH agent (requires {@code ssh -A}). The agent is retrieved
- * from the inbound MINA SSHD session and exposed to JGit's outbound SSH transport via a {@link Connector} bridge that
- * translates JGit's wire-protocol RPC calls into {@link SshAgent} method invocations.
+ * <p>Upstream authentication uses the client's forwarded SSH agent (requires {@code ssh -A}) via
+ * {@link SshUpstreamTransport}, shared with {@link SshGitUploadCommand}.
  */
 @Slf4j
 public class SshGitReceiveCommand implements Command {
@@ -187,74 +165,7 @@ public class SshGitReceiveCommand implements Command {
 
             log.info("SSH git-receive-pack: user='{}' path={} -> {}", sshUser, repoPath, upstreamUrl);
 
-            SshAgent capturedAgent = agent;
-            SshdSessionFactory perPushFactory =
-                    new SshdSessionFactory(new JGitKeyCache(), new DefaultProxyDataFactory()) {
-                        @Override
-                        protected ConnectorFactory getConnectorFactory() {
-                            return new ConnectorFactory() {
-                                @Override
-                                public Connector create(String identityAgent, File homeDir) {
-                                    return new SshAgentConnector(capturedAgent);
-                                }
-
-                                @Override
-                                public boolean isSupported() {
-                                    return true;
-                                }
-
-                                @Override
-                                public String getName() {
-                                    return "forwarded-agent";
-                                }
-
-                                @Override
-                                public java.util.Collection<ConnectorDescriptor> getSupportedConnectors() {
-                                    return List.of(getDefaultConnector());
-                                }
-
-                                @Override
-                                public ConnectorDescriptor getDefaultConnector() {
-                                    return new ConnectorDescriptor() {
-                                        @Override
-                                        public String getIdentityAgent() {
-                                            return "SSH_AUTH_SOCK";
-                                        }
-
-                                        @Override
-                                        public String getDisplayName() {
-                                            return "Forwarded SSH Agent";
-                                        }
-                                    };
-                                }
-                            };
-                        }
-
-                        @Override
-                        protected ServerKeyDatabase getServerKeyDatabase(File homeDir, File sshDir) {
-                            return new AcceptAllKnownServerKeyDatabase(super.getServerKeyDatabase(homeDir, sshDir));
-                        }
-
-                        @Override
-                        protected String getDefaultPreferredAuthentications() {
-                            return "publickey";
-                        }
-
-                        @Override
-                        protected List<Path> getDefaultIdentities(File sshDir) {
-                            // Never load identity files from ~/.ssh — agent forwarding is the only auth path.
-                            return List.of();
-                        }
-                    };
-
-            // Inject the per-push factory via TransportConfigCallback — each push gets its own
-            // isolated SSH session factory scoped to the forwarded agent, avoiding global mutation.
-            TransportConfigCallback transportConfig = transport -> {
-                if (transport instanceof SshTransport sshTransport) {
-                    sshTransport.setSshSessionFactory(perPushFactory);
-                }
-            };
-
+            TransportConfigCallback transportConfig = SshUpstreamTransport.forwardedAgent(agent);
             var pushTransport = new PushTransport.Ssh(resolvedUser, connectingFingerprint, transportConfig, liveness);
 
             Repository localRepo = cache.getOrClone(upstreamUrl, null, transportConfig);
@@ -297,125 +208,4 @@ public class SshGitReceiveCommand implements Command {
 
     @Override
     public void destroy(ChannelSession channel) {}
-
-    /**
-     * Bridges MINA SSHD's in-process forwarded {@link SshAgent} into JGit's {@link Connector} interface. JGit uses
-     * {@link Connector} as a raw SSH-agent wire-protocol transport; we implement the two operations fogwall needs —
-     * {@code REQUEST_IDENTITIES} and {@code SIGN_REQUEST} — by delegating directly to the {@link SshAgent} methods and
-     * re-encoding the responses in the expected wire format.
-     */
-    private static final class SshAgentConnector implements Connector {
-
-        private final SshAgent agent;
-
-        SshAgentConnector(SshAgent agent) {
-            this.agent = agent;
-        }
-
-        @Override
-        public boolean connect() throws IOException {
-            return agent != null && agent.isOpen();
-        }
-
-        @Override
-        public byte[] rpc(byte command, byte[] message) throws IOException {
-            if (command == SshAgentConstants.SSH2_AGENTC_REQUEST_IDENTITIES) {
-                return encodeIdentities(agent.getIdentities());
-            }
-            if (command == SshAgentConstants.SSH2_AGENTC_SIGN_REQUEST) {
-                return sign(message);
-            }
-            throw new IOException("Unsupported SSH agent command: " + SshAgentConstants.getCommandMessageName(command));
-        }
-
-        private static byte[] encodeIdentities(Iterable<? extends Map.Entry<PublicKey, String>> identities)
-                throws IOException {
-            List<Map.Entry<PublicKey, String>> list = new ArrayList<>();
-            for (var entry : identities) list.add(entry);
-
-            ByteArrayBuffer buf = new ByteArrayBuffer();
-            buf.putByte(SshAgentConstants.SSH2_AGENT_IDENTITIES_ANSWER);
-            buf.putInt(list.size());
-            for (var entry : list) {
-                buf.putPublicKey(entry.getKey());
-                buf.putString(entry.getValue());
-            }
-            return buf.getCompactData();
-        }
-
-        private byte[] sign(byte[] message) throws IOException {
-            // Wire layout from SshAgentClient: [4-byte-length][command=13][pubkey-blob][data-blob][flags:int]
-            // putPublicKey writes [4-byte-outer-len][keytype-len][keytype][key-material],
-            // so use getPublicKey (not getRawPublicKey) to consume the outer length first.
-            Buffer buf = new ByteArrayBuffer(message);
-            buf.rpos(5); // skip 4-byte length prefix + 1-byte command byte
-            PublicKey key = buf.getPublicKey(BufferPublicKeyParser.DEFAULT);
-            byte[] data = buf.getBytes();
-            int flags = buf.getInt();
-
-            String keyType = KeyUtils.getKeyType(key);
-            String algorithm =
-                    switch (flags) {
-                        case 4 -> KeyUtils.RSA_SHA512_KEY_TYPE_ALIAS;
-                        case 2 -> KeyUtils.RSA_SHA256_KEY_TYPE_ALIAS;
-                        default -> keyType;
-                    };
-
-            Map.Entry<String, byte[]> sig = agent.sign(null, key, algorithm, data);
-
-            // Encode inner blob: [algo:string][sig-bytes:bytes]
-            ByteArrayBuffer sigContent = new ByteArrayBuffer();
-            sigContent.putString(sig.getKey());
-            sigContent.putBytes(sig.getValue());
-
-            // Response: [SSH2_AGENT_SIGN_RESPONSE][outer-length][inner-blob]
-            ByteArrayBuffer reply = new ByteArrayBuffer();
-            reply.putByte(SshAgentConstants.SSH2_AGENT_SIGN_RESPONSE);
-            reply.putBytes(sigContent.getCompactData());
-            return reply.getCompactData();
-        }
-
-        @Override
-        public void close() {
-            // Don't close — agent lifetime is tied to the inbound SSH session
-        }
-    }
-
-    /**
-     * Wraps a delegate {@link ServerKeyDatabase} but never blocks waiting for user interaction. If the upstream host
-     * key is not in known_hosts, it is accepted with a warning rather than hanging on a TTY prompt.
-     */
-    private static final class AcceptAllKnownServerKeyDatabase implements ServerKeyDatabase {
-
-        private final ServerKeyDatabase delegate;
-
-        AcceptAllKnownServerKeyDatabase(ServerKeyDatabase delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public List<PublicKey> lookup(
-                String connectAddress, InetSocketAddress remoteAddress, ServerKeyDatabase.Configuration config) {
-            return delegate.lookup(connectAddress, remoteAddress, config);
-        }
-
-        @Override
-        public boolean accept(
-                String connectAddress,
-                InetSocketAddress remoteAddress,
-                PublicKey serverKey,
-                ServerKeyDatabase.Configuration config,
-                CredentialsProvider provider) {
-            List<PublicKey> known = delegate.lookup(connectAddress, remoteAddress, config);
-            for (PublicKey k : known) {
-                if (KeyUtils.compareKeys(k, serverKey)) {
-                    return true;
-                }
-            }
-            log.warn(
-                    "SSH upstream: accepting UNKNOWN host key for {} — add to ~/.ssh/known_hosts to suppress",
-                    connectAddress);
-            return true;
-        }
-    }
 }

--- a/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitServer.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitServer.java
@@ -1,6 +1,7 @@
 package com.rbc.fogwall.ssh;
 
 import com.rbc.fogwall.config.SshConfig;
+import com.rbc.fogwall.db.UrlRuleRegistry;
 import com.rbc.fogwall.git.LocalRepositoryCache;
 import com.rbc.fogwall.git.StoreAndForwardReceivePackFactory;
 import com.rbc.fogwall.provider.FogwallProvider;
@@ -18,9 +19,9 @@ import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
 
 /**
- * Wraps an Apache MINA SSHD server that accepts {@code git push} connections over SSH. On each push,
- * {@link SshGitCommandFactory} routes the {@code git-receive-pack} command to {@link SshGitReceiveCommand}, which runs
- * the same validation hook chain as the HTTP store-and-forward path.
+ * Wraps an Apache MINA SSHD server that accepts {@code git push}/{@code git fetch} connections over SSH.
+ * {@link SshGitCommandFactory} routes {@code git-receive-pack} to {@link SshGitReceiveCommand} (which runs the same
+ * validation hook chain as the HTTP store-and-forward path) and {@code git-upload-pack} to {@link SshGitUploadCommand}.
  *
  * <p>Upstream authentication uses SSH agent forwarding. Clients must connect with agent forwarding enabled ({@code ssh
  * -A}, or {@code ForwardAgent yes} in {@code ~/.ssh/config}). Fogwall relays the forwarded agent to authenticate with
@@ -30,12 +31,7 @@ import org.apache.sshd.server.session.ServerSession;
  * looked up in the user store at connection time to resolve their {@link UserEntry}, which is then stored on the MINA
  * session for use by {@link SshGitReceiveCommand}.
  *
- * <p>MVP constraints:
- *
- * <ul>
- *   <li>Only a single provider is supported per server instance.
- *   <li>{@code git-upload-pack} (clone/fetch over SSH) is not yet implemented.
- * </ul>
+ * <p>MVP constraint: only a single provider is supported per server instance.
  */
 @Slf4j
 public class SshGitServer {
@@ -57,7 +53,8 @@ public class SshGitServer {
             FogwallProvider provider,
             LocalRepositoryCache cache,
             StoreAndForwardReceivePackFactory receivePackFactory,
-            ReadOnlyUserStore userStore)
+            ReadOnlyUserStore userStore,
+            UrlRuleRegistry urlRuleRegistry)
             throws IOException {
 
         SshServer sshd = SshServer.setUpDefaultServer();
@@ -75,7 +72,8 @@ public class SshGitServer {
         sshd.setAgentFactory(agentFactory);
         sshd.setForwardingFilter(AcceptAllForwardingFilter.INSTANCE);
 
-        sshd.setCommandFactory(new SshGitCommandFactory(provider, cache, receivePackFactory, agentFactory));
+        sshd.setCommandFactory(
+                new SshGitCommandFactory(provider, cache, receivePackFactory, agentFactory, urlRuleRegistry));
 
         return new SshGitServer(sshd);
     }

--- a/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitUploadCommand.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitUploadCommand.java
@@ -1,0 +1,179 @@
+package com.rbc.fogwall.ssh;
+
+import com.rbc.fogwall.db.UrlRuleRegistry;
+import com.rbc.fogwall.git.HttpOperation;
+import com.rbc.fogwall.git.LocalRepositoryCache;
+import com.rbc.fogwall.provider.FogwallProvider;
+import com.rbc.fogwall.servlet.filter.UrlRuleEvaluator;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.sshd.agent.SshAgent;
+import org.apache.sshd.common.channel.exception.SshChannelClosedException;
+import org.apache.sshd.server.Environment;
+import org.apache.sshd.server.ExitCallback;
+import org.apache.sshd.server.channel.ChannelSession;
+import org.apache.sshd.server.command.Command;
+import org.eclipse.jgit.api.TransportConfigCallback;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.transport.UploadPack;
+
+/**
+ * MINA SSHD {@link Command} that handles {@code git-upload-pack} (clone/fetch) over SSH.
+ *
+ * <p>Mirrors {@link SshGitReceiveCommand}'s connection handling — resolves the route, syncs the local mirror from
+ * upstream via the client's forwarded SSH agent (see {@link SshUpstreamTransport}), then serves the fetch from the
+ * synced local repo.
+ *
+ * <p>URL allow/deny rules are enforced explicitly here via {@link UrlRuleEvaluator} before syncing/serving. HTTP
+ * enforces this for both push and fetch via {@code UrlRuleAggregateFilter}, a servlet filter — SSH has no equivalent
+ * filter chain, so this is the only enforcement point for fetch on this transport (push already gets it via
+ * {@code RepositoryUrlRuleHook} in the shared JGit hook chain). No other push-side hook applies here: content
+ * validation and approval gating are push-specific, and fetch has no fogwall-side permission grant on either transport
+ * today — access is delegated to the upstream SCM via the forwarded agent, same as HTTP delegates via client-forwarded
+ * credentials.
+ */
+@Slf4j
+public class SshGitUploadCommand implements Command {
+
+    private final String repoPath;
+    private final FogwallProvider provider;
+    private final LocalRepositoryCache cache;
+    private final FogwallProxyAgentFactory agentFactory;
+    private final UrlRuleRegistry urlRuleRegistry;
+
+    private InputStream in;
+    private OutputStream out;
+    private OutputStream err;
+    private ExitCallback exitCallback;
+
+    SshGitUploadCommand(
+            String repoPath,
+            FogwallProvider provider,
+            LocalRepositoryCache cache,
+            FogwallProxyAgentFactory agentFactory,
+            UrlRuleRegistry urlRuleRegistry) {
+        this.repoPath = repoPath;
+        this.provider = provider;
+        this.cache = cache;
+        this.agentFactory = agentFactory;
+        this.urlRuleRegistry = urlRuleRegistry;
+    }
+
+    @Override
+    public void setInputStream(InputStream in) {
+        this.in = in;
+    }
+
+    @Override
+    public void setOutputStream(OutputStream out) {
+        this.out = out;
+    }
+
+    @Override
+    public void setErrorStream(OutputStream err) {
+        this.err = err;
+    }
+
+    @Override
+    public void setExitCallback(ExitCallback callback) {
+        this.exitCallback = callback;
+    }
+
+    @Override
+    public void start(ChannelSession channel, Environment env) {
+        String sshUser = channel.getSession().getUsername();
+        // SSH_AUTH_SOCK is set on the channel env by MINA SSHD when the client's ssh -A forwarding
+        // channel is established. Capture it here before handing off to the worker thread.
+        String authSocket = env.getEnv().get(SshAgent.SSH_AUTHSOCKET_ENV_NAME);
+        Thread worker = new Thread(() -> runUploadPack(sshUser, authSocket), "ssh-git-upload-" + repoPath);
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    private void runUploadPack(String sshUser, String authSocket) {
+        int exitCode = 0;
+        SshAgent agent = null;
+        try {
+            SshGitReceiveCommand.RepoRoute route;
+            try {
+                route = SshGitReceiveCommand.resolveRoute(repoPath, provider.getUri());
+            } catch (IllegalArgumentException e) {
+                writeError(e.getMessage());
+                exitCode = 128;
+                return;
+            }
+            String owner = route.owner();
+            String repo = route.repo();
+            String upstreamUrl = route.upstreamUrl();
+
+            // Mirrors UrlRuleAggregateFilter's fetch-side gate — the only enforcement point for URL allow/deny
+            // rules on this transport, since SSH has no servlet filter chain.
+            var evaluator = new UrlRuleEvaluator(urlRuleRegistry, provider);
+            String slug = owner + "/" + repo;
+            UrlRuleEvaluator.Result result = evaluator.evaluate(slug, owner, repo, HttpOperation.FETCH);
+            if (!(result instanceof UrlRuleEvaluator.Result.Allowed allowed)) {
+                String reason = result instanceof UrlRuleEvaluator.Result.Denied denied
+                        ? "Repository blocked by deny rule: " + denied.ruleId()
+                        : "Repository not in allow list";
+                log.debug("SSH fetch blocked for {}: {}", repoPath, reason);
+                writeError(reason);
+                exitCode = 128;
+                return;
+            } else {
+                log.debug("SSH fetch allowed by rule: {}", allowed.ruleId());
+            }
+
+            // Look up the forwarded SSH agent by the proxy ID that MINA SSHD stored in the
+            // channel env as SSH_AUTH_SOCK when the client's ssh -A request was processed.
+            agent = agentFactory.getForwardedAgent(authSocket);
+            if (agent == null || !agent.isOpen()) {
+                writeError(
+                        "SSH agent forwarding required — connect with 'ssh -A' or set 'ForwardAgent yes' in ~/.ssh/config");
+                exitCode = 128;
+                return;
+            }
+
+            log.info("SSH git-upload-pack: user='{}' path={} -> {}", sshUser, repoPath, upstreamUrl);
+
+            TransportConfigCallback transportConfig = SshUpstreamTransport.forwardedAgent(agent);
+            Repository localRepo = cache.getOrClone(upstreamUrl, null, transportConfig);
+            localRepo.getConfig().setString("fogwall", null, "upstreamUrl", upstreamUrl);
+            localRepo.getConfig().save();
+
+            UploadPack up = new UploadPack(localRepo);
+            up.setBiDirectionalPipe(true);
+            up.upload(in, out, err);
+
+        } catch (SshChannelClosedException e) {
+            log.debug("SSH channel already closed for {} (client disconnected)", repoPath);
+            exitCode = 1;
+        } catch (Exception e) {
+            log.error("SSH git-upload-pack failed for {}", repoPath, e);
+            writeError("Internal error: " + e.getMessage());
+            exitCode = 1;
+        } finally {
+            if (agent != null) {
+                try {
+                    agent.close();
+                } catch (IOException ignored) {
+                }
+            }
+            if (exitCallback != null) {
+                exitCallback.onExit(exitCode);
+            }
+        }
+    }
+
+    private void writeError(String message) {
+        try {
+            err.write(("error: " + message + "\n").getBytes());
+            err.flush();
+        } catch (IOException ignored) {
+        }
+    }
+
+    @Override
+    public void destroy(ChannelSession channel) {}
+}

--- a/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshUpstreamTransport.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshUpstreamTransport.java
@@ -1,0 +1,227 @@
+package com.rbc.fogwall.ssh;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.sshd.agent.SshAgent;
+import org.apache.sshd.agent.SshAgentConstants;
+import org.apache.sshd.common.config.keys.KeyUtils;
+import org.apache.sshd.common.util.buffer.Buffer;
+import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
+import org.apache.sshd.common.util.buffer.keys.BufferPublicKeyParser;
+import org.eclipse.jgit.api.TransportConfigCallback;
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.SshTransport;
+import org.eclipse.jgit.transport.sshd.DefaultProxyDataFactory;
+import org.eclipse.jgit.transport.sshd.JGitKeyCache;
+import org.eclipse.jgit.transport.sshd.ServerKeyDatabase;
+import org.eclipse.jgit.transport.sshd.SshdSessionFactory;
+import org.eclipse.jgit.transport.sshd.agent.Connector;
+import org.eclipse.jgit.transport.sshd.agent.ConnectorFactory;
+import org.eclipse.jgit.transport.sshd.agent.ConnectorFactory.ConnectorDescriptor;
+
+/**
+ * Builds a JGit {@link TransportConfigCallback} that routes outbound SSH transport (to the upstream SCM) through a
+ * MINA-forwarded {@link SshAgent} instead of loading identity files from disk. Shared by {@link SshGitReceiveCommand}
+ * and {@link SshGitUploadCommand} - each push/fetch gets its own isolated {@link SshdSessionFactory} scoped to the
+ * connecting client's forwarded agent, avoiding global mutation.
+ */
+@Slf4j
+final class SshUpstreamTransport {
+
+    private SshUpstreamTransport() {}
+
+    /** Builds a per-connection {@link TransportConfigCallback} backed by the given forwarded agent. */
+    static TransportConfigCallback forwardedAgent(SshAgent agent) {
+        SshdSessionFactory factory = new SshdSessionFactory(new JGitKeyCache(), new DefaultProxyDataFactory()) {
+            @Override
+            protected ConnectorFactory getConnectorFactory() {
+                return new ConnectorFactory() {
+                    @Override
+                    public Connector create(String identityAgent, File homeDir) {
+                        return new SshAgentConnector(agent);
+                    }
+
+                    @Override
+                    public boolean isSupported() {
+                        return true;
+                    }
+
+                    @Override
+                    public String getName() {
+                        return "forwarded-agent";
+                    }
+
+                    @Override
+                    public java.util.Collection<ConnectorDescriptor> getSupportedConnectors() {
+                        return List.of(getDefaultConnector());
+                    }
+
+                    @Override
+                    public ConnectorDescriptor getDefaultConnector() {
+                        return new ConnectorDescriptor() {
+                            @Override
+                            public String getIdentityAgent() {
+                                return "SSH_AUTH_SOCK";
+                            }
+
+                            @Override
+                            public String getDisplayName() {
+                                return "Forwarded SSH Agent";
+                            }
+                        };
+                    }
+                };
+            }
+
+            @Override
+            protected ServerKeyDatabase getServerKeyDatabase(File homeDir, File sshDir) {
+                return new AcceptAllKnownServerKeyDatabase(super.getServerKeyDatabase(homeDir, sshDir));
+            }
+
+            @Override
+            protected String getDefaultPreferredAuthentications() {
+                return "publickey";
+            }
+
+            @Override
+            protected List<Path> getDefaultIdentities(File sshDir) {
+                // Never load identity files from ~/.ssh — agent forwarding is the only auth path.
+                return List.of();
+            }
+        };
+
+        return transport -> {
+            if (transport instanceof SshTransport sshTransport) {
+                sshTransport.setSshSessionFactory(factory);
+            }
+        };
+    }
+
+    /**
+     * Bridges MINA SSHD's in-process forwarded {@link SshAgent} into JGit's {@link Connector} interface. JGit uses
+     * {@link Connector} as a raw SSH-agent wire-protocol transport; we implement the two operations fogwall needs —
+     * {@code REQUEST_IDENTITIES} and {@code SIGN_REQUEST} — by delegating directly to the {@link SshAgent} methods and
+     * re-encoding the responses in the expected wire format.
+     */
+    private static final class SshAgentConnector implements Connector {
+
+        private final SshAgent agent;
+
+        SshAgentConnector(SshAgent agent) {
+            this.agent = agent;
+        }
+
+        @Override
+        public boolean connect() throws IOException {
+            return agent != null && agent.isOpen();
+        }
+
+        @Override
+        public byte[] rpc(byte command, byte[] message) throws IOException {
+            if (command == SshAgentConstants.SSH2_AGENTC_REQUEST_IDENTITIES) {
+                return encodeIdentities(agent.getIdentities());
+            }
+            if (command == SshAgentConstants.SSH2_AGENTC_SIGN_REQUEST) {
+                return sign(message);
+            }
+            throw new IOException("Unsupported SSH agent command: " + SshAgentConstants.getCommandMessageName(command));
+        }
+
+        private static byte[] encodeIdentities(Iterable<? extends Map.Entry<PublicKey, String>> identities)
+                throws IOException {
+            List<Map.Entry<PublicKey, String>> list = new ArrayList<>();
+            for (var entry : identities) list.add(entry);
+
+            ByteArrayBuffer buf = new ByteArrayBuffer();
+            buf.putByte(SshAgentConstants.SSH2_AGENT_IDENTITIES_ANSWER);
+            buf.putInt(list.size());
+            for (var entry : list) {
+                buf.putPublicKey(entry.getKey());
+                buf.putString(entry.getValue());
+            }
+            return buf.getCompactData();
+        }
+
+        private byte[] sign(byte[] message) throws IOException {
+            // Wire layout from SshAgentClient: [4-byte-length][command=13][pubkey-blob][data-blob][flags:int]
+            // putPublicKey writes [4-byte-outer-len][keytype-len][keytype][key-material],
+            // so use getPublicKey (not getRawPublicKey) to consume the outer length first.
+            Buffer buf = new ByteArrayBuffer(message);
+            buf.rpos(5); // skip 4-byte length prefix + 1-byte command byte
+            PublicKey key = buf.getPublicKey(BufferPublicKeyParser.DEFAULT);
+            byte[] data = buf.getBytes();
+            int flags = buf.getInt();
+
+            String keyType = KeyUtils.getKeyType(key);
+            String algorithm =
+                    switch (flags) {
+                        case 4 -> KeyUtils.RSA_SHA512_KEY_TYPE_ALIAS;
+                        case 2 -> KeyUtils.RSA_SHA256_KEY_TYPE_ALIAS;
+                        default -> keyType;
+                    };
+
+            Map.Entry<String, byte[]> sig = agent.sign(null, key, algorithm, data);
+
+            // Encode inner blob: [algo:string][sig-bytes:bytes]
+            ByteArrayBuffer sigContent = new ByteArrayBuffer();
+            sigContent.putString(sig.getKey());
+            sigContent.putBytes(sig.getValue());
+
+            // Response: [SSH2_AGENT_SIGN_RESPONSE][outer-length][inner-blob]
+            ByteArrayBuffer reply = new ByteArrayBuffer();
+            reply.putByte(SshAgentConstants.SSH2_AGENT_SIGN_RESPONSE);
+            reply.putBytes(sigContent.getCompactData());
+            return reply.getCompactData();
+        }
+
+        @Override
+        public void close() {
+            // Don't close — agent lifetime is tied to the inbound SSH session
+        }
+    }
+
+    /**
+     * Wraps a delegate {@link ServerKeyDatabase} but never blocks waiting for user interaction. If the upstream host
+     * key is not in known_hosts, it is accepted with a warning rather than hanging on a TTY prompt.
+     */
+    private static final class AcceptAllKnownServerKeyDatabase implements ServerKeyDatabase {
+
+        private final ServerKeyDatabase delegate;
+
+        AcceptAllKnownServerKeyDatabase(ServerKeyDatabase delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public List<PublicKey> lookup(
+                String connectAddress, InetSocketAddress remoteAddress, ServerKeyDatabase.Configuration config) {
+            return delegate.lookup(connectAddress, remoteAddress, config);
+        }
+
+        @Override
+        public boolean accept(
+                String connectAddress,
+                InetSocketAddress remoteAddress,
+                PublicKey serverKey,
+                ServerKeyDatabase.Configuration config,
+                CredentialsProvider provider) {
+            List<PublicKey> known = delegate.lookup(connectAddress, remoteAddress, config);
+            for (PublicKey k : known) {
+                if (KeyUtils.compareKeys(k, serverKey)) {
+                    return true;
+                }
+            }
+            log.warn(
+                    "SSH upstream: accepting UNKNOWN host key for {} — add to ~/.ssh/known_hosts to suppress",
+                    connectAddress);
+            return true;
+        }
+    }
+}

--- a/fogwall-server/src/test/java/com/rbc/fogwall/e2e/SshE2ETest.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/e2e/SshE2ETest.java
@@ -2,6 +2,9 @@ package com.rbc.fogwall.e2e;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.rbc.fogwall.db.model.AccessRule;
+import com.rbc.fogwall.db.model.MatchTarget;
+import com.rbc.fogwall.db.model.MatchType;
 import com.rbc.fogwall.db.model.PushQuery;
 import com.rbc.fogwall.db.model.PushStatus;
 import java.io.IOException;
@@ -12,11 +15,13 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.*;
 
 /**
- * End-to-end tests for the SSH store-and-forward path.
+ * End-to-end tests for the SSH store-and-forward path — both {@code git-receive-pack} (push) and
+ * {@code git-upload-pack} (fetch/clone).
  *
- * <p>Each test clones the upstream test repo from Gitea over HTTP, switches the push remote to fogwall's SSH port, and
- * pushes a unique commit. The test key is pre-seeded in fogwall's {@link com.rbc.fogwall.user.StaticUserStore} and
- * registered with Gitea, so the full agent-forwarding path is exercised end-to-end.
+ * <p>Push-focused tests clone the upstream test repo from Gitea over HTTP, switch the push remote to fogwall's SSH
+ * port, and push a unique commit. Fetch-focused tests clone directly through fogwall's SSH endpoint. The test key is
+ * pre-seeded in fogwall's {@link com.rbc.fogwall.user.StaticUserStore} and registered with Gitea, so the full
+ * agent-forwarding path is exercised end-to-end.
  *
  * <p>Infrastructure: a Gitea container with SSH exposed, fogwall's SSH server on an ephemeral port, and a real
  * {@code ssh-agent} process started in {@link #startInfrastructure()}.
@@ -104,10 +109,10 @@ class SshE2ETest {
 
     /**
      * Clones the test repo from Gitea via HTTP, sets the push remote to fogwall SSH, and configures a valid author.
-     * Returns the cloned repo path.
+     * Returns the cloned repo path. Push-focused tests only care about the push path, so cloning directly from upstream
+     * keeps setup independent of the fetch-via-SSH path covered separately below.
      */
     private Path prepareRepo(String dirSuffix) throws Exception {
-        // Clone over HTTP (upload-pack via SSH not yet implemented), then redirect push remote to fogwall SSH
         var git = sshGit();
         Path repo = git.clone(
                 gitea.getBaseUrl() + "/" + GiteaContainer.TEST_ORG + "/" + GiteaContainer.TEST_REPO + ".git",
@@ -207,6 +212,40 @@ class SshE2ETest {
         assertTrue(
                 result.output().contains("agent forwarding") || result.output().contains("ssh -A"),
                 "Expected agent forwarding hint in output:\n" + result.output());
+    }
+
+    @Test
+    @Order(5)
+    void fetchViaSsh_clonesRepoContent() throws Exception {
+        var git = sshGit();
+        Path repo = git.clone(proxy.pushUrl(GiteaContainer.TEST_ORG, GiteaContainer.TEST_REPO), "ssh-fetch");
+
+        assertTrue(Files.isDirectory(repo.resolve(".git")), "Expected a valid git repo to be cloned via SSH");
+        runCmd(repo, "git", "log", "-1"); // throws if HEAD doesn't resolve to a real commit
+    }
+
+    @Test
+    @Order(6)
+    void fetchViaSsh_deniedByUrlRule_isRejected() throws Exception {
+        // Lower ruleOrder than the fixture's catch-all allow (order 1), so this is evaluated first.
+        // Last test in the class by design — no cleanup needed for a rule that outlives this method.
+        proxy.getUrlRuleRegistry()
+                .save(AccessRule.builder()
+                        .ruleOrder(0)
+                        .access(AccessRule.Access.DENY)
+                        .operation(AccessRule.Operation.BOTH)
+                        .target(MatchTarget.SLUG)
+                        .value(GiteaContainer.TEST_ORG + "/" + GiteaContainer.TEST_REPO)
+                        .matchType(MatchType.LITERAL)
+                        .build());
+
+        var git = sshGit();
+        RuntimeException ex = assertThrows(
+                RuntimeException.class,
+                () -> git.clone(proxy.pushUrl(GiteaContainer.TEST_ORG, GiteaContainer.TEST_REPO), "ssh-fetch-denied"));
+        assertTrue(
+                ex.getMessage().contains("denied") || ex.getMessage().contains("not permitted"),
+                "Expected URL-rule denial in clone failure output:\n" + ex.getMessage());
     }
 
     // ── static utilities ──────────────────────────────────────────────────────

--- a/fogwall-server/src/test/java/com/rbc/fogwall/e2e/SshProxyFixture.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/e2e/SshProxyFixture.java
@@ -53,6 +53,7 @@ class SshProxyFixture implements AutoCloseable {
     private final int sshPort;
     private final PushStore pushStore;
     private final String giteaSshHostPort;
+    private final InMemoryUrlRuleRegistry urlRuleRegistry;
 
     /**
      * Creates and starts the SSH fixture.
@@ -105,7 +106,7 @@ class SshProxyFixture implements AutoCloseable {
         pushStore = PushStoreFactory.inMemory();
         var cache = new LocalRepositoryCache(Files.createTempDirectory("fogwall-ssh-e2e-cache-"), 0, true);
 
-        var urlRuleRegistry = new InMemoryUrlRuleRegistry();
+        urlRuleRegistry = new InMemoryUrlRuleRegistry();
         urlRuleRegistry.save(AccessRule.builder()
                 .ruleOrder(1)
                 .access(AccessRule.Access.ALLOW)
@@ -150,7 +151,7 @@ class SshProxyFixture implements AutoCloseable {
                 .resolve("host_key")
                 .toString());
 
-        sshServer = SshGitServer.create(sshConfig, provider, cache, receivePackFactory, userStore);
+        sshServer = SshGitServer.create(sshConfig, provider, cache, receivePackFactory, userStore, urlRuleRegistry);
         sshServer.start();
     }
 
@@ -166,6 +167,10 @@ class SshProxyFixture implements AutoCloseable {
 
     PushStore getPushStore() {
         return pushStore;
+    }
+
+    InMemoryUrlRuleRegistry getUrlRuleRegistry() {
+        return urlRuleRegistry;
     }
 
     @Override

--- a/fogwall-server/src/test/java/com/rbc/fogwall/ssh/SshGitCommandFactoryTest.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/ssh/SshGitCommandFactoryTest.java
@@ -1,0 +1,60 @@
+package com.rbc.fogwall.ssh;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.rbc.fogwall.db.UrlRuleRegistry;
+import com.rbc.fogwall.git.LocalRepositoryCache;
+import com.rbc.fogwall.git.StoreAndForwardReceivePackFactory;
+import com.rbc.fogwall.provider.FogwallProvider;
+import java.io.IOException;
+import org.apache.sshd.server.channel.ChannelSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SshGitCommandFactoryTest {
+
+    private SshGitCommandFactory factory;
+    private ChannelSession channel;
+
+    @BeforeEach
+    void setUp() {
+        factory = new SshGitCommandFactory(
+                mock(FogwallProvider.class),
+                mock(LocalRepositoryCache.class),
+                mock(StoreAndForwardReceivePackFactory.class),
+                mock(FogwallProxyAgentFactory.class),
+                mock(UrlRuleRegistry.class));
+        channel = mock(ChannelSession.class);
+    }
+
+    @Test
+    void routesReceivePackCommand() throws IOException {
+        var command = factory.createCommand(channel, "git-receive-pack '/localhost:3022/owner/repo.git'");
+        assertInstanceOf(SshGitReceiveCommand.class, command);
+    }
+
+    @Test
+    void routesUploadPackCommand() throws IOException {
+        var command = factory.createCommand(channel, "git-upload-pack '/localhost:3022/owner/repo.git'");
+        assertInstanceOf(SshGitUploadCommand.class, command);
+    }
+
+    @Test
+    void routesReceivePackCommandWithoutQuotes() throws IOException {
+        var command = factory.createCommand(channel, "git-receive-pack /localhost:3022/owner/repo.git");
+        assertInstanceOf(SshGitReceiveCommand.class, command);
+    }
+
+    @Test
+    void routesUploadPackCommandWithoutQuotes() throws IOException {
+        var command = factory.createCommand(channel, "git-upload-pack /localhost:3022/owner/repo.git");
+        assertInstanceOf(SshGitUploadCommand.class, command);
+    }
+
+    @Test
+    void rejectsUnsupportedCommand() {
+        assertThrows(IOException.class, () -> factory.createCommand(channel, "git-upload-archive '/owner/repo.git'"));
+    }
+}


### PR DESCRIPTION
## Summary

`SshGitCommandFactory` previously rejected `git-upload-pack` outright, so clone and fetch were only possible over HTTP even when SSH push was configured.

- `SshGitUploadCommand` mirrors `SshGitReceiveCommand`'s connection handling: resolve the route, sync the local mirror from upstream via the client's forwarded SSH agent, then serve the fetch from the synced local repo via `UploadPack` instead of `ReceivePack` + hooks.
- The forwarded-agent `SshdSessionFactory`/`Connector`/`AcceptAllKnownServerKeyDatabase` boilerplate is extracted out of `SshGitReceiveCommand` into a shared `SshUpstreamTransport` helper, used by both commands.
- **URL allow/deny rules are enforced explicitly in `SshGitUploadCommand`**, via the same `UrlRuleEvaluator` that `RepositoryUrlRuleHook` (SSH push) and `UrlRuleAggregateFilter` (HTTP, both push and fetch) already delegate to. SSH has no servlet filter chain, so without this, fetch over SSH would have silently bypassed URL rules that push already respects. No other push-side hook applies here — content validation and approval gating are push-specific, and neither transport has a fogwall-side fetch permission grant (access is delegated to the upstream SCM via forwarded credentials/agent) — so this brings SSH to parity with HTTP's actual fetch behavior, without adding anything HTTP doesn't already have.

closes #428

## Test plan

- [x] New `SshGitCommandFactoryTest` — command routing for both `git-receive-pack` and `git-upload-pack`, with/without quoting, and unsupported-command rejection
- [x] New `SshE2ETest` case: clone directly through fogwall's SSH endpoint, verify content
- [x] New `SshE2ETest` case: URL-rule deny test proving fetch is actually gated on this transport
- [x] `./gradlew :fogwall-core:test :fogwall-server:test` — full suite green
- [ ] `./gradlew e2eTest` — requires Docker; not run locally (Podman flakiness noted separately), expected green in CI