### PR TITLE
docs: tag outbound proxy config as available since v1.3.0

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -281,6 +281,8 @@ This applies to both proxy modes:
 
 ## Outbound proxy
 
+_Available since v1.3.0._
+
 For environments without direct internet access, fogwall can route its own outbound connections through a corporate HTTP
 proxy. This covers all three places fogwall makes outbound connections: store-and-forward upstream pushes (JGit
 Transport), transparent-proxy forwarding (Jetty `HttpClient`), and provider REST API calls (identity resolution, SSH key


### PR DESCRIPTION
## Summary
- Outbound proxy config section (PR #427) missed the "Available since v1.3.0" tagging sweep because it merged after the pre-release doc cleanup PR (#443) landed
- Adds `_Available since v1.3.0._` under the Outbound proxy heading in docs/CONFIGURATION.md, matching the convention established in #443

## Test plan
- [x] Visual diff review of docs/CONFIGURATION.md