### PR TITLE
feat: route SSH pushes/fetches to the correct provider among multiple

### DIFF
--- a/fogwall-core/src/main/java/com/rbc/fogwall/provider/GitHubProvider.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/provider/GitHubProvider.java
@@ -23,34 +23,50 @@ public class GitHubProvider extends AbstractFogwallProvider implements HttpToken
     public static final URI DEFAULT_URI = URI.create("https://github.com");
 
     @Builder
-    public GitHubProvider(String name, URI uri, String pathSuffix) {
+    public GitHubProvider(String name, URI uri, String pathSuffix, URI apiUri) {
         super(name != null ? name : NAME, NAME, uri != null ? uri : DEFAULT_URI, pathSuffix);
+        this.apiUri = apiUri;
     }
 
     public GitHubProvider(String pathSuffix) {
-        this(NAME, DEFAULT_URI, pathSuffix);
+        this(NAME, DEFAULT_URI, pathSuffix, null);
     }
 
     public String getApiUrl() {
-        if (uri.equals(DEFAULT_URI)) {
+        if (apiUri != null) {
+            return apiUri.toString();
+        }
+        if (isDefaultHost()) {
             return "https://api.github.com";
         }
         if (isGhe()) {
             return String.format("https://api.%s", uri.getHost());
         }
-        // fallback to self-hosted GHES
-        return String.format("%s/api/v3", uri);
+        // Self-hosted GHES: assumes the API is reachable on the same host over HTTPS on the standard port — true for
+        // most deployments. Set api-uri explicitly when that doesn't hold (e.g. local dev where SSH and HTTPS run on
+        // different non-standard ports on the same host).
+        return String.format("%s/api/v3", selfHostedHttpsBase());
     }
 
     public String getGraphqlUrl() {
-        if (uri.equals(DEFAULT_URI)) {
+        if (apiUri != null) {
+            return apiUri + "/graphql";
+        }
+        if (isDefaultHost()) {
             return "https://api.github.com/graphql";
         }
         if (isGhe()) {
             return String.format("https://api.%s/graphql", uri.getHost());
         }
-        // fallback to self-hosted GHES
-        return String.format("%s/api/graphql", uri);
+        return String.format("%s/api/graphql", selfHostedHttpsBase());
+    }
+
+    /** {@link #uri} as an {@code https://} base URL, converting from {@code ssh://} if needed. */
+    private String selfHostedHttpsBase() {
+        if ("ssh".equals(uri.getScheme())) {
+            return "https://" + uri.getHost();
+        }
+        return uri.toString();
     }
 
     /**
@@ -131,6 +147,15 @@ public class GitHubProvider extends AbstractFogwallProvider implements HttpToken
      */
     private boolean isGhe() {
         return uri.getHost().endsWith(".ghe.com");
+    }
+
+    /**
+     * Whether {@link #uri} points at github.com itself, regardless of scheme — {@code https://github.com} (the HTTP
+     * default) and {@code ssh://git@github.com} (an SSH-transport provider entry) both derive the same
+     * {@code api.github.com} API base, mirroring how {@link ForgejoProvider} derives its API URL from an SSH URI.
+     */
+    private boolean isDefaultHost() {
+        return DEFAULT_URI.getHost().equals(uri.getHost());
     }
 }
 

--- a/fogwall-core/src/test/java/com/rbc/fogwall/provider/ProviderTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/provider/ProviderTest.java
@@ -43,6 +43,63 @@ class ProviderTest {
     }
 
     @Test
+    void gitHub_sshUri_apiUrlsDeriveFromDefaultHost() {
+        // ssh://git@github.com is a valid SSH-transport provider entry for the built-in host — the API base must
+        // still resolve to api.github.com even though the scheme no longer equals DEFAULT_URI exactly.
+        var p = GitHubProvider.builder().uri(URI.create("ssh://git@github.com")).build();
+        assertEquals("https://api.github.com", p.getApiUrl());
+        assertEquals("https://api.github.com/graphql", p.getGraphqlUrl());
+    }
+
+    @Test
+    void gitHub_selfHostedSshUri_apiUrlsDeriveFromHostOnStandardPort() {
+        var p = GitHubProvider.builder()
+                .uri(URI.create("ssh://git@ghes.corp.example.com"))
+                .build();
+        assertEquals("https://ghes.corp.example.com/api/v3", p.getApiUrl());
+        assertEquals("https://ghes.corp.example.com/api/graphql", p.getGraphqlUrl());
+    }
+
+    @Test
+    void gitHub_selfHostedSshUri_withNonStandardPort_dropsSshPortRatherThanGuessing() {
+        // The SSH port has no fixed relationship to the HTTPS port, so it must not be carried over — api-uri is
+        // required when HTTPS isn't on the standard port (documented in ADMIN_GUIDE.md for the same reason).
+        var p = GitHubProvider.builder()
+                .uri(URI.create("ssh://git@ghes.corp.example.com:2222"))
+                .build();
+        assertEquals("https://ghes.corp.example.com/api/v3", p.getApiUrl());
+    }
+
+    @Test
+    void gitHub_sshUri_withExplicitApiUri_honorsOverride() {
+        var p = GitHubProvider.builder()
+                .uri(URI.create("ssh://git@github.corp.example.com"))
+                .apiUri(URI.create("https://github.corp.example.com/api/v3"))
+                .build();
+        assertEquals("https://github.corp.example.com/api/v3", p.getApiUrl());
+    }
+
+    @Test
+    void gitHub_gheDataResidencyUri_apiUrls() {
+        // GitHub Enterprise Cloud with data residency (*.ghe.com) uses api.<host> instead of <host>/api/v3.
+        var p = GitHubProvider.builder()
+                .uri(URI.create("https://corpo-example.ghe.com"))
+                .build();
+        assertEquals("https://api.corpo-example.ghe.com", p.getApiUrl());
+        assertEquals("https://api.corpo-example.ghe.com/graphql", p.getGraphqlUrl());
+    }
+
+    @Test
+    void gitHub_gheDataResidencySshUri_apiUrls() {
+        // Same *.ghe.com derivation must hold for an SSH-transport provider entry.
+        var p = GitHubProvider.builder()
+                .uri(URI.create("ssh://git@corpo-example.ghe.com"))
+                .build();
+        assertEquals("https://api.corpo-example.ghe.com", p.getApiUrl());
+        assertEquals("https://api.corpo-example.ghe.com/graphql", p.getGraphqlUrl());
+    }
+
+    @Test
     void gitHub_getName() {
         assertEquals("github", new GitHubProvider("/proxy").getName());
     }

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
@@ -1021,6 +1021,7 @@ public class JettyConfigurationBuilder {
                         .name(name)
                         .uri(parsedUri)
                         .pathSuffix(pathSuffix)
+                        .apiUri(parsedApiUri)
                         .build());
             }
             case "gitlab" -> {

--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/SshServerRegistrar.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/SshServerRegistrar.java
@@ -4,15 +4,20 @@ import com.rbc.fogwall.config.JettyConfigurationBuilder;
 import com.rbc.fogwall.config.SshConfig;
 import com.rbc.fogwall.provider.FogwallProvider;
 import com.rbc.fogwall.ssh.SshGitServer;
+import com.rbc.fogwall.ssh.SshProviderTarget;
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * Starts and stops the MINA SSHD server. Symmetric to {@link FogwallServletRegistrar} for the HTTP path.
  *
- * <p>SSH providers are identified by an {@code ssh://} URI scheme. The current MVP supports only a single SSH provider;
- * if more than one is configured a warning is logged and the first is used.
+ * <p>SSH providers are identified by an {@code ssh://} URI scheme. Every configured SSH provider is routed by its
+ * {@link FogwallProvider#servletPath()} (the same host/port/path-suffix key the HTTP path uses), so a single SSH server
+ * instance can serve multiple upstream providers on one port — the client selects which one with the path segment in
+ * the SSH command, e.g. {@code ssh://fogwall:2222/github.com/owner/repo.git}.
  */
 @Slf4j
 public class SshServerRegistrar {
@@ -43,17 +48,29 @@ public class SshServerRegistrar {
             return null;
         }
 
-        if (sshProviders.size() > 1) {
-            log.warn(
-                    "SSH transport MVP supports only a single provider; using '{}' (others ignored)",
-                    sshProviders.get(0).getName());
-        }
+        Map<String, SshProviderTarget> routes = buildRoutes(sshProviders, ctx, configBuilder);
 
-        FogwallProvider sshProvider = sshProviders.get(0);
-        var factory = FogwallServletRegistrar.buildReceivePackFactory(ctx, configBuilder, sshProvider);
-        SshGitServer server = SshGitServer.create(
-                sshConfig, sshProvider, ctx.storeForwardCache(), factory, ctx.userStore(), ctx.urlRuleRegistry());
+        SshGitServer server =
+                SshGitServer.create(sshConfig, routes, ctx.storeForwardCache(), ctx.userStore(), ctx.urlRuleRegistry());
         server.start();
         return server;
+    }
+
+    private static Map<String, SshProviderTarget> buildRoutes(
+            List<FogwallProvider> sshProviders, FogwallContext ctx, JettyConfigurationBuilder configBuilder) {
+        Map<String, SshProviderTarget> routes = new LinkedHashMap<>();
+        for (FogwallProvider provider : sshProviders) {
+            String key = provider.servletPath();
+            SshProviderTarget existing = routes.get(key);
+            if (existing != null) {
+                throw new IllegalStateException("Duplicate SSH provider path '" + key + "' for providers '"
+                        + existing.provider().getName() + "' and '" + provider.getName()
+                        + "' — configure distinct hosts or pathSuffix values");
+            }
+            var factory = FogwallServletRegistrar.buildReceivePackFactory(ctx, configBuilder, provider);
+            routes.put(key, new SshProviderTarget(provider, factory));
+            log.info("Routing SSH path '{}' -> provider '{}'", key, provider.getName());
+        }
+        return routes;
     }
 }

--- a/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitCommandFactory.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitCommandFactory.java
@@ -2,10 +2,9 @@ package com.rbc.fogwall.ssh;
 
 import com.rbc.fogwall.db.UrlRuleRegistry;
 import com.rbc.fogwall.git.LocalRepositoryCache;
-import com.rbc.fogwall.git.StoreAndForwardReceivePackFactory;
-import com.rbc.fogwall.provider.FogwallProvider;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.sshd.server.channel.ChannelSession;
@@ -14,15 +13,17 @@ import org.apache.sshd.server.command.CommandFactory;
 
 /**
  * MINA SSHD {@link CommandFactory} that maps {@code git-receive-pack} SSH commands to {@link SshGitReceiveCommand} and
- * {@code git-upload-pack} commands to {@link SshGitUploadCommand}.
+ * {@code git-upload-pack} commands to {@link SshGitUploadCommand}. The provider a given command routes to isn't known
+ * until the command's repo path is parsed, so {@code routes} (built once at startup by
+ * {@link com.rbc.fogwall.jetty.SshServerRegistrar}) is handed to the command itself, which resolves the matching
+ * provider from the path segment when it runs — see {@link SshGitReceiveCommand#resolveRoute}.
  */
 @Slf4j
 @RequiredArgsConstructor
 public class SshGitCommandFactory implements CommandFactory {
 
-    private final FogwallProvider provider;
+    private final Map<String, SshProviderTarget> routes;
     private final LocalRepositoryCache cache;
-    private final StoreAndForwardReceivePackFactory receivePackFactory;
     private final FogwallProxyAgentFactory agentFactory;
     private final UrlRuleRegistry urlRuleRegistry;
 
@@ -39,15 +40,14 @@ public class SshGitCommandFactory implements CommandFactory {
         if (command.startsWith("git-receive-pack ")) {
             String repoPath =
                     stripQuotes(command.substring("git-receive-pack ".length()).trim());
-            return new SshGitReceiveCommand(
-                    repoPath, provider, cache, receivePackFactory, agentFactory, knownHostsFile, trustOnFirstUse);
+            return new SshGitReceiveCommand(repoPath, routes, cache, agentFactory, knownHostsFile, trustOnFirstUse);
         }
 
         if (command.startsWith("git-upload-pack ")) {
             String repoPath =
                     stripQuotes(command.substring("git-upload-pack ".length()).trim());
             return new SshGitUploadCommand(
-                    repoPath, provider, cache, agentFactory, urlRuleRegistry, knownHostsFile, trustOnFirstUse);
+                    repoPath, routes, cache, agentFactory, urlRuleRegistry, knownHostsFile, trustOnFirstUse);
         }
 
         log.warn("Unsupported SSH git command: {}", command);

--- a/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitReceiveCommand.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitReceiveCommand.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.sshd.agent.SshAgent;
 import org.apache.sshd.common.Closeable;
@@ -34,9 +36,8 @@ import org.eclipse.jgit.transport.ReceivePack;
 public class SshGitReceiveCommand implements Command {
 
     private final String repoPath;
-    private final FogwallProvider provider;
+    private final Map<String, SshProviderTarget> routes;
     private final LocalRepositoryCache cache;
-    private final StoreAndForwardReceivePackFactory receivePackFactory;
     private final FogwallProxyAgentFactory agentFactory;
     private final Path knownHostsFile;
     private final boolean trustOnFirstUse;
@@ -48,16 +49,14 @@ public class SshGitReceiveCommand implements Command {
 
     SshGitReceiveCommand(
             String repoPath,
-            FogwallProvider provider,
+            Map<String, SshProviderTarget> routes,
             LocalRepositoryCache cache,
-            StoreAndForwardReceivePackFactory receivePackFactory,
             FogwallProxyAgentFactory agentFactory,
             Path knownHostsFile,
             boolean trustOnFirstUse) {
         this.repoPath = repoPath;
-        this.provider = provider;
+        this.routes = routes;
         this.cache = cache;
-        this.receivePackFactory = receivePackFactory;
         this.agentFactory = agentFactory;
         this.knownHostsFile = knownHostsFile;
         this.trustOnFirstUse = trustOnFirstUse;
@@ -108,35 +107,47 @@ public class SshGitReceiveCommand implements Command {
     }
 
     /**
-     * Parses an SSH git path and validates it against the configured provider.
+     * Parses an SSH git path and resolves which configured provider it targets.
      *
-     * <p>Path format: {@code /{host}:{port}/{owner}/{repo}.git} — mirrors the HTTP
-     * {@code /push/{host}:{port}/{owner}/{repo}.git} convention.
+     * <p>Path format: {@code /{providerPath}/{owner}/{repo}.git}, where {@code providerPath} is a provider's
+     * {@link FogwallProvider#servletPath()} (typically {@code {host}} or {@code {host}:{port}}, or a configured
+     * {@code pathSuffix}) — mirrors the HTTP {@code /push/{providerPath}/{owner}/{repo}.git} convention. Matching is by
+     * longest-prefix so a multi-segment {@code pathSuffix} still resolves correctly.
      *
-     * @return a {@link RepoRoute} if the path is valid and matches the provider
-     * @throws IllegalArgumentException if the path is malformed or doesn't match the provider
+     * @return a {@link RepoRoute} if the path is valid and matches a configured provider
+     * @throws IllegalArgumentException if the path is malformed or doesn't match any configured provider
      */
-    static RepoRoute resolveRoute(String repoPath, java.net.URI providerUri) {
-        String normalised = repoPath.startsWith("/") ? repoPath : "/" + repoPath;
-        String[] segments = normalised.replaceAll("\\.git$", "").split("/", 4);
-        if (segments.length < 4) {
-            throw new IllegalArgumentException(
-                    "Invalid repository path: " + repoPath + " (expected /{host}:{port}/{owner}/{repo}.git)");
-        }
-        String providerSegment = segments[1];
-        String owner = segments[2];
-        String repo = segments[3];
+    static RepoRoute resolveRoute(String repoPath, Map<String, SshProviderTarget> routes) {
+        String normalised = (repoPath.startsWith("/") ? repoPath : "/" + repoPath).replaceAll("\\.git$", "");
 
-        int uriPort = providerUri.getPort();
-        String expectedSegment = uriPort > 0 ? providerUri.getHost() + ":" + uriPort : providerUri.getHost();
-        if (!providerSegment.equals(expectedSegment)) {
-            throw new IllegalArgumentException("Unknown provider host '" + providerSegment + "' in path: " + repoPath
-                    + " (expected " + expectedSegment + ")");
+        Map.Entry<String, SshProviderTarget> match = routes.entrySet().stream()
+                .filter(e -> normalised.equals(e.getKey()) || normalised.startsWith(e.getKey() + "/"))
+                .max(Comparator.comparingInt(e -> e.getKey().length()))
+                .orElseThrow(() -> new IllegalArgumentException("Unknown provider path in: " + repoPath
+                        + " (configured provider paths: " + routes.keySet() + ")"));
+
+        String remainder = normalised.substring(match.getKey().length()).replaceFirst("^/", "");
+        String[] ownerRepo = remainder.split("/", 2);
+        if (ownerRepo.length < 2 || ownerRepo[0].isBlank() || ownerRepo[1].isBlank()) {
+            throw new IllegalArgumentException(
+                    "Invalid repository path: " + repoPath + " (expected " + match.getKey() + "/{owner}/{repo}.git)");
         }
-        return new RepoRoute(owner, repo, providerUri + "/" + owner + "/" + repo + ".git", "/" + owner + "/" + repo);
+        String owner = ownerRepo[0];
+        String repo = ownerRepo[1];
+        SshProviderTarget target = match.getValue();
+        String upstreamUrl = target.provider().getUri() + "/" + owner + "/" + repo + ".git";
+        return new RepoRoute(target, owner, repo, upstreamUrl, "/" + owner + "/" + repo);
     }
 
-    record RepoRoute(String owner, String repo, String upstreamUrl, String repoSlug) {}
+    record RepoRoute(SshProviderTarget target, String owner, String repo, String upstreamUrl, String repoSlug) {
+        FogwallProvider provider() {
+            return target.provider();
+        }
+
+        StoreAndForwardReceivePackFactory receivePackFactory() {
+            return target.receivePackFactory();
+        }
+    }
 
     private void runReceivePack(
             String sshUser,
@@ -149,7 +160,7 @@ public class SshGitReceiveCommand implements Command {
         try {
             RepoRoute route;
             try {
-                route = resolveRoute(repoPath, provider.getUri());
+                route = resolveRoute(repoPath, routes);
             } catch (IllegalArgumentException e) {
                 writeError(e.getMessage());
                 exitCode = 128;
@@ -180,7 +191,7 @@ public class SshGitReceiveCommand implements Command {
             localRepo.getConfig().setString("fogwall", null, "upstreamUrl", upstreamUrl);
             localRepo.getConfig().save();
 
-            ReceivePack rp = receivePackFactory.createForSsh(localRepo, sshUser, repoSlug, pushTransport);
+            ReceivePack rp = route.receivePackFactory().createForSsh(localRepo, sshUser, repoSlug, pushTransport);
             rp.setBiDirectionalPipe(true); // factory defaults to false for HTTP; SSH is bidirectional
             rp.receive(in, out, err);
 

--- a/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitServer.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitServer.java
@@ -3,13 +3,12 @@ package com.rbc.fogwall.ssh;
 import com.rbc.fogwall.config.SshConfig;
 import com.rbc.fogwall.db.UrlRuleRegistry;
 import com.rbc.fogwall.git.LocalRepositoryCache;
-import com.rbc.fogwall.git.StoreAndForwardReceivePackFactory;
-import com.rbc.fogwall.provider.FogwallProvider;
 import com.rbc.fogwall.user.ReadOnlyUserStore;
 import com.rbc.fogwall.user.UserEntry;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.sshd.common.session.Session;
@@ -32,7 +31,9 @@ import org.apache.sshd.server.session.ServerSession;
  * looked up in the user store at connection time to resolve their {@link UserEntry}, which is then stored on the MINA
  * session for use by {@link SshGitReceiveCommand}.
  *
- * <p>MVP constraint: only a single provider is supported per server instance.
+ * <p>A single server instance can serve multiple upstream providers — {@link SshGitCommandFactory} routes each command
+ * to the right one using the {@link SshProviderTarget} map keyed by {@code servletPath()} (see
+ * {@link com.rbc.fogwall.jetty.SshServerRegistrar}).
  */
 @Slf4j
 public class SshGitServer {
@@ -51,9 +52,8 @@ public class SshGitServer {
 
     public static SshGitServer create(
             SshConfig config,
-            FogwallProvider provider,
+            Map<String, SshProviderTarget> routes,
             LocalRepositoryCache cache,
-            StoreAndForwardReceivePackFactory receivePackFactory,
             ReadOnlyUserStore userStore,
             UrlRuleRegistry urlRuleRegistry)
             throws IOException {
@@ -78,13 +78,7 @@ public class SshGitServer {
         Path knownHostsFile = UpstreamKnownHosts.assemble(config.getKnownHostsPath(), config.getExtraKnownHosts());
 
         sshd.setCommandFactory(new SshGitCommandFactory(
-                provider,
-                cache,
-                receivePackFactory,
-                agentFactory,
-                urlRuleRegistry,
-                knownHostsFile,
-                config.isTrustOnFirstUse()));
+                routes, cache, agentFactory, urlRuleRegistry, knownHostsFile, config.isTrustOnFirstUse()));
 
         return new SshGitServer(sshd);
     }

--- a/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitUploadCommand.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitUploadCommand.java
@@ -3,12 +3,12 @@ package com.rbc.fogwall.ssh;
 import com.rbc.fogwall.db.UrlRuleRegistry;
 import com.rbc.fogwall.git.HttpOperation;
 import com.rbc.fogwall.git.LocalRepositoryCache;
-import com.rbc.fogwall.provider.FogwallProvider;
 import com.rbc.fogwall.servlet.filter.UrlRuleEvaluator;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.sshd.agent.SshAgent;
 import org.apache.sshd.common.channel.exception.SshChannelClosedException;
@@ -39,7 +39,7 @@ import org.eclipse.jgit.transport.UploadPack;
 public class SshGitUploadCommand implements Command {
 
     private final String repoPath;
-    private final FogwallProvider provider;
+    private final Map<String, SshProviderTarget> routes;
     private final LocalRepositoryCache cache;
     private final FogwallProxyAgentFactory agentFactory;
     private final UrlRuleRegistry urlRuleRegistry;
@@ -53,14 +53,14 @@ public class SshGitUploadCommand implements Command {
 
     SshGitUploadCommand(
             String repoPath,
-            FogwallProvider provider,
+            Map<String, SshProviderTarget> routes,
             LocalRepositoryCache cache,
             FogwallProxyAgentFactory agentFactory,
             UrlRuleRegistry urlRuleRegistry,
             Path knownHostsFile,
             boolean trustOnFirstUse) {
         this.repoPath = repoPath;
-        this.provider = provider;
+        this.routes = routes;
         this.cache = cache;
         this.agentFactory = agentFactory;
         this.urlRuleRegistry = urlRuleRegistry;
@@ -105,7 +105,7 @@ public class SshGitUploadCommand implements Command {
         try {
             SshGitReceiveCommand.RepoRoute route;
             try {
-                route = SshGitReceiveCommand.resolveRoute(repoPath, provider.getUri());
+                route = SshGitReceiveCommand.resolveRoute(repoPath, routes);
             } catch (IllegalArgumentException e) {
                 writeError(e.getMessage());
                 exitCode = 128;
@@ -117,7 +117,7 @@ public class SshGitUploadCommand implements Command {
 
             // Mirrors UrlRuleAggregateFilter's fetch-side gate — the only enforcement point for URL allow/deny
             // rules on this transport, since SSH has no servlet filter chain.
-            var evaluator = new UrlRuleEvaluator(urlRuleRegistry, provider);
+            var evaluator = new UrlRuleEvaluator(urlRuleRegistry, route.provider());
             String slug = owner + "/" + repo;
             UrlRuleEvaluator.Result result = evaluator.evaluate(slug, owner, repo, HttpOperation.FETCH);
             if (!(result instanceof UrlRuleEvaluator.Result.Allowed allowed)) {

--- a/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshProviderTarget.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshProviderTarget.java
@@ -1,0 +1,12 @@
+package com.rbc.fogwall.ssh;
+
+import com.rbc.fogwall.git.StoreAndForwardReceivePackFactory;
+import com.rbc.fogwall.provider.FogwallProvider;
+
+/**
+ * Pairs an SSH-routed provider with its pre-built {@link StoreAndForwardReceivePackFactory}. {@link SshServerRegistrar}
+ * builds one of these per configured SSH provider at startup (mirroring how the HTTP path builds one factory per
+ * provider), keyed by {@link FogwallProvider#servletPath()} so {@link SshGitCommandFactory} can route each incoming
+ * command to the right provider without rebuilding anything per-request.
+ */
+public record SshProviderTarget(FogwallProvider provider, StoreAndForwardReceivePackFactory receivePackFactory) {}

--- a/fogwall-server/src/main/resources/fogwall-local.yml
+++ b/fogwall-server/src/main/resources/fogwall-local.yml
@@ -21,6 +21,18 @@ providers:
     api-uri: http://localhost:3000  # needed for SCM identity enrichment — SSH URI can't be used for HTTP API calls
     # api-token: <PAT>  # required when Gitea is configured with REQUIRE_SIGNIN_VIEW=true
     #                    # no env var override — set via external config file or FOGWALL_CONFIG_PROFILES
+  # Second SSH provider, to exercise multi-provider SSH routing (#447) against a real host — GitHub's SSH key
+  # listing endpoint (GET /users/{login}/keys) is public, so no api-token is needed here.
+  github-ssh:
+    enabled: true
+    type: github
+    uri: ssh://git@github.com
+    # To actually push/fetch through this provider you need your OWN github.com SSH key loaded in ssh-agent
+    # (fogwall relays your forwarded agent — it never holds credentials itself). Steps:
+    #   1. Add your real public key under dev's ssh-keys below (replace the placeholder test key, or add a second entry).
+    #   2. Add your GitHub username under dev's scm-identities for provider: github-ssh (see below).
+    #   3. Add an allow rule + permission for a repo you actually control (see rules/permissions below).
+    #   4. Push via: ssh://localhost:2222/github.com/<your-org>/<your-repo>.git (agent forwarding required: ssh -A)
 # Three users for local development:
 #   admin    — full dashboard access, can approve any push
 #   dev      — a developer account; add your SCM identity here to push through the proxy
@@ -50,10 +62,17 @@ users:
         username: test-user
       - provider: gitea-ssh
         username: test-user
+      # Uncomment and set to your real GitHub username to test the github-ssh provider above:
+      # - provider: github-ssh
+      #   username: your-gh-handle
     emails:
       - dev@example.com
     ssh-keys:
         - public-key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILZutQPsqDrByIRlmp6JgAK8DSGzf7+SoKBzjCy+av2J fogwall-test@local"
+        # Add your own real key here (the one loaded in your ssh-agent, already registered on github.com)
+        # to authenticate against the github-ssh provider — the placeholder key above only works for gitea-ssh
+        # since it's pre-registered with the local Gitea test container, not with GitHub.
+        # - public-key: "ssh-ed25519 AAAA... you@yourhost"
 
   - username: reviewer
     password-hash: "{noop}password"
@@ -136,6 +155,14 @@ permissions:
   #     value: /your-org/your-repo
   #     type: LITERAL
   #   operation: PUSH
+  # For github-ssh (see providers above), scope this to a repo you actually control:
+  # - username: dev
+  #   provider: github-ssh
+  #   match:
+  #     target: SLUG
+  #     value: /your-org/your-repo
+  #     type: LITERAL
+  #   grant: PUSH
 
 rules:
   # Evaluated like firewall rules: all allow and deny rules merged into a single list
@@ -175,6 +202,16 @@ rules:
     #   order: 110
     #   operation: BOTH
     #   provider: github
+    #   match:
+    #     target: SLUG
+    #     value: /your-org/your-repo
+    #     type: LITERAL
+
+    # For github-ssh (see providers above), scope this to a repo you actually control:
+    # - enabled: true
+    #   order: 111
+    #   operation: BOTH
+    #   provider: github-ssh
     #   match:
     #     target: SLUG
     #     value: /your-org/your-repo

--- a/fogwall-server/src/test/java/com/rbc/fogwall/e2e/SshE2ETest.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/e2e/SshE2ETest.java
@@ -226,6 +226,57 @@ class SshE2ETest {
 
     @Test
     @Order(6)
+    void secondProvider_pushIsRoutedAndForwarded_notSilentlyDropped() throws Exception {
+        // Regression test for #447: a second SSH provider entry (same Gitea backend, routed under a distinct
+        // pathSuffix — see SshProxyFixture.ALIAS_PATH_SUFFIX) must actually be reachable, not silently ignored in
+        // favor of the first configured provider.
+        var git = sshGit();
+        Path repo = git.clone(
+                gitea.getBaseUrl() + "/" + GiteaContainer.TEST_ORG + "/" + GiteaContainer.TEST_REPO + ".git",
+                "ssh-second-provider");
+        git.setRemoteUrl(repo, "origin", proxy.aliasPushUrl(GiteaContainer.TEST_ORG, GiteaContainer.TEST_REPO));
+        git.setAuthor(repo, GiteaContainer.VALID_AUTHOR_NAME, GiteaContainer.VALID_AUTHOR_EMAIL);
+        git.writeAndStage(repo, "ssh-second-provider.txt", "pushed via the second SSH provider entry");
+        git.commit(repo, "test: push via second SSH provider (issue #447)");
+
+        var result = git.pushWithResult(repo);
+        assertTrue(result.succeeded(), "Expected push via the second provider to succeed\n" + result.output());
+
+        var records = proxy.getPushStore().find(PushQuery.builder().limit(200).build());
+        assertTrue(
+                records.stream()
+                        .anyMatch(r -> PushStatus.FORWARDED.equals(r.getStatus())
+                                && "gitea-ssh-e2e-alias".equals(r.getProvider())),
+                "Expected a FORWARDED record attributed to the second provider entry");
+    }
+
+    @Test
+    @Order(7)
+    void unknownProviderPath_isRejectedWithClearError() throws Exception {
+        // A path segment that doesn't match any configured provider must fail cleanly, not fall back to the
+        // first-configured provider (the exact silent-drop behavior #447 fixes).
+        var git = sshGit();
+        Path repo = git.clone(
+                gitea.getBaseUrl() + "/" + GiteaContainer.TEST_ORG + "/" + GiteaContainer.TEST_REPO + ".git",
+                "ssh-unknown-provider");
+        git.setRemoteUrl(
+                repo,
+                "origin",
+                "ssh://localhost:" + proxy.getSshPort() + "/no-such-provider/" + GiteaContainer.TEST_ORG + "/"
+                        + GiteaContainer.TEST_REPO + ".git");
+        git.setAuthor(repo, GiteaContainer.VALID_AUTHOR_NAME, GiteaContainer.VALID_AUTHOR_EMAIL);
+        git.writeAndStage(repo, "unknown-provider.txt", "should not reach any provider");
+        git.commit(repo, "test: unknown provider path should be rejected cleanly");
+
+        var result = git.pushWithResult(repo);
+        assertFalse(result.succeeded(), "Expected push to an unconfigured provider path to fail");
+        assertTrue(
+                result.output().contains("Unknown provider path"),
+                "Expected a clear routing error in output:\n" + result.output());
+    }
+
+    @Test
+    @Order(8)
     void fetchViaSsh_deniedByUrlRule_isRejected() throws Exception {
         // Lower ruleOrder than the fixture's catch-all allow (order 1), so this is evaluated first.
         // Last test in the class by design — no cleanup needed for a rule that outlives this method.

--- a/fogwall-server/src/test/java/com/rbc/fogwall/e2e/SshProxyFixture.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/e2e/SshProxyFixture.java
@@ -15,10 +15,12 @@ import com.rbc.fogwall.git.StoreAndForwardReceivePackFactory;
 import com.rbc.fogwall.permission.InMemoryRepoPermissionStore;
 import com.rbc.fogwall.permission.RepoPermission;
 import com.rbc.fogwall.permission.RepoPermissionService;
+import com.rbc.fogwall.provider.FogwallProvider;
 import com.rbc.fogwall.provider.ForgejoProvider;
 import com.rbc.fogwall.service.SshScmIdentityEnricher;
 import com.rbc.fogwall.ssh.SshGitServer;
 import com.rbc.fogwall.ssh.SshKeyUtils;
+import com.rbc.fogwall.ssh.SshProviderTarget;
 import com.rbc.fogwall.user.ScmIdentity;
 import com.rbc.fogwall.user.SshKeyEntry;
 import com.rbc.fogwall.user.StaticUserStore;
@@ -29,7 +31,9 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -80,16 +84,25 @@ class SshProxyFixture implements AutoCloseable {
 
         // Provider name is also the providerId used when matching scm_identities in the enricher.
         String providerId = "gitea-ssh-e2e";
+        // Second provider entry, same Gitea backend but routed under a distinct pathSuffix instead of host:port —
+        // exercises real multi-provider SSH routing (issue #447) without standing up a second upstream container.
+        String aliasProviderId = "gitea-ssh-e2e-alias";
 
         // The test key is registered in Gitea under ADMIN_USER — link the test user's SCM identity accordingly
-        // so the enricher can verify the connecting fingerprint against ADMIN_USER's Gitea keys.
+        // so the enricher can verify the connecting fingerprint against ADMIN_USER's Gitea keys. One identity per
+        // provider entry, since identity resolution is keyed by providerId.
         var testUser = UserEntry.builder()
                 .username(TEST_USER)
                 .emails(List.of(GiteaContainer.VALID_AUTHOR_EMAIL))
-                .scmIdentities(List.of(ScmIdentity.builder()
-                        .provider(providerId)
-                        .username(GiteaContainer.ADMIN_USER)
-                        .build()))
+                .scmIdentities(List.of(
+                        ScmIdentity.builder()
+                                .provider(providerId)
+                                .username(GiteaContainer.ADMIN_USER)
+                                .build(),
+                        ScmIdentity.builder()
+                                .provider(aliasProviderId)
+                                .username(GiteaContainer.ADMIN_USER)
+                                .build()))
                 .sshKeys(List.of(sshKeyEntry))
                 .build();
 
@@ -101,6 +114,13 @@ class SshProxyFixture implements AutoCloseable {
         var provider = ForgejoProvider.builder()
                 .name(providerId)
                 .uri(giteaSshUri)
+                .apiUri(URI.create(gitea.getBaseUrl()))
+                .apiToken(giteaApiToken)
+                .build();
+        var aliasProvider = ForgejoProvider.builder()
+                .name(aliasProviderId)
+                .uri(giteaSshUri)
+                .pathSuffix(ALIAS_PATH_SUFFIX)
                 .apiUri(URI.create(gitea.getBaseUrl()))
                 .apiToken(giteaApiToken)
                 .build();
@@ -118,33 +138,39 @@ class SshProxyFixture implements AutoCloseable {
                 .matchType(MatchType.GLOB)
                 .build());
 
-        // Seed a catch-all PUSH permission for the test user so CheckUserPushPermissionHook passes.
+        // Seed a catch-all PUSH permission for the test user against both provider entries.
         var permissionStore = new InMemoryRepoPermissionStore();
-        permissionStore.save(RepoPermission.builder()
-                .username(TEST_USER)
-                .provider(provider.getProviderId())
-                .value("/**")
-                .matchType(MatchType.GLOB)
-                .grant(RepoPermission.Grant.PUSH)
-                .build());
+        for (FogwallProvider p : List.of(provider, aliasProvider)) {
+            permissionStore.save(RepoPermission.builder()
+                    .username(TEST_USER)
+                    .provider(p.getProviderId())
+                    .value("/**")
+                    .matchType(MatchType.GLOB)
+                    .grant(RepoPermission.Grant.PUSH)
+                    .build());
+        }
         var permissionService = new RepoPermissionService(permissionStore);
 
-        var receivePackFactory = new StoreAndForwardReceivePackFactory(
-                provider,
-                JettyProxyFixture::buildCommitConfig,
-                null,
-                null,
-                null,
-                ContentPatternConfig.defaultConfig(),
-                GpgConfig.defaultConfig(),
-                permissionService,
-                null,
-                pushStore,
-                new AutoApprovalGateway(pushStore),
-                null,
-                Duration.ofSeconds(10),
-                urlRuleRegistry);
-        receivePackFactory.setSshScmIdentityEnricher(new SshScmIdentityEnricher());
+        Map<String, SshProviderTarget> routes = new LinkedHashMap<>();
+        for (FogwallProvider p : List.of(provider, aliasProvider)) {
+            var receivePackFactory = new StoreAndForwardReceivePackFactory(
+                    p,
+                    JettyProxyFixture::buildCommitConfig,
+                    null,
+                    null,
+                    null,
+                    ContentPatternConfig.defaultConfig(),
+                    GpgConfig.defaultConfig(),
+                    permissionService,
+                    null,
+                    pushStore,
+                    new AutoApprovalGateway(pushStore),
+                    null,
+                    Duration.ofSeconds(10),
+                    urlRuleRegistry);
+            receivePackFactory.setSshScmIdentityEnricher(new SshScmIdentityEnricher());
+            routes.put(p.servletPath(), new SshProviderTarget(p, receivePackFactory));
+        }
 
         sshPort = findFreePort();
         var sshConfig = new SshConfig();
@@ -158,18 +184,30 @@ class SshProxyFixture implements AutoCloseable {
         // mechanism operators opt into for internal providers (see SshConfig#isTrustOnFirstUse).
         sshConfig.setTrustOnFirstUse(true);
 
-        sshServer = SshGitServer.create(sshConfig, provider, cache, receivePackFactory, userStore, urlRuleRegistry);
+        sshServer = SshGitServer.create(sshConfig, routes, cache, userStore, urlRuleRegistry);
         sshServer.start();
     }
+
+    /** Path suffix the second (alias) provider entry is routed under — see the multi-provider routing note above. */
+    private static final String ALIAS_PATH_SUFFIX = "/gitea-alias";
 
     /** The host port the fogwall SSH server is listening on. */
     int getSshPort() {
         return sshPort;
     }
 
-    /** The push URL for a repository, targeting this SSH fixture. */
+    /** The push URL for a repository, targeting this SSH fixture's primary (host:port-routed) provider entry. */
     String pushUrl(String owner, String repo) {
         return "ssh://localhost:" + sshPort + "/" + giteaSshHostPort + "/" + owner + "/" + repo + ".git";
+    }
+
+    /**
+     * The push URL for a repository, targeting this SSH fixture's second provider entry (routed by
+     * {@link #ALIAS_PATH_SUFFIX} instead of host:port) — same upstream Gitea backend, different provider entry, used to
+     * verify multi-provider SSH routing (issue #447).
+     */
+    String aliasPushUrl(String owner, String repo) {
+        return "ssh://localhost:" + sshPort + ALIAS_PATH_SUFFIX + "/" + owner + "/" + repo + ".git";
     }
 
     PushStore getPushStore() {

--- a/fogwall-server/src/test/java/com/rbc/fogwall/jetty/config/JettyConfigurationBuilderTest.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/jetty/config/JettyConfigurationBuilderTest.java
@@ -304,6 +304,24 @@ class JettyConfigurationBuilderTest {
     }
 
     @Test
+    void createProvider_githubType_sshUriWithApiUri_wiresApiUriThrough() {
+        var providerConfig = new ProviderConfig();
+        providerConfig.setEnabled(true);
+        providerConfig.setType("github");
+        providerConfig.setUri("ssh://git@github.corp.example.com");
+        providerConfig.setApiUri("https://github.corp.example.com/api/v3");
+
+        var providers =
+                new JettyConfigurationBuilder(configWithSingleProvider("github-ssh", providerConfig)).buildProviders();
+
+        assertEquals(1, providers.size());
+        assertInstanceOf(GitHubProvider.class, providers.get(0));
+        var github = (GitHubProvider) providers.get(0);
+        assertEquals(URI.create("ssh://git@github.corp.example.com"), github.getUri());
+        assertEquals("https://github.corp.example.com/api/v3", github.getApiUrl());
+    }
+
+    @Test
     void createProvider_gitlabKey_inferredAsGitLabProvider() {
         var providers = new JettyConfigurationBuilder(configWithSingleProvider("gitlab", new ProviderConfig()))
                 .buildProviders();

--- a/fogwall-server/src/test/java/com/rbc/fogwall/ssh/SshGitCommandFactoryTest.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/ssh/SshGitCommandFactoryTest.java
@@ -9,6 +9,7 @@ import com.rbc.fogwall.git.LocalRepositoryCache;
 import com.rbc.fogwall.git.StoreAndForwardReceivePackFactory;
 import com.rbc.fogwall.provider.FogwallProvider;
 import java.io.IOException;
+import java.util.Map;
 import org.apache.sshd.server.channel.ChannelSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,10 +21,12 @@ class SshGitCommandFactoryTest {
 
     @BeforeEach
     void setUp() {
+        FogwallProvider provider = mock(FogwallProvider.class);
+        Map<String, SshProviderTarget> routes = Map.of(
+                "/localhost:3022", new SshProviderTarget(provider, mock(StoreAndForwardReceivePackFactory.class)));
         factory = new SshGitCommandFactory(
-                mock(FogwallProvider.class),
+                routes,
                 mock(LocalRepositoryCache.class),
-                mock(StoreAndForwardReceivePackFactory.class),
                 mock(FogwallProxyAgentFactory.class),
                 mock(UrlRuleRegistry.class),
                 null,

--- a/fogwall-server/src/test/java/com/rbc/fogwall/ssh/SshGitReceiveCommandTest.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/ssh/SshGitReceiveCommandTest.java
@@ -2,9 +2,14 @@ package com.rbc.fogwall.ssh;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
+import com.rbc.fogwall.git.StoreAndForwardReceivePackFactory;
+import com.rbc.fogwall.provider.ForgejoProvider;
 import com.rbc.fogwall.ssh.SshGitReceiveCommand.RepoRoute;
 import java.net.URI;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -13,11 +18,25 @@ class SshGitReceiveCommandTest {
 
     private static final URI GITEA_URI = URI.create("ssh://git@localhost:3022");
 
+    private static SshProviderTarget target(URI uri, String pathSuffix) {
+        var provider = ForgejoProvider.builder()
+                .name("gitea")
+                .uri(uri)
+                .pathSuffix(pathSuffix)
+                .build();
+        return new SshProviderTarget(provider, mock(StoreAndForwardReceivePackFactory.class));
+    }
+
+    private static Map<String, SshProviderTarget> singleRoute() {
+        SshProviderTarget giteaTarget = target(GITEA_URI, null);
+        return Map.of(giteaTarget.provider().servletPath(), giteaTarget);
+    }
+
     // ── Happy path ────────────────────────────────────────────────────────────
 
     @Test
     void resolvesStandardPath() {
-        RepoRoute route = SshGitReceiveCommand.resolveRoute("/localhost:3022/test-owner/test-repo.git", GITEA_URI);
+        RepoRoute route = SshGitReceiveCommand.resolveRoute("/localhost:3022/test-owner/test-repo.git", singleRoute());
         assertEquals("test-owner", route.owner());
         assertEquals("test-repo", route.repo());
         assertEquals("ssh://git@localhost:3022/test-owner/test-repo.git", route.upstreamUrl());
@@ -26,14 +45,14 @@ class SshGitReceiveCommandTest {
 
     @Test
     void acceptsPathWithoutLeadingSlash() {
-        RepoRoute route = SshGitReceiveCommand.resolveRoute("localhost:3022/org/repo.git", GITEA_URI);
+        RepoRoute route = SshGitReceiveCommand.resolveRoute("localhost:3022/org/repo.git", singleRoute());
         assertEquals("org", route.owner());
         assertEquals("repo", route.repo());
     }
 
     @Test
     void acceptsPathWithoutDotGitSuffix() {
-        RepoRoute route = SshGitReceiveCommand.resolveRoute("/localhost:3022/owner/repo", GITEA_URI);
+        RepoRoute route = SshGitReceiveCommand.resolveRoute("/localhost:3022/owner/repo", singleRoute());
         assertEquals("owner", route.owner());
         assertEquals("repo", route.repo());
     }
@@ -41,10 +60,53 @@ class SshGitReceiveCommandTest {
     @Test
     void matchesProviderWithNoPort() {
         URI noPortUri = URI.create("ssh://git@github.com");
-        RepoRoute route = SshGitReceiveCommand.resolveRoute("/github.com/myorg/myrepo.git", noPortUri);
+        SshProviderTarget githubTarget = target(noPortUri, null);
+        Map<String, SshProviderTarget> routes = Map.of(githubTarget.provider().servletPath(), githubTarget);
+
+        RepoRoute route = SshGitReceiveCommand.resolveRoute("/github.com/myorg/myrepo.git", routes);
         assertEquals("myorg", route.owner());
         assertEquals("myrepo", route.repo());
         assertEquals("ssh://git@github.com/myorg/myrepo.git", route.upstreamUrl());
+    }
+
+    // ── Multi-provider routing ───────────────────────────────────────────────
+
+    @Test
+    void routesToCorrectProviderAmongMultiple() {
+        SshProviderTarget giteaTarget = target(GITEA_URI, null);
+        SshProviderTarget githubTarget = target(URI.create("ssh://git@github.com"), null);
+        Map<String, SshProviderTarget> routes = Map.of(
+                giteaTarget.provider().servletPath(), giteaTarget,
+                githubTarget.provider().servletPath(), githubTarget);
+
+        RepoRoute giteaRoute = SshGitReceiveCommand.resolveRoute("/localhost:3022/owner/repo.git", routes);
+        assertEquals(giteaTarget.provider(), giteaRoute.provider());
+
+        RepoRoute githubRoute = SshGitReceiveCommand.resolveRoute("/github.com/owner/repo.git", routes);
+        assertEquals(githubTarget.provider(), githubRoute.provider());
+    }
+
+    @Test
+    void routesByPathSuffixWhenConfigured() {
+        SshProviderTarget target = target(GITEA_URI, "/internal-gitea");
+        Map<String, SshProviderTarget> routes = Map.of(target.provider().servletPath(), target);
+
+        RepoRoute route = SshGitReceiveCommand.resolveRoute("/internal-gitea/owner/repo.git", routes);
+        assertEquals("owner", route.owner());
+        assertEquals("repo", route.repo());
+        assertEquals(target.provider(), route.provider());
+    }
+
+    @Test
+    void resolvesCorrectReceivePackFactoryPerProvider() {
+        SshProviderTarget giteaTarget = target(GITEA_URI, null);
+        SshProviderTarget githubTarget = target(URI.create("ssh://git@github.com"), null);
+        Map<String, SshProviderTarget> routes = Map.of(
+                giteaTarget.provider().servletPath(), giteaTarget,
+                githubTarget.provider().servletPath(), githubTarget);
+
+        RepoRoute githubRoute = SshGitReceiveCommand.resolveRoute("/github.com/owner/repo.git", routes);
+        assertEquals(githubTarget.receivePackFactory(), githubRoute.receivePackFactory());
     }
 
     // ── Path format errors ────────────────────────────────────────────────────
@@ -58,7 +120,7 @@ class SshGitReceiveCommandTest {
                 "" // empty
             })
     void rejectsPathWithTooFewSegments(String path) {
-        assertThrows(IllegalArgumentException.class, () -> SshGitReceiveCommand.resolveRoute(path, GITEA_URI));
+        assertThrows(IllegalArgumentException.class, () -> SshGitReceiveCommand.resolveRoute(path, singleRoute()));
     }
 
     // ── Provider mismatch ─────────────────────────────────────────────────────
@@ -67,22 +129,22 @@ class SshGitReceiveCommandTest {
     void rejectsWrongHost() {
         IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class,
-                () -> SshGitReceiveCommand.resolveRoute("/github.com:443/org/repo.git", GITEA_URI));
-        assertEquals(true, ex.getMessage().contains("github.com:443"));
-        assertEquals(true, ex.getMessage().contains("localhost:3022"));
+                () -> SshGitReceiveCommand.resolveRoute("/github.com:443/org/repo.git", singleRoute()));
+        assertTrue(ex.getMessage().contains("github.com:443"));
+        assertTrue(ex.getMessage().contains("localhost:3022"));
     }
 
     @Test
     void rejectsWrongPort() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> SshGitReceiveCommand.resolveRoute("/localhost:9999/owner/repo.git", GITEA_URI));
+                () -> SshGitReceiveCommand.resolveRoute("/localhost:9999/owner/repo.git", singleRoute()));
     }
 
     @Test
     void rejectsRightHostWrongPort() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> SshGitReceiveCommand.resolveRoute("/localhost/owner/repo.git", GITEA_URI));
+                () -> SshGitReceiveCommand.resolveRoute("/localhost/owner/repo.git", singleRoute()));
     }
 }


### PR DESCRIPTION
## Summary
- `SshServerRegistrar` previously built a receive-pack factory for only the first configured SSH provider and silently dropped the rest. Every SSH provider is now routed by its `servletPath()` (host:port, or a configured `pathSuffix` — the same key the HTTP path already uses), matched by longest prefix against the incoming SSH command's repo path, with one receive-pack factory built per provider at startup.
- Fixes `GitHubProvider`, which could not actually function as an SSH provider before this: `getApiUrl()`/`getGraphqlUrl()` compared the full URI against `DEFAULT_URI` (scheme included), so an `ssh://` URI never matched the default-host branch, and there was no `apiUri` field/builder param at all to override it manually (unlike GitLab/Forgejo). Now derives by host instead of full-URI equality, adds `apiUri` support end-to-end (class, builder, `JettyConfigurationBuilder` wiring), and fixes the self-hosted GHES fallback to convert `ssh://` to `https://` rather than producing an unusable `ssh://.../api/v3` URL.

## Test plan
- [x] Unit tests: `SshGitReceiveCommandTest`, `SshGitCommandFactoryTest`, `ProviderTest`, `JettyConfigurationBuilderTest`
- [x] E2e (`SshE2ETest` against a real Gitea container): second provider entry pushes and forwards correctly; unconfigured provider paths are rejected cleanly instead of falling through to the first provider
- [x] Manual end-to-end run against real `github.com` over SSH: identity verification, review/approval flow, and forwarding all worked through a `github-ssh` provider entry
- [x] `./gradlew spotlessApply build` and jacoco coverage verification pass locally

closes #447