### PR TITLE
ci: cover fogwall-server in the weekly scan and manual retag workflows

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -11,6 +11,12 @@ jobs:
   grype:
     name: Container Scan
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: dashboard
+          - name: server
     env:
       GRYPE_VERSION: "0.112.0"
     steps:
@@ -31,7 +37,9 @@ jobs:
       # SARIF upload intentionally omitted — OS-layer CVEs are triaged with application
       # context; uploading creates misleading noise in the GitHub Security tab.
       - name: Set image name
-        run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+        run: |
+          SUFFIX="${{ matrix.name == 'server' && '-server' || '' }}"
+          echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')${SUFFIX}" >> "$GITHUB_ENV"
 
       - name: Scan image
         if: always()
@@ -45,7 +53,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
-          name: grype-container-scan
+          name: grype-container-scan-${{ matrix.name }}
           path: |
             grype-report.txt
             grype-report.json

--- a/.github/workflows/retag.yml
+++ b/.github/workflows/retag.yml
@@ -8,6 +8,14 @@ name: Retag Image
 on:
   workflow_dispatch:
     inputs:
+      image:
+        description: "Which image to retag"
+        required: true
+        type: choice
+        options:
+          - dashboard
+          - server
+        default: dashboard
       source-digest:
         description: "Source image digest (e.g. sha256:abc123...)"
         required: true
@@ -39,7 +47,9 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # ratchet:docker/setup-buildx-action@v4
 
       - name: Set image name
-        run: echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+        run: |
+          SUFFIX="${{ inputs.image == 'server' && '-server' || '' }}"
+          echo "IMAGE=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')${SUFFIX}" >> "$GITHUB_ENV"
 
       - name: Retag
         run: |

--- a/fogwall-dashboard/frontend/src/pages/PushDetail.tsx
+++ b/fogwall-dashboard/frontend/src/pages/PushDetail.tsx
@@ -861,13 +861,22 @@ export function PushDetail({ currentUser, dark = false }: PushDetailProps) {
                                     : 'text-gray-400 dark:text-gray-500'
                           }
                         >
-                          {s.status === 'PASS' ? '✓' : isFailed ? '✗' : isWarn || isSkipped ? '⚠' : '–'}
+                          {s.status === 'PASS'
+                            ? '✓'
+                            : isFailed
+                              ? '✗'
+                              : isWarn || isSkipped
+                                ? '⚠'
+                                : '–'}
                         </span>
                         <span className="text-sm text-gray-700 w-56 shrink-0 dark:text-gray-300">
                           {stepDisplayName(s.stepName)}
                         </span>
                         <span className="text-gray-500 text-xs truncate flex-1 dark:text-gray-400">
-                          {s.errorMessage ?? s.blockedMessage ?? (isWarn ? s.content : undefined) ?? (isSkipped ? 'skipped' : '')}
+                          {s.errorMessage ??
+                            s.blockedMessage ??
+                            (isWarn ? s.content : undefined) ??
+                            (isSkipped ? 'skipped' : '')}
                         </span>
                         {(isFailed || isWarn || isSkipped) &&
                           (s.content || s.errorMessage || s.blockedMessage) && (


### PR DESCRIPTION
## Summary
- `container-scan.yml` (weekly scheduled grype scan): matrixed over `{dashboard, server}` so both images' `:latest` tag get scanned, not just the dashboard image. Both left un-covered when #422 added `fogwall-server` to `docker-publish.yml`.
- `retag.yml` (manual ad-hoc digest retag): added an `image` choice input (`dashboard`/`server`) so it can target either image instead of only the dashboard one.

## Test plan
- [ ] CI green on this PR
- [ ] `fogwall-server:latest` won't exist until the next stable release tag cuts — `Container Scan (server)` will have nothing to scan until then, same as it would for any newly-added image