### PR TITLE
fix(deps): pin plugin-classpath Jackson to 2.22.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,12 @@ buildscript {
         resolutionStrategy {
             force 'org.codehaus.plexus:plexus-utils:3.6.1'
             force 'org.bouncycastle:bcpg-jdk18on:1.85'
+            // Jackson 2.x on the *plugin* classpath (gradle-node-plugin, cyclonedx-gradle-plugin).
+            // The runtime pin in the subprojects eachDependency table does not reach this
+            // configuration, and the dependency graph submitted to GitHub includes it.
+            // CVE fix: GHSA-r7wm-3cxj-wff9, GHSA-5gvw-p9qm-jgwh, GHSA-5jmj-h7xm-6q6v
+            force 'com.fasterxml.jackson.core:jackson-core:2.22.1'
+            force 'com.fasterxml.jackson.core:jackson-databind:2.22.1'
         }
     }
 }


### PR DESCRIPTION
## What

Adds `jackson-core`/`jackson-databind` 2.22.1 forces to the existing `buildscript` `resolutionStrategy` block (alongside the plexus-utils and bouncycastle plugin-classpath pins).

## Why

The runtime Jackson pin in the `subprojects` `eachDependency` table governs project configurations only — it never reaches the plugin classpath, where `gradle-node-plugin` 7.1.0 and `cyclonedx-gradle-plugin` 3.3.0 pull Jackson 2.20.1. The dependency-submission workflow submits that classpath too, so the graph (correctly) kept reporting 2.20.1 and the Dependabot alerts never cleared, despite the app itself shipping 2.22.1.

## Verification

- `./gradlew buildEnvironment`: all plugin-classpath Jackson coordinates now resolve to 2.22.1 (previously 2.20.1).
- `./gradlew compileJava` green across modules with the bumped plugin classpath.
- Alerts should clear after this merges and the next dependency-submission run on main completes.