### PR TITLE
docs: final pre-release doc/config/deployment cleanup for 1.3.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -434,3 +434,10 @@ this step.
 
 This means every release image is byte-for-byte identical to the `:edge` image that was scanned when the version bump
 merged.
+
+### Documenting new config surface
+
+When a PR introduces a new config section (not just a key on an existing one) in
+[docs/CONFIGURATION.md](docs/CONFIGURATION.md), tag it with the release it's shipping in, e.g.
+`_Available since v1.3.0._`, right under the heading. This isn't backfilled onto existing sections — only applied going
+forward from a section's introduction.

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,8 @@ RUN bash -c 'mkdir -p /app/{.data,logs,home} \
 ENV HOME=/app/home
 
 EXPOSE 8080
+# SSH transport (server.ssh.enabled, default false) - declared for images that opt into it.
+EXPOSE 2222
 
 USER 1000
 
@@ -139,6 +141,8 @@ RUN bash -c 'mkdir -p /app/{.data,logs,home} \
 ENV HOME=/app/home
 
 EXPOSE 8080
+# SSH transport (server.ssh.enabled, default false) - declared for images that opt into it.
+EXPOSE 2222
 
 USER 1000
 

--- a/charts/fogwall/README.md
+++ b/charts/fogwall/README.md
@@ -1,5 +1,7 @@
 # fogwall Helm chart
 
+_Available since v1.3.0._
+
 A minimal starting chart for deploying fogwall on Kubernetes: `Deployment`, `Service`, `ConfigMap`, and
 liveness/readiness probes. It defaults to the dashboard image (`ghcr.io/rbc/fogwall`) — proxy, REST API, and approval
 UI.
