### PR TITLE
feat: add WARN as a first-class validation step status

### DIFF
--- a/fogwall-core/src/main/java/com/rbc/fogwall/db/model/StepStatus.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/db/model/StepStatus.java
@@ -3,6 +3,7 @@ package com.rbc.fogwall.db.model;
 /** Result status of a single validation step. */
 public enum StepStatus {
     PASS,
+    WARN,
     FAIL,
     BLOCKED,
     SKIPPED

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/GitClientUtils.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/GitClientUtils.java
@@ -278,17 +278,11 @@ public class GitClientUtils {
             sb.append(color(AnsiColor.CYAN, sym(SymbolCodes.KEY) + "  " + label + "..."))
                     .append("\n");
             if (step.getStatus() == StepStatus.PASS) {
-                if (step.getContent() != null && !step.getContent().isBlank()) {
-                    // PASS with content = warning (e.g. identity verified via SCM but emails unregistered)
-                    for (String line : step.getContent().split("\n")) {
-                        sb.append(color(AnsiColor.YELLOW, "  " + sym(SymbolCodes.WARNING) + "  " + line))
-                                .append("\n");
-                    }
-                } else {
-                    String result = passResults.getOrDefault(step.getStepName(), "passed");
-                    sb.append(color(AnsiColor.GREEN, "  " + sym(SymbolCodes.HEAVY_CHECK_MARK) + "  " + result))
-                            .append("\n");
-                }
+                String result = passResults.getOrDefault(step.getStepName(), "passed");
+                sb.append(color(AnsiColor.GREEN, "  " + sym(SymbolCodes.HEAVY_CHECK_MARK) + "  " + result))
+                        .append("\n");
+            } else if (step.getStatus() == StepStatus.WARN) {
+                appendWarningLines(sb, step.getContent());
             } else if (step.getStatus() == StepStatus.FAIL) {
                 String detail = step.getErrorMessage() != null ? step.getErrorMessage() : "failed";
                 sb.append(color(AnsiColor.RED, "  " + sym(SymbolCodes.CROSS_MARK) + "  " + detail))
@@ -299,5 +293,16 @@ public class GitClientUtils {
             }
         }
         return sb.toString();
+    }
+
+    /** Appends each line of {@code content} to {@code sb} as a yellow warning line, prefixed with a warning symbol. */
+    private static void appendWarningLines(StringBuilder sb, String content) {
+        if (content == null || content.isBlank()) {
+            return;
+        }
+        for (String line : content.split("\n")) {
+            sb.append(color(AnsiColor.YELLOW, "  " + sym(SymbolCodes.WARNING) + "  " + line))
+                    .append("\n");
+        }
     }
 }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/IdentityVerificationHook.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/IdentityVerificationHook.java
@@ -175,7 +175,7 @@ public class IdentityVerificationHook implements FogwallHook {
             pushContext.addStep(PushStep.builder()
                     .stepName(STEP_NAME)
                     .stepOrder(ORDER)
-                    .status(StepStatus.PASS)
+                    .status(StepStatus.WARN)
                     .content(String.join("\n", warnViolations))
                     .build());
         }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/IdentityVerificationFilter.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/IdentityVerificationFilter.java
@@ -169,7 +169,7 @@ public class IdentityVerificationFilter extends AbstractFogwallFilter {
                     warnViolations.size());
             recordStep(
                     request,
-                    StepStatus.PASS,
+                    StepStatus.WARN,
                     null,
                     warnViolations.size() + " unrecognised commit email(s) — not in proxy user registry");
         }

