### PR TITLE
ci: publish and release the standalone server Docker image

### DIFF
--- a/.github/workflows/cleanup-interim-images.yml
+++ b/.github/workflows/cleanup-interim-images.yml
@@ -2,7 +2,8 @@ name: Cleanup Interim Images
 
 # Deletes GHCR package versions whose tags are exclusively build-* (ephemeral
 # per-commit images). Versions carrying any other tag (v*, edge, latest, etc.)
-# are never touched. Runs weekly and can be triggered manually.
+# are never touched. Runs weekly and can be triggered manually. Logic lives in
+# scripts/cleanup-interim-images.sh so it can also be run locally.
 
 on:
   schedule:
@@ -25,58 +26,9 @@ jobs:
     permissions:
       packages: write
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+
       - name: Delete stale build-* package versions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          OWNER="${{ github.repository_owner }}"
-          PACKAGE="${{ github.event.repository.name }}"
-          DELETED=0
-          KEPT=0
-
-          echo "Fetching package versions for ${OWNER}/${PACKAGE}..."
-
-          # Collect all versions into a temp file (handles pagination via --paginate)
-          gh api \
-            -H "Accept: application/vnd.github+json" \
-            "/users/${OWNER}/packages/container/${PACKAGE}/versions" \
-            --paginate > /tmp/versions.json
-
-          TOTAL=$(jq 'length' /tmp/versions.json)
-          echo "Found ${TOTAL} total package versions."
-          echo ""
-
-          jq -c '.[]' /tmp/versions.json | while read -r version; do
-            VERSION_ID=$(echo "$version" | jq -r '.id')
-            TAGS=$(echo "$version" | jq -r '.metadata.container.tags // [] | .[]')
-
-            # Skip untagged versions — never delete them (likely referenced by a manifest list)
-            if [ -z "$TAGS" ]; then
-              echo "KEEP  [${VERSION_ID}] (untagged)"
-              continue
-            fi
-
-            TAG_LIST=$(echo "$TAGS" | tr '\n' ' ' | sed 's/ $//')
-
-            # Guard: keep if ANY tag does not match build-[0-9a-f]+
-            PROTECTED=false
-            while IFS= read -r tag; do
-              if [[ ! "$tag" =~ ^build-[0-9a-f]+$ ]]; then
-                PROTECTED=true
-                break
-              fi
-            done <<< "$TAGS"
-
-            if [ "$PROTECTED" = true ]; then
-              echo "KEEP  [${VERSION_ID}] tags: ${TAG_LIST}"
-            else
-              echo "DELETE [${VERSION_ID}] tags: ${TAG_LIST}"
-              gh api \
-                --method DELETE \
-                -H "Accept: application/vnd.github+json" \
-                "/users/${OWNER}/packages/container/${PACKAGE}/versions/${VERSION_ID}"
-            fi
-          done
-
-          echo ""
-          echo "Cleanup complete."
+        run: ./scripts/cleanup-interim-images.sh

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,8 +29,19 @@ jobs:
     # Tags are released by promoting the already-built build image — no rebuild needed.
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: dashboard
+          - name: server
+    # Matrix legs run in parallel, so PR wall-clock time is unchanged by adding the server image
+    # — only total runner-minutes go up. Each leg writes its digest under a name-scoped output key
+    # (digest_dashboard / digest_server) since matrix job outputs collapse to one value per key;
+    # distinct keys per leg is the standard workaround so `scan` can look up the right digest.
     outputs:
-      digest: ${{ steps.push.outputs.digest }}
+      digest_dashboard: ${{ steps.export.outputs.digest_dashboard }}
+      digest_server: ${{ steps.export.outputs.digest_server }}
     permissions:
       contents: read
       packages: write
@@ -45,7 +56,9 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # ratchet:docker/setup-buildx-action@v4
 
       - name: Set image name
-        run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+        run: |
+          SUFFIX="${{ matrix.name == 'server' && '-server' || '' }}"
+          echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')${SUFFIX}" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
@@ -71,14 +84,19 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # ratchet:docker/build-push-action@v7
         with:
           context: .
+          target: ${{ matrix.name }}
           platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: mode=max
           sbom: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+      - name: Export digest
+        id: export
+        run: echo "digest_${{ matrix.name }}=${{ steps.push.outputs.digest }}" >> "$GITHUB_OUTPUT"
 
       - name: Attest image
         if: github.event_name != 'pull_request'
@@ -92,6 +110,12 @@ jobs:
     name: Container Scan
     needs: build-and-push
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: dashboard
+          - name: server
     permissions:
       contents: read
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -102,7 +126,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
 
       - name: Set image name
-        run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+        run: |
+          SUFFIX="${{ matrix.name == 'server' && '-server' || '' }}"
+          echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')${SUFFIX}" >> "$GITHUB_ENV"
 
       - name: Install grype
         run: |
@@ -116,7 +142,8 @@ jobs:
 
       - name: Scan image
         run: |
-          grype "${IMAGE}@${{ needs.build-and-push.outputs.digest }}" \
+          DIGEST="${{ needs.build-and-push.outputs[format('digest_{0}', matrix.name)] }}"
+          grype "${IMAGE}@${DIGEST}" \
             --config .grype.yaml \
             -o "template=grype-report.txt" \
             -o "json=grype-report.json"
@@ -125,7 +152,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
-          name: grype-container-scan
+          name: grype-container-scan-${{ matrix.name }}
           path: |
             grype-report.txt
             grype-report.json
@@ -135,6 +162,12 @@ jobs:
     name: Publish Release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: dashboard
+          - name: server
     permissions:
       contents: read
       packages: write
@@ -154,13 +187,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set image name
-        run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+        run: |
+          SUFFIX="${{ matrix.name == 'server' && '-server' || '' }}"
+          echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')${SUFFIX}" >> "$GITHUB_ENV"
 
       # Resolve the digest of the build-{sha} image produced when this commit landed on main.
-      # The tag ruleset enforces Container Scan passed on this commit before the tag could be
-      # pushed, so the build image is guaranteed scanned. Using the commit-pinned build tag
-      # (not :edge) ensures we promote the exact image for this release regardless of how
-      # many commits have landed on main since.
+      # The tag ruleset enforces Container Scan (per image) passed on this commit before the tag
+      # could be pushed, so the build image is guaranteed scanned. Using the commit-pinned build
+      # tag (not :edge) ensures we promote the exact image for this release regardless of how many
+      # commits have landed on main since.
       - name: Resolve build image digest
         id: build
         run: |

--- a/scripts/cleanup-interim-images.sh
+++ b/scripts/cleanup-interim-images.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Deletes GHCR package versions whose tags are exclusively build-* (ephemeral per-commit
+# images). Versions carrying any other tag (v*, edge, latest, etc.) are never touched.
+#
+# Runs via .github/workflows/cleanup-interim-images.yml (weekly + workflow_dispatch), using the
+# default GITHUB_TOKEN with the packages:write job permission - confirmed working for org-owned
+# packages once the /orgs/ (not /users/) endpoint is used. For local runs against an org-owned
+# package, GitHub Apps cannot delete package versions at all (confirmed with GitHub support) and
+# this org blocks classic PATs, so a token from an account GitHub does permit here is required -
+# GITHUB_TOKEN only works from within an Actions run.
+#
+# Usage: GH_TOKEN=<token> ./scripts/cleanup-interim-images.sh [owner] [package ...]
+# Defaults: owner/packages resolved from the current repo (dashboard + "-server" image).
+
+set -euo pipefail
+
+OWNER="${1:-$(gh repo view --json owner -q .owner.login)}"
+shift || true
+
+if [ "$#" -gt 0 ]; then
+  PACKAGES=("$@")
+else
+  BASE_PACKAGE="$(gh repo view --json name -q .name)"
+  PACKAGES=("${BASE_PACKAGE}" "${BASE_PACKAGE}-server")
+fi
+
+: "${GH_TOKEN:?GH_TOKEN must be set to a token with org package delete rights}"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+VERSIONS_FILE="${WORKDIR}/versions.json"
+ERR_FILE="${WORKDIR}/err.txt"
+DELETE_ERR_FILE="${WORKDIR}/delete_err.txt"
+
+TOTAL_DELETED=0
+TOTAL_KEPT=0
+
+for PACKAGE in "${PACKAGES[@]}"; do
+  echo "Fetching package versions for ${OWNER}/${PACKAGE}..."
+
+  if ! gh api \
+    -H "Accept: application/vnd.github+json" \
+    "/orgs/${OWNER}/packages/container/${PACKAGE}/versions" \
+    --paginate > "$VERSIONS_FILE" 2>"$ERR_FILE"; then
+    echo "  could not list versions for ${PACKAGE}, skipping:"
+    cat "$ERR_FILE"
+    echo ""
+    continue
+  fi
+
+  TOTAL=$(jq 'length' "$VERSIONS_FILE")
+  echo "Found ${TOTAL} total package versions."
+  echo ""
+
+  DELETED=0
+  KEPT=0
+
+  while IFS= read -r version; do
+    VERSION_ID=$(echo "$version" | jq -r '.id')
+    TAGS=$(echo "$version" | jq -r '.metadata.container.tags // [] | .[]')
+
+    # Skip untagged versions — never delete them (likely referenced by a manifest list)
+    if [ -z "$TAGS" ]; then
+      echo "KEEP  [${VERSION_ID}] (untagged)"
+      KEPT=$((KEPT + 1))
+      continue
+    fi
+
+    TAG_LIST=$(echo "$TAGS" | tr '\n' ' ' | sed 's/ $//')
+
+    # Guard 1 (allow-list): keep if ANY tag does not match build-[0-9a-f]+ exactly.
+    PROTECTED=false
+    while IFS= read -r tag; do
+      if [[ ! "$tag" =~ ^build-[0-9a-f]+$ ]]; then
+        PROTECTED=true
+        break
+      fi
+    done <<< "$TAGS"
+
+    # Guard 2 (deny-list, independent of guard 1): keep if ANY tag looks like a real
+    # release/promotion tag (semver, major, minor, latest, edge). This is deliberately a second,
+    # separately-written check — a bug in guard 1's regex alone must not be able to delete a
+    # production tag; both guards have to agree it's safe before anything is deleted.
+    FORBIDDEN=false
+    while IFS= read -r tag; do
+      if [[ "$tag" =~ ^v?[0-9]+(\.[0-9]+){0,2}(-.+)?$ ]] || [ "$tag" = "latest" ] || [ "$tag" = "edge" ]; then
+        FORBIDDEN=true
+        break
+      fi
+    done <<< "$TAGS"
+
+    if [ "$PROTECTED" = true ] || [ "$FORBIDDEN" = true ]; then
+      echo "KEEP  [${VERSION_ID}] tags: ${TAG_LIST}"
+      KEPT=$((KEPT + 1))
+    else
+      echo "DELETE [${VERSION_ID}] tags: ${TAG_LIST}"
+      if gh api \
+        --method DELETE \
+        -H "Accept: application/vnd.github+json" \
+        "/orgs/${OWNER}/packages/container/${PACKAGE}/versions/${VERSION_ID}" \
+        >"$DELETE_ERR_FILE" 2>&1; then
+        DELETED=$((DELETED + 1))
+      elif grep -q '"status":"404"' "$DELETE_ERR_FILE"; then
+        # Already gone (e.g. superseded by a concurrent release promotion) — not a failure.
+        echo "  already deleted, skipping"
+        DELETED=$((DELETED + 1))
+      else
+        echo "  delete failed:"
+        cat "$DELETE_ERR_FILE"
+        exit 1
+      fi
+    fi
+  done < <(jq -c '.[]' "$VERSIONS_FILE")
+
+  echo ""
+  echo "${PACKAGE}: deleted ${DELETED}, kept ${KEPT}."
+  echo ""
+  TOTAL_DELETED=$((TOTAL_DELETED + DELETED))
+  TOTAL_KEPT=$((TOTAL_KEPT + KEPT))
+done
+
+echo "Cleanup complete. Deleted ${TOTAL_DELETED}, kept ${TOTAL_KEPT} across all packages."


### PR DESCRIPTION
## Summary
- Matrix `build-and-push`, `scan`, and `publish-release` in `docker-publish.yml` over `{dashboard, server}` so the existing `server` Docker target (from #122) is finally built, scanned, and release-promoted alongside the dashboard image, publishing `ghcr.io/rbc/fogwall-server`.
- Matrix legs run in parallel — PR wall-clock CI time is unchanged, only total runner-minutes go up.
- Updated the two repo rulesets to match the new matrixed job names GitHub Actions produces (`Build & Push (dashboard)`/`Build & Push (server)`, `Container Scan (dashboard)`/`Container Scan (server)`), otherwise the old literal-string required checks would sit pending forever.
- Bonus fix while on this branch: `cleanup-interim-images.yml` had been failing (and was manually disabled) since the repo moved from a personal account to the RBC org. Root cause was deleting package versions via the `/users/` owner endpoint, which stopped resolving after the org transfer — org-owned packages need `/orgs/`. Extracted the logic into `scripts/cleanup-interim-images.sh` (runnable locally too), looped it over both the dashboard and new server packages, and made an individual 404-on-delete non-fatal (treated as already-gone) instead of aborting the whole run.
- Confirmed via live `workflow_dispatch` runs on this branch against the real GHCR packages: after the `/orgs/` fix, plain `GITHUB_TOKEN` (with the job's `packages: write` permission) deletes org-owned package versions fine — no PAT or GitHub App needed. (A GitHub App installation token was tried first and consistently 404s on delete despite working fine for listing; confirmed via GitHub support elsewhere that Apps cannot delete package versions at all. Classic PATs are blocked outright by this org's policy. Fine-grained PATs don't support the Packages permission. GHCR's registry API doesn't support manifest deletion at all (405). `GITHUB_TOKEN` was the one path that actually works.)
- Added a second, independent deny-list guard (semver/`latest`/`edge` tag shapes) alongside the existing allow-list guard (only delete if every tag matches `build-[0-9a-f]+`) — both must agree before anything is deleted, so a future bug in either check alone can't delete a real release tag.
- Verified end-to-end on this branch: a live run actually deleted 51 stale `build-*` versions from `ghcr.io/rbc/fogwall` and correctly kept all 337 remaining (tagged releases + untagged manifests), then a follow-up run confirmed idempotency (0 to delete, 337 kept).

## Test plan
- [x] CI green on this PR (`Build & Push (dashboard)`, `Build & Push (server)`)
- [x] `Cleanup Interim Images` re-enabled and verified via `workflow_dispatch`: real deletions confirmed, re-run confirmed idempotent
- [ ] Confirm `ghcr.io/rbc/fogwall-server:edge` gets pushed once merged to main
- [ ] Confirm `Container Scan (server)` runs on main push
- [ ] One-time backfill of the current released version's server image via `workflow_dispatch` (not part of this PR)

closes #422