@@ -75,24 +77,27 @@ check — the server image has no `/api/health` endpoint (see
 
 ## Values reference
 
-| Key                  | Default        | Description                                                                       |
-| -------------------- | -------------- | --------------------------------------------------------------------------------- |
-| `variant`            | `dashboard`    | `dashboard` or `server` — picks the default image and probe type together         |
-| `replicaCount`       | `1`            | Pod replica count                                                                 |
-| `image.repository`   | _(by variant)_ | Override to deploy a private mirror; blank uses the `variant` default             |
-| `image.tag`          | `latest`       | Image tag — pin to a specific release in production                               |
-| `image.pullPolicy`   | `IfNotPresent` |                                                                                   |
-| `service.type`       | `ClusterIP`    |                                                                                   |
-| `service.port`       | `80`           | Service port (routes to `targetPort` on the pod)                                  |
-| `service.targetPort` | `8080`         | Container port                                                                    |
-| `configProfiles`     | `custom`       | `FOGWALL_CONFIG_PROFILES` value — comma-separated profile names                   |
-| `configProfileName`  | `custom`       | Name used for the operator-supplied profile file mounted from the `ConfigMap`     |
-| `config`             | _(sample)_     | Contents of `fogwall-<configProfileName>.yml` — see [Install](#install)           |
-| `extraEnvFrom`       | `[]`           | `envFrom` entries — use to project an existing `Secret`                           |
-| `extraEnv`           | `[]`           | Additional `env` entries                                                          |
-| `resources`          | `{}`           | Pod resource requests/limits                                                      |
-| `livenessProbe`      | _(by variant)_ | Override to replace the variant default entirely (`httpGet`, `tcpSocket`, `exec`) |
-| `readinessProbe`     | _(by variant)_ | Override to replace the variant default entirely                                  |
-| `nodeSelector`       | `{}`           |                                                                                   |
-| `tolerations`        | `[]`           |                                                                                   |
-| `affinity`           | `{}`           |                                                                                   |
+| Key                     | Default        | Description                                                                                      |
+| ----------------------- | -------------- | ------------------------------------------------------------------------------------------------ |
+| `variant`               | `dashboard`    | `dashboard` or `server` — picks the default image and probe type together                        |
+| `replicaCount`          | `1`            | Pod replica count                                                                                |
+| `image.repository`      | _(by variant)_ | Override to deploy a private mirror; blank uses the `variant` default                            |
+| `image.tag`             | `latest`       | Image tag — pin to a specific release in production                                              |
+| `image.pullPolicy`      | `IfNotPresent` |                                                                                                  |
+| `service.type`          | `ClusterIP`    |                                                                                                  |
+| `service.port`          | `80`           | Service port (routes to `targetPort` on the pod)                                                 |
+| `service.targetPort`    | `8080`         | Container port                                                                                   |
+| `sshService.enabled`    | `false`        | Adds an SSH `Service` port + container port. Still needs `server.ssh.enabled: true` in `config`  |
+| `sshService.port`       | `22`           | Service port for SSH — LB/Service does the privileged-port mapping, the container never binds it |
+| `sshService.targetPort` | `2222`         | Container port — matches fogwall's own `server.ssh.port` default                                 |
+| `configProfiles`        | `custom`       | `FOGWALL_CONFIG_PROFILES` value — comma-separated profile names                                  |
+| `configProfileName`     | `custom`       | Name used for the operator-supplied profile file mounted from the `ConfigMap`                    |
+| `config`                | _(sample)_     | Contents of `fogwall-<configProfileName>.yml` — see [Install](#install)                          |
+| `extraEnvFrom`          | `[]`           | `envFrom` entries — use to project an existing `Secret`                                          |
+| `extraEnv`              | `[]`           | Additional `env` entries                                                                         |
+| `resources`             | `{}`           | Pod resource requests/limits                                                                     |
+| `livenessProbe`         | _(by variant)_ | Override to replace the variant default entirely (`httpGet`, `tcpSocket`, `exec`)                |
+| `readinessProbe`        | _(by variant)_ | Override to replace the variant default entirely                                                 |
+| `nodeSelector`          | `{}`           |                                                                                                  |
+| `tolerations`           | `[]`           |                                                                                                  |
+| `affinity`              | `{}`           |                                                                                                  |

--- a/charts/fogwall/templates/deployment.yaml
+++ b/charts/fogwall/templates/deployment.yaml
@@ -31,6 +31,11 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- if .Values.sshService.enabled }}
+            - name: ssh
+              containerPort: {{ .Values.sshService.targetPort }}
+              protocol: TCP
+            {{- end }}
           env:
             - name: FOGWALL_CONFIG_PROFILES
               value: {{ .Values.configProfiles | quote }}

--- a/charts/fogwall/templates/service.yaml
+++ b/charts/fogwall/templates/service.yaml
@@ -11,5 +11,11 @@ spec:
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
+    {{- if .Values.sshService.enabled }}
+    - port: {{ .Values.sshService.port }}
+      targetPort: {{ .Values.sshService.targetPort }}
+      protocol: TCP
+      name: ssh
+    {{- end }}
   selector:
     {{- include "fogwall.selectorLabels" . | nindent 4 }}

--- a/charts/fogwall/values.yaml
+++ b/charts/fogwall/values.yaml
@@ -23,6 +23,14 @@ service:
   port: 80
   targetPort: 8080
 
+# SSH transport (see docs/CONFIGURATION.md#ssh-transport). Off by default, matching fogwall's own
+# server.ssh.enabled default. Setting sshService.enabled here only exposes the port — you still
+# need server.ssh.enabled: true (and at least one provider configured for SSH) in `config` below.
+sshService:
+  enabled: false
+  port: 22
+  targetPort: 2222
+
 # Config profile(s) to load, matching FOGWALL_CONFIG_PROFILES. "custom" (below) is this chart's
 # operator-supplied profile, mounted from the ConfigMap built from `config`. Comma-separated to
 # layer additional profiles baked into a custom image build — later profiles take priority.

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -827,8 +827,24 @@ that needs an audit trail.
 
 ## SSH transport
 
+_Available since v1.3.0._
+
 fogwall can accept pushes over SSH on port 2222 (default). This is an alternative to the HTTP push path — not a
 replacement. SSH transport and HTTP transport run side-by-side; a provider can be reached via either or both.
+
+### Exposing SSH on the standard port
+
+The container never binds port 22 directly — that would need root or `CAP_NET_BIND_SERVICE`, the same constraint that
+already keeps the HTTP listener on plaintext 8080 behind your load balancer's TLS termination for 443. Apply the same
+pattern for SSH: a plain TCP/L4 passthrough rule (external `:22` → the pod's `:2222`) needs no app or container change,
+since SSH is a single TCP stream with no Host-header-style routing for an L7 proxy to key off. The Helm chart's
+`sshService.*` values do this out of the box.
+
+This matters for clients: Git's SCP-like shorthand (`git@host:owner/repo.git`, what GitHub's own
+`git@github.com:owner/repo.git` uses) has no field for a non-default port — only the explicit `ssh://host:port/path`
+form does. Without the port-22 passthrough above, your users are stuck with the explicit form (see
+[Adding an SSH remote](USER_GUIDE.md#setting-up-ssh) in the user guide). With it, the shorthand form works unchanged,
+since fogwall's own command parsing doesn't care which URL syntax the client's git produced it from.
 
 ### How SSH identity verification works
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3,6 +3,10 @@
 fogwall uses layered YAML configuration merged at startup. A base file ships with the jar; additional profile files and
 environment variable overrides are applied on top in a defined order.
 
+> A section introducing a new config surface is tagged with the release it first shipped in, e.g.
+> `_Available since v1.3.0._`, right under the heading. Untagged sections predate this convention — it isn't backfilled
+> retroactively, only applied going forward from the section's introduction.
+
 ## Configuration files and profiles
 
 ### Load order (lowest → highest priority)
@@ -89,6 +93,23 @@ Strip the `FOGWALL_` prefix, lowercase, and replace `_` with `.` to get the conf
 
 > Complex nested structures (URL rules, full commit validation blocks) are not overridable via env vars. Use YAML
 > profile files instead.
+
+### Hyphenated keys and provider names
+
+_Available since v1.3.0._
+
+The single-underscore rule above can't produce a hyphen — there's no way to write `providers.gitea-ssh.api-token` as an
+env var name if every `_` is a path separator. For a config key or a provider name that itself contains a hyphen, use
+the double-underscore convention instead (same idea as systemd, Kubernetes, and Docker Compose): `__` is the path
+separator, and a lone `_` becomes a hyphen.
+
+| Environment Variable                      | Config path                     |
+| ----------------------------------------- | ------------------------------- |
+| `FOGWALL_PROVIDERS__GITEA_SSH__API_TOKEN` | `providers.gitea-ssh.api-token` |
+| `FOGWALL_SERVER__SESSION_STORE`           | `server.session-store`          |
+
+This only activates when the env var name contains `__` — every existing single-underscore example above still works
+unchanged, since none of them contain `__`.
 
 ## Server settings
 
@@ -634,12 +655,15 @@ providers:
 
 ### Provider properties
 
-| Property       | Type    | Default              | Description                                                                                                                                                 |
-| -------------- | ------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `enabled`      | boolean | `true`               | Whether the provider is active                                                                                                                              |
-| `servlet-path` | string  | `""`                 | Additional URL prefix for this provider                                                                                                                     |
-| `uri`          | string  | _(built-in default)_ | Upstream base URI. Required for custom-named providers; omit for built-ins.                                                                                 |
-| `type`         | string  | _(from name)_        | Provider implementation: `github`, `gitlab`, `bitbucket`, `codeberg`, `forgejo`, `gitea`. Required for any name that is not one of the five reserved names. |
+| Property                   | Type    | Default                | Description                                                                                                                                                                                                                                                                |
+| -------------------------- | ------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`                  | boolean | `true`                 | Whether the provider is active                                                                                                                                                                                                                                             |
+| `servlet-path`             | string  | `""`                   | Additional URL prefix for this provider                                                                                                                                                                                                                                    |
+| `uri`                      | string  | _(built-in default)_   | Upstream base URI. Required for custom-named providers; omit for built-ins.                                                                                                                                                                                                |
+| `type`                     | string  | _(from name)_          | Provider implementation: `github`, `gitlab`, `bitbucket`, `codeberg`, `forgejo`, `gitea`. Required for any name that is not one of the five reserved names.                                                                                                                |
+| `api-uri`                  | string  | _(derived from `uri`)_ | HTTP base URI for provider REST API calls (identity resolution, SSH key lookup). Only needed when the HTTP API port can't be derived from `uri` — e.g. a self-hosted SSH provider where the HTTP and SSH ports are both non-standard. See [SSH transport](#ssh-transport). |
+| `api-token`                | string  | _(none)_               | PAT used when the provider's SSH key listing API requires authentication (Forgejo/GitLab with `REQUIRE_SIGNIN_VIEW=true`). GitHub's equivalent endpoint is public and needs no token.                                                                                      |
+| `blocked-info-refs-status` | int     | `403`                  | HTTP status returned when a blocked `/info/refs` discovery request is denied. `403` is unambiguous; `404` obscures whether the repo exists (security by obscurity).                                                                                                        |
 
 The five reserved names (`github`, `gitlab`, `bitbucket`, `codeberg`, `gitea`) carry a built-in default URI and provider
 type. Any other name is opaque — the name is never parsed for type hints — so `type` and `uri` must both be set. The
@@ -668,6 +692,39 @@ accepts the internal username, not an email address.
 <!-- prettier-ignore-start -->
 > [!TIP]
 > **M&A / private server use case:** This same mechanism works for self-hosted Bitbucket Data Center instances. Set `uri` to your internal Bitbucket URL and the proxy will route and rewrite credentials accordingly, making it straightforward to gate pushes to acquired-company repositories during an integration period.
+<!-- prettier-ignore-end -->
+
+## SSH transport
+
+_Available since v1.3.0._
+
+An alternative to the HTTP push path — see [docs/ADMIN_GUIDE.md](ADMIN_GUIDE.md#ssh-transport) for how identity
+verification and agent forwarding work. This section covers the listener config itself.
+
+```yaml
+server:
+  ssh:
+    enabled: false # off by default
+    port: 2222 # non-standard on purpose - see note below
+    host-key-path: .ssh/fogwall_host_key # generated on first start if absent
+```
+
+| Property        | Type    | Default                 | Description                                                                   |
+| --------------- | ------- | ----------------------- | ----------------------------------------------------------------------------- |
+| `enabled`       | boolean | `false`                 | Whether the SSH listener starts                                               |
+| `port`          | int     | `2222`                  | TCP port the SSH server binds                                                 |
+| `host-key-path` | string  | `.ssh/fogwall_host_key` | Path to the SSH host key file (absolute or relative to the working directory) |
+
+<!-- prettier-ignore-start -->
+> [!NOTE]
+> **Why port 2222, and why `git@host:path` shorthand doesn't work out of the box:** the default avoids clashing with a
+> real `sshd` that may already be running on the same host, and avoids the container needing root or
+> `CAP_NET_BIND_SERVICE` just to bind a port below 1024. The trade-off is that Git's SCP-like shorthand
+> (`git@host:owner/repo.git`, the syntax GitHub's `git@github.com:...` uses) has no field for a non-default port — only
+> the explicit `ssh://host:port/path` form does. If you want the shorthand to work, put fogwall's SSH port behind a
+> plain TCP/L4 passthrough on your load balancer or `Service` (external `:22` → the pod's `:2222`) rather than changing
+> what the container itself binds — the same pattern most deployments already use for terminating TLS on 443 in front
+> of the container's plaintext 8080. The Helm chart's `sshService.*` values do exactly this.
 <!-- prettier-ignore-end -->
 
 ## Commit validation
@@ -758,6 +815,8 @@ secret-scan:
 ```
 
 ## Binary blob detection
+
+_Available since v1.3.0._
 
 Push-level check applied once per push against the aggregate diff (all commits combined) — same scope as
 [diff scan](#diff-scan). Flags added/modified blobs that exceed a size threshold or match a denied MIME type.
@@ -1367,6 +1426,49 @@ permissions:
 > `SELF_CERTIFY` is a two-key lock: the user must have both a `SELF_CERTIFY` permission entry for the repository _and_ the `SELF_CERTIFY` role (set via `users[].roles` or `auth.role-mappings`). Either alone is not sufficient.
 <!-- prettier-ignore-end -->
 
+## Groups
+
+_Available since v1.3.0._
+
+Named groups of users that share a common set of permission grants — an alternative to repeating the same `permissions:`
+entry for every member individually. A user assigned to a group inherits all of the group's grants in addition to any
+directly-assigned permissions.
+
+```yaml
+groups:
+  - name: team-alpha
+    description: "Alpha team push access"
+    members:
+      - alice
+      - bob
+    grants:
+      - provider: github
+        match:
+          target: SLUG
+          value: /myorg/**
+          type: GLOB
+        grant: PUSH
+```
+
+### Group properties
+
+| Property            | Type   | Default | Description                                                                                        |
+| ------------------- | ------ | ------- | -------------------------------------------------------------------------------------------------- |
+| `name`              | string | —       | Group name, shown in the dashboard                                                                 |
+| `description`       | string | `""`    | Free-text description                                                                              |
+| `members`           | list   | `[]`    | Usernames belonging to this group (must match a `users:` entry or a DB user)                       |
+| `grants`            | list   | `[]`    | Permission grants applied to every member — same shape as `permissions:` entries, minus `username` |
+| `grants[].provider` | string | —       | Provider name as defined in `providers:` config                                                    |
+| `grants[].match`    | object | —       | Repository match criteria — same semantics as [Permissions](#permissions)                          |
+| `grants[].grant`    | enum   | `PUSH`  | `PUSH`, `REVIEW`, `PUSH_AND_REVIEW`, or `SELF_CERTIFY` — see [Grant](#grant)                       |
+
+<!-- prettier-ignore-start -->
+> [!NOTE]
+> Groups defined here are CONFIG-sourced and read-only from the dashboard — editing or deleting a config-sourced group
+> via the UI/REST API is rejected. Groups created through the dashboard instead are DB-sourced and fully editable there.
+> This mirrors how CONFIG-sourced `permissions:`/`rules:` entries behave.
+<!-- prettier-ignore-end -->
+
 ## Attestations
 
 Attestation questions are presented to reviewers in the dashboard approval form. All configured questions must be
@@ -1398,18 +1500,29 @@ attestations:
       - High
     required: true
     tooltip: "Select the risk level based on the scope and nature of the change"
+
+  - id: policy-review
+    type: checkbox
+    label: "I have reviewed the applicable policy"
+    required: true
+    links:
+      - text: "Open source contribution policy"
+        url: "https://policy.example.com/open-source"
+      - text: "Data classification guide"
+        url: "https://policy.example.com/data-classification"
 ```
 
 ### Attestation properties
 
-| Property   | Type    | Default    | Description                                                          |
-| ---------- | ------- | ---------- | -------------------------------------------------------------------- |
-| `id`       | string  | —          | Unique key used to store the reviewer's answer in the push record    |
-| `type`     | string  | `checkbox` | Input type: `checkbox`, `text`, or `dropdown`                        |
-| `label`    | string  | —          | Question text shown in the review form                               |
-| `required` | boolean | `false`    | Whether the question must be answered before the reviewer can submit |
-| `options`  | list    | _(empty)_  | Choices for `dropdown` type; ignored for other types                 |
-| `tooltip`  | string  | _(none)_   | Optional help text shown alongside the question                      |
+| Property   | Type    | Default    | Description                                                              |
+| ---------- | ------- | ---------- | ------------------------------------------------------------------------ |
+| `id`       | string  | —          | Unique key used to store the reviewer's answer in the push record        |
+| `type`     | string  | `checkbox` | Input type: `checkbox`, `text`, or `dropdown`                            |
+| `label`    | string  | —          | Question text shown in the review form                                   |
+| `required` | boolean | `false`    | Whether the question must be answered before the reviewer can submit     |
+| `links`    | list    | `[]`       | Policy/reference links (`text` + `url` each) rendered below the question |
+| `options`  | list    | _(empty)_  | Choices for `dropdown` type; ignored for other types                     |
+| `tooltip`  | string  | _(none)_   | Optional help text shown alongside the question                          |
 
 Set `attestations: []` (or omit the key) to disable attestations entirely.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -151,7 +151,21 @@ do not use a PAT — your identity is tied to your SSH key instead.
    git push proxy main
    ```
 
-   Your administrator can confirm the exact SCM host and port for each configured SSH provider.
+   Check the **Providers** page in the dashboard to see the exact SCM host and port for each configured SSH provider —
+   it shows the upstream URI verbatim, exactly as your administrator configured it. This matters because whether the
+   `<scm-ssh-port>` segment is needed is an exact match against that URI string, not a "is this the default port" check:
+   if the port was written explicitly there, include it; if it wasn't, omit it entirely (including it when it's not
+   expected is itself a mismatch).
+
+   **Why not the `git@host:owner/repo.git` shorthand you're used to from GitHub?** That shorthand syntax has no way to
+   specify a non-default SSH port, and fogwall's SSH listener normally runs on a non-standard port (`2222` by default)
+   rather than `22`. It's the same underlying SSH protocol either way — just ask your administrator whether they've
+   exposed the proxy's SSH port behind a standard `:22` mapping. If so, the shorthand form works too (same caveat about
+   the `<scm-ssh-port>` segment applies):
+
+   ```shell
+   git remote add proxy git@fogwall.corp.example.com:gitea.corp.example.com:22/myorg/myrepo.git
+   ```
 
 ### SSH identity verification
 


### PR DESCRIPTION
## Summary

Consolidated cleanup branch — audited every change since v1.2.1 for missing docs, undeclared config surface, and deployment config gaps rather than opening a branch/PR per item.

**"Available since vX.Y.Z" convention** — documented in CONTRIBUTING.md, applied to sections new since v1.2.1 (Binary blob detection, SSH transport, Groups, Helm chart README).

**Real content gaps found and fixed** (all shipped in 1.3.0, all previously undocumented):
- `groups:` (#101) — zero documentation, added a full Groups section
- Attestation `links` (#366) — missing from example + properties table
- Env var double-underscore convention (#386) — doc only described the legacy single-underscore rule
- Provider `api-uri`/`api-token`/`blocked-info-refs-status` — existed in code, never documented
- SSH transport (`server.ssh.*`) — zero mention in CONFIGURATION.md despite being in ADMIN_GUIDE.md

**SSH port/URL clarification** — documented why `git@host:path` shorthand doesn't work against fogwall by default (Git SCP-like syntax has no field for a non-default port — not a fogwall gap), and that a plain TCP/L4 passthrough (external `:22` → pod's `:2222`) fixes it with zero app changes, same pattern already used for 443→8080.

**Deployment config to match:**
- `Dockerfile`: `EXPOSE 2222` on both targets (was undeclared)
- Helm chart: optional `sshService.*` values + `Service`/`Deployment` wiring, off by default

**Deliberately deferred:** SSH clone URL in the dashboard Clone button (filed as #442) — needs new backend API surface, a real feature with its own test coverage, not a doc/cosmetic change.

## Test plan
- [x] `helm lint` and `helm template` clean, both with and without `sshService.enabled`
- [x] All markdown passes Prettier
- [ ] CI green