### PR TITLE
fix(test): unbreak main — DiffGenerationHook ctor merge mismatch

### DIFF
--- a/fogwall-core/src/test/java/com/rbc/fogwall/git/ContentPatternDiffHookTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/git/ContentPatternDiffHookTest.java
@@ -58,7 +58,7 @@ class ContentPatternDiffHookTest {
         ReceivePack rp = new ReceivePack(repo);
         ReceiveCommand cmd = new ReceiveCommand(oldId, newId, "refs/heads/main", ReceiveCommand.Type.UPDATE);
 
-        new DiffGenerationHook(pushCtx).onPreReceive(rp, List.of(cmd));
+        new DiffGenerationHook(new ValidationContext(), pushCtx).onPreReceive(rp, List.of(cmd));
         new ContentPatternDiffHook(config, pushCtx).onPreReceive(rp, List.of(cmd));
     }
 


### PR DESCRIPTION
`main` fails to compile after #448 and the content-pattern PR merged in sequence. Both changed different files so git merged them cleanly, but they are semantically incompatible:

- The content-pattern PR added `ContentPatternDiffHookTest`, which constructs `DiffGenerationHook(pushContext)`.
- #448 changed that constructor to `DiffGenerationHook(validationContext, pushContext)` so the hook can fail closed on internal errors.

Result: `ContentPatternDiffHookTest.java:61` no longer compiles (`constructor DiffGenerationHook cannot be applied to given types`), which is what the CodeQL / Build & Test job reports on main.

Fix: pass a `ValidationContext`, matching every other diff-generation test call site. Full `compileJava`/`compileTestJava` across all modules is green locally and the affected tests pass.