--- a/fogwall-core/src/test/java/com/rbc/fogwall/git/IdentityVerificationHookTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/git/IdentityVerificationHookTest.java
@@ -198,7 +198,7 @@ class IdentityVerificationHookTest {
     // ---- committer warn + mismatch → no issue, push proceeds ----
 
     @Test
-    void committerWarn_mismatch_noIssue_recordsPass() throws Exception {
+    void committerWarn_mismatch_noIssue_recordsWarn() throws Exception {
         when(resolver.resolve(any(FogwallProvider.class), eq("alice-git"), isNull()))
                 .thenReturn(Optional.of(alice()));
 
@@ -214,7 +214,7 @@ class IdentityVerificationHookTest {
 
         assertFalse(vc.hasIssues(), "WARN mode should not block the push");
         assertFalse(pc.getSteps().isEmpty());
-        assertEquals(StepStatus.PASS, pc.getSteps().get(0).getStatus());
+        assertEquals(StepStatus.WARN, pc.getSteps().get(0).getStatus());
     }
 
     // ---- DELETE command → skipped entirely, no violation ----

--- a/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/IdentityVerificationFilterTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/IdentityVerificationFilterTest.java
@@ -259,11 +259,11 @@ class IdentityVerificationFilterTest {
 
         assertFalse(resp.committed.get());
         assertEquals(GitRequestDetails.GitResult.PENDING, details.getResult(), "WARN mode must not reject push");
-        // WARN mode records a PASS step with violation details in content (for the amber dashboard badge)
+        // WARN mode records a WARN step with violation details in content (for the amber dashboard badge)
         assertFalse(details.getSteps().isEmpty(), "WARN mode should record a step");
         var step = details.getSteps().get(0);
         assertEquals("identityVerification", step.getStepName());
-        assertEquals(StepStatus.PASS, step.getStatus());
+        assertEquals(StepStatus.WARN, step.getStatus());
         assertNotNull(step.getContent(), "WARN mode step should carry violation details in content");
     }
 

--- a/fogwall-dashboard/frontend/src/pages/PushDetail.tsx
+++ b/fogwall-dashboard/frontend/src/pages/PushDetail.tsx
@@ -59,7 +59,7 @@ const STEP_DISPLAY_NAMES: Record<string, string> = {
 function IdentityBadge({ record }: { record: PushRecord }) {
   if (record.resolvedUser) {
     const idStep = (record.steps ?? []).find((s) => s.stepName === 'identityVerification')
-    const hasEmailWarning = idStep?.status === 'PASS' && !!idStep?.content
+    const hasEmailWarning = idStep?.status === 'WARN'
     if (hasEmailWarning) {
       return (
         <span
@@ -839,6 +839,7 @@ export function PushDetail({ currentUser, dark = false }: PushDetailProps) {
               <div className="space-y-1">
                 {validationSteps.map((s) => {
                   const isFailed = s.status === 'FAIL' || s.status === 'BLOCKED'
+                  const isWarn = s.status === 'WARN'
                   const isSkipped = s.status === 'SKIPPED'
                   const isOpen = openSteps[s.id]
                   return (
@@ -853,20 +854,22 @@ export function PushDetail({ currentUser, dark = false }: PushDetailProps) {
                               ? 'text-green-500 dark:text-green-400'
                               : isFailed
                                 ? 'text-red-500 dark:text-red-400'
-                                : isSkipped
-                                  ? 'text-yellow-500 dark:text-yellow-400'
-                                  : 'text-gray-400 dark:text-gray-500'
+                                : isWarn
+                                  ? 'text-amber-500 dark:text-amber-400'
+                                  : isSkipped
+                                    ? 'text-yellow-500 dark:text-yellow-400'
+                                    : 'text-gray-400 dark:text-gray-500'
                           }
                         >
-                          {s.status === 'PASS' ? '✓' : isFailed ? '✗' : isSkipped ? '⚠' : '–'}
+                          {s.status === 'PASS' ? '✓' : isFailed ? '✗' : isWarn || isSkipped ? '⚠' : '–'}
                         </span>
                         <span className="text-sm text-gray-700 w-56 shrink-0 dark:text-gray-300">
                           {stepDisplayName(s.stepName)}
                         </span>
                         <span className="text-gray-500 text-xs truncate flex-1 dark:text-gray-400">
-                          {s.errorMessage ?? s.blockedMessage ?? (isSkipped ? 'skipped' : '')}
+                          {s.errorMessage ?? s.blockedMessage ?? (isWarn ? s.content : undefined) ?? (isSkipped ? 'skipped' : '')}
                         </span>
-                        {(isFailed || isSkipped) &&
+                        {(isFailed || isWarn || isSkipped) &&
                           (s.content || s.errorMessage || s.blockedMessage) && (
                             <span className="text-xs text-gray-400 shrink-0 dark:text-gray-500">
                               {isOpen ? '▲ hide' : '▼ details'}

--- a/fogwall-dashboard/frontend/src/types.ts
+++ b/fogwall-dashboard/frontend/src/types.ts
@@ -5,7 +5,7 @@ export interface Step {
   id: string
   stepName: string
   stepOrder: number
-  status: 'PASS' | 'FAIL' | 'BLOCKED' | string
+  status: 'PASS' | 'WARN' | 'FAIL' | 'BLOCKED' | 'SKIPPED' | string
   errorMessage?: string
   blockedMessage?: string
   content?: string


### PR DESCRIPTION
## Summary

- `StepStatus` gains a `WARN` value alongside `PASS`/`FAIL`/`BLOCKED`/`SKIPPED`.
- `IdentityVerificationHook` and `IdentityVerificationFilter` now record `WARN` for warn-mode identity mismatches, instead of faking the result as `PASS` with content attached (a pre-existing misrepresentation the check had lived with).
- `GitClientUtils`' warning-line rendering (used for the CLI/sideband summary) is extracted into a reusable `appendWarningLines` helper.
- Dashboard `IdentityBadge` and the validation-steps list key off `WARN` directly, with its own amber treatment distinct from `SKIPPED`'s yellow.

Scoped deliberately narrow per #141's own guidance: this lands the plumbing and fixes the one existing WARN-shaped check (identity verification) rather than sweeping in new WARN emitters (diff size, commit count, etc.) — those are separate follow-ups. This is also the prerequisite for #413 (content pattern bundles), which will ship WARN-only.

## Test plan

- [x] `./gradlew compileJava compileTestJava`
- [x] `./gradlew :fogwall-core:test --tests "*IdentityVerification*"` — updated assertions for `WARN` pass
- [x] `./gradlew :fogwall-core:test :fogwall-core:jacocoTestCoverageVerification` — full suite green aside from a pre-existing, unrelated Mongo/Testcontainers flake (`MongoGroupPermissionStoreIntegrationTest`, container startup failure)
- [x] Frontend `tsc -b && vite build` — clean, no type errors from the `Step['status']` union change

closes #141

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>