### PR TITLE
fix(cache): key the mirror fetch cooldown by principal, not repository alone

### DIFF
--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/LocalRepositoryCache.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/LocalRepositoryCache.java
@@ -108,7 +108,15 @@ public class LocalRepositoryCache {
     }
 
     /**
-     * Get or create a local clone of a remote repository.
+     * Get or create a local clone of a remote repository <b>as an anonymous caller</b> — no credentials, no principal.
+     *
+     * <p>Only appropriate when the repository is expected to be publicly readable. All anonymous callers share a single
+     * cache identity, which is safe precisely because an anonymous cache hit can only ever reuse a previous anonymous
+     * fetch, and that fetch succeeded without credentials. If you have credentials, you also have an identity: use
+     * {@link #getOrClone(String, CredentialsProvider, TransportConfigCallback, String)} and pass both. There is
+     * deliberately no overload that accepts credentials without a principal — supplying one and not the other means
+     * authenticating the fetch while leaving the cooldown anonymous, which silently makes one caller's access reusable
+     * by the next.
      *
      * @param remoteUrl The URL of the remote repository
      * @return The local repository
@@ -116,30 +124,7 @@ public class LocalRepositoryCache {
      * @throws IOException If I/O operations fail
      */
     public Repository getOrClone(String remoteUrl) throws GitAPIException, IOException {
-        return getOrClone(remoteUrl, null);
-    }
-
-    /**
-     * Get or create a local clone of a remote repository, using the supplied credentials for clone and fetch.
-     * Credentials are passed transiently to JGit — they are never written to disk.
-     *
-     * <p>On a cache hit, re-fetches from upstream to keep the local mirror fresh. The re-fetch is serialized via a
-     * per-repository lock and skipped if the mirror was already refreshed within {@code fetchCooldownMs}.
-     */
-    public Repository getOrClone(String remoteUrl, CredentialsProvider credentials)
-            throws GitAPIException, IOException {
-        return getOrClone(remoteUrl, credentials, null);
-    }
-
-    /**
-     * Get or create a local clone of a remote repository, with an optional {@link TransportConfigCallback} applied to
-     * every clone and fetch operation. Use this overload when per-request transport configuration is needed (e.g. SSH
-     * agent forwarding) — the callback is scoped to this call and never stored globally.
-     */
-    public Repository getOrClone(
-            String remoteUrl, CredentialsProvider credentials, TransportConfigCallback transportConfig)
-            throws GitAPIException, IOException {
-        return getOrClone(remoteUrl, credentials, transportConfig, null);
+        return getOrClone(remoteUrl, null, null, null);
     }
 
     /**

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/LocalRepositoryCache.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/LocalRepositoryCache.java
@@ -2,9 +2,13 @@ package com.rbc.fogwall.git;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Comparator;
+import java.util.HexFormat;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
@@ -44,6 +48,12 @@ public class LocalRepositoryCache {
      * from each triggering a separate fetch when the mirror is already fresh.
      */
     private static final long DEFAULT_FETCH_COOLDOWN_MS = 5_000;
+
+    /**
+     * Identity used when a caller supplies no principal. Not a hash, so it can never collide with a real hashed
+     * principal — an unauthenticated caller only ever shares a cooldown with other unauthenticated callers.
+     */
+    private static final String ANONYMOUS_PRINCIPAL = "anonymous";
 
     private final Path cacheDirectory;
     private final Map<String, CachedRepository> cache = new ConcurrentHashMap<>();
@@ -129,18 +139,61 @@ public class LocalRepositoryCache {
     public Repository getOrClone(
             String remoteUrl, CredentialsProvider credentials, TransportConfigCallback transportConfig)
             throws GitAPIException, IOException {
+        return getOrClone(remoteUrl, credentials, transportConfig, null);
+    }
+
+    /**
+     * Get or create a local clone, recording which principal's credentials last successfully reached upstream.
+     *
+     * <p><b>Why the principal matters.</b> The fetch cooldown exists to avoid redundant network round-trips, but the
+     * upstream fetch it skips is also the only thing that proves the caller may access the repository — there is no
+     * separate read-authorization check on this path. Keyed on the repository alone, the cooldown therefore made one
+     * principal's authorization transferable to any other principal who asked within the window: the mirror would be
+     * handed back without their credentials ever being sent anywhere. Keying it on {@code (repository, principal)}
+     * means an unrecognised principal always forces a real upstream fetch with their own credentials, so an
+     * unauthorized caller fails closed instead of inheriting someone else's access.
+     *
+     * @param principal opaque identity of the caller — HTTP Basic {@code user:token}, an SSH key fingerprint, or
+     *     {@code null} for an unauthenticated caller (all of which share a single anonymous identity). Hashed before
+     *     use; the raw value is never retained.
+     */
+    public Repository getOrClone(
+            String remoteUrl,
+            CredentialsProvider credentials,
+            TransportConfigCallback transportConfig,
+            String principal)
+            throws GitAPIException, IOException {
         String cacheKey = getCacheKey(remoteUrl);
+        String principalKey = hashPrincipal(principal);
 
         CachedRepository cached = cache.get(cacheKey);
         if (cached != null && cached.isValid()) {
             log.debug("Using cached repository for: {}", remoteUrl);
-            refreshIfStale(cached, cacheKey, credentials, transportConfig);
+            refreshIfStale(cached, cacheKey, credentials, transportConfig, principalKey);
             cached.repository.incrementOpen();
             return cached.repository;
         }
 
         log.info("Cloning repository from: {}", remoteUrl);
-        return cloneOrFetch(remoteUrl, cacheKey, credentials, transportConfig);
+        return cloneOrFetch(remoteUrl, cacheKey, credentials, transportConfig, principalKey);
+    }
+
+    /**
+     * Hashes a caller-supplied principal so raw credentials never live in the cache's keys or heap dumps. Mirrors the
+     * SCM token cache, which likewise stores only a digest. A blank or absent principal collapses to a single shared
+     * anonymous identity — safe because an anonymous caller can only ever benefit from a previous *anonymous* fetch,
+     * which by definition succeeded without credentials and so implies the repository is publicly readable.
+     */
+    private static String hashPrincipal(String principal) {
+        if (principal == null || principal.isBlank()) {
+            return ANONYMOUS_PRINCIPAL;
+        }
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(principal.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable — cannot key the mirror cache by principal", e);
+        }
     }
 
     /**
@@ -155,18 +208,23 @@ public class LocalRepositoryCache {
             CachedRepository cached,
             String cacheKey,
             CredentialsProvider credentials,
-            TransportConfigCallback transportConfig)
+            TransportConfigCallback transportConfig,
+            String principalKey)
             throws GitAPIException, IOException {
         cached.fetchLock.lock();
         try {
-            if (System.currentTimeMillis() - cached.lastFetchedAt <= fetchCooldownMs) {
+            cached.purgeExpiredPrincipals(fetchCooldownMs);
+            Long lastFetched = cached.lastFetchedByPrincipal.get(principalKey);
+            if (lastFetched != null && System.currentTimeMillis() - lastFetched <= fetchCooldownMs) {
                 log.debug(
-                        "Skipping re-fetch for {} — mirror refreshed {}ms ago",
+                        "Skipping re-fetch for {} — this principal refreshed the mirror {}ms ago",
                         cacheKey,
-                        System.currentTimeMillis() - cached.lastFetchedAt);
+                        System.currentTimeMillis() - lastFetched);
                 return;
             }
-            log.debug("Re-fetching upstream for cached repository: {}", cacheKey);
+            log.debug(
+                    "Re-fetching upstream for cached repository: {} — principal not verified within cooldown",
+                    cacheKey);
             try (Git git = Git.open(new File(cacheDirectory.toFile(), cacheKey))) {
                 var fetch = git.fetch()
                         .setRemote("origin")
@@ -175,7 +233,10 @@ public class LocalRepositoryCache {
                 if (transportConfig != null) fetch.setTransportConfigCallback(transportConfig);
                 fetch.call();
             }
-            cached.lastFetchedAt = System.currentTimeMillis();
+            // Recorded only after the fetch succeeds: reaching upstream with these credentials IS the
+            // authorization proof. A failed fetch throws, so an unauthorized principal is never recorded
+            // and never gets to skip the check on a subsequent request.
+            cached.lastFetchedByPrincipal.put(principalKey, System.currentTimeMillis());
         } finally {
             cached.fetchLock.unlock();
         }
@@ -186,7 +247,11 @@ public class LocalRepositoryCache {
      * multiple threads race on first access for the same URL.
      */
     private synchronized Repository cloneOrFetch(
-            String remoteUrl, String cacheKey, CredentialsProvider credentials, TransportConfigCallback transportConfig)
+            String remoteUrl,
+            String cacheKey,
+            CredentialsProvider credentials,
+            TransportConfigCallback transportConfig,
+            String principalKey)
             throws GitAPIException, IOException {
         // Double-check after acquiring lock — another thread may have cloned while we waited
         CachedRepository cached = cache.get(cacheKey);
@@ -222,7 +287,8 @@ public class LocalRepositoryCache {
         }
 
         var newCached = new CachedRepository(repository, remoteUrl);
-        newCached.lastFetchedAt = System.currentTimeMillis();
+        // The clone/fetch above succeeded with this principal's credentials, so record them as verified.
+        newCached.lastFetchedByPrincipal.put(principalKey, System.currentTimeMillis());
         cache.put(cacheKey, newCached);
         return repository;
     }
@@ -335,16 +401,27 @@ public class LocalRepositoryCache {
         final ReentrantLock fetchLock = new ReentrantLock();
 
         /**
-         * Timestamp of the last successful upstream fetch. Compared against {@code fetchCooldownMs} to avoid redundant
-         * re-fetches when multiple concurrent requests arrive for the same mirror. Volatile so that the write from the
-         * thread holding {@code fetchLock} is visible to all other threads after the lock is released.
+         * Timestamp of the last successful upstream fetch, <b>per principal</b>. Compared against
+         * {@code fetchCooldownMs} to avoid redundant re-fetches when the same caller makes several requests in quick
+         * succession.
+         *
+         * <p>Keyed by principal rather than globally because a successful upstream fetch doubles as this path's only
+         * proof that the caller may access the repository. A single shared timestamp would let any caller skip that
+         * proof for {@code fetchCooldownMs} after someone else established it. Entries are purged once older than the
+         * cooldown, so the map is bounded by the number of distinct principals active within one cooldown window.
          */
-        volatile long lastFetchedAt = 0;
+        final Map<String, Long> lastFetchedByPrincipal = new ConcurrentHashMap<>();
 
         CachedRepository(Repository repository, String remoteUrl) {
             this.repository = repository;
             this.remoteUrl = remoteUrl;
             this.cachedAt = System.currentTimeMillis();
+        }
+
+        /** Drops principals whose verification has aged past the cooldown; they must re-prove access on next use. */
+        void purgeExpiredPrincipals(long cooldownMs) {
+            long now = System.currentTimeMillis();
+            lastFetchedByPrincipal.entrySet().removeIf(e -> now - e.getValue() > cooldownMs);
         }
 
         boolean isValid() {

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/StoreAndForwardRepositoryResolver.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/StoreAndForwardRepositoryResolver.java
@@ -55,8 +55,13 @@ public class StoreAndForwardRepositoryResolver implements RepositoryResolver<Htt
         // Credentials are held in memory only and never written to disk.
         String[] userPass = extractCredentials(req);
         CredentialsProvider creds = null;
+        // Identity for the mirror cache's per-principal fetch cooldown. Built from the full credential, not
+        // the username: providers such as GitHub ignore the HTTP Basic username entirely, so the token is the
+        // only part that actually identifies the caller. Hashed inside the cache; never retained raw.
+        String principal = null;
         if (userPass != null) {
             creds = new UsernamePasswordCredentialsProvider(userPass[0], userPass[1]);
+            principal = userPass[0] + ":" + userPass[1];
             req.setAttribute(CREDENTIALS_ATTRIBUTE, creds);
             req.setAttribute("com.rbc.fogwall.pushUser", userPass[0]);
         }
@@ -64,7 +69,7 @@ public class StoreAndForwardRepositoryResolver implements RepositoryResolver<Htt
         log.info("Opening store-and-forward repository: {} -> {}", name, cleanUpstreamUrl);
 
         try {
-            Repository repo = cache.getOrClone(cleanUpstreamUrl, creds);
+            Repository repo = cache.getOrClone(cleanUpstreamUrl, creds, null, principal);
 
             // Store the upstream URL so PostReceiveHook can find it
             repo.getConfig().setString("fogwall", null, "upstreamUrl", cleanUpstreamUrl);

--- a/fogwall-core/src/test/java/com/rbc/fogwall/git/LocalRepositoryCacheTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/git/LocalRepositoryCacheTest.java
@@ -7,6 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
 import org.junit.jupiter.api.BeforeEach;
@@ -100,6 +101,105 @@ class LocalRepositoryCacheTest {
 
         assertNull(cache.getCached(remoteUrl), "Entry should be gone from cache");
         assertFalse(cloneDir.exists(), "Clone directory should be deleted from disk");
+    }
+
+    /**
+     * The fetch cooldown must not let one principal's upstream verification carry over to another. A successful
+     * upstream fetch is this path's only proof that the caller may access the repository, so an unrecognised principal
+     * has to trigger a real fetch with its own credentials rather than being served the warm mirror.
+     *
+     * <p>Observed indirectly: a commit added upstream after the first call only reaches the mirror if a fetch actually
+     * happened.
+     */
+    @Test
+    void cooldown_isNotSharedBetweenPrincipals() throws Exception {
+        // Long cooldown so any re-fetch is attributable to the principal changing, not to elapsed time.
+        LocalRepositoryCache cache = new LocalRepositoryCache(cacheTempDir, 0, false, 60_000);
+
+        Repository first = cache.getOrClone(remoteUrl, null, null, "alice:token-a");
+        first.close();
+
+        String newSha = addUpstreamCommit("second commit");
+
+        Repository sameAgain = cache.getOrClone(remoteUrl, null, null, "alice:token-a");
+        assertFalse(
+                hasObject(sameAgain, newSha),
+                "Same principal inside the cooldown should reuse the mirror without re-fetching");
+        sameAgain.close();
+
+        Repository other = cache.getOrClone(remoteUrl, null, null, "bob:token-b");
+        assertTrue(
+                hasObject(other, newSha),
+                "A different principal must force a real upstream fetch — that fetch is the authorization check");
+        other.close();
+    }
+
+    /** All callers without a principal share one anonymous identity, so they do share a cooldown with each other. */
+    @Test
+    void cooldown_isSharedAmongAnonymousCallers() throws Exception {
+        LocalRepositoryCache cache = new LocalRepositoryCache(cacheTempDir, 0, false, 60_000);
+
+        Repository first = cache.getOrClone(remoteUrl);
+        first.close();
+
+        String newSha = addUpstreamCommit("second commit");
+
+        Repository second = cache.getOrClone(remoteUrl);
+        assertFalse(hasObject(second, newSha), "Anonymous callers share one identity and therefore one cooldown");
+        second.close();
+    }
+
+    /** An anonymous warm-up must not satisfy the cooldown for an identified principal, or vice versa. */
+    @Test
+    void anonymousWarmUp_doesNotSatisfyIdentifiedPrincipal() throws Exception {
+        LocalRepositoryCache cache = new LocalRepositoryCache(cacheTempDir, 0, false, 60_000);
+
+        Repository anon = cache.getOrClone(remoteUrl);
+        anon.close();
+
+        String newSha = addUpstreamCommit("second commit");
+
+        Repository identified = cache.getOrClone(remoteUrl, null, null, "alice:token-a");
+        assertTrue(hasObject(identified, newSha), "An identified principal must not inherit an anonymous verification");
+        identified.close();
+    }
+
+    /** Once the cooldown lapses, even the same principal must re-verify against upstream. */
+    @Test
+    void cooldown_expiresForSamePrincipal() throws Exception {
+        LocalRepositoryCache cache = new LocalRepositoryCache(cacheTempDir, 0, false, 0);
+
+        Repository first = cache.getOrClone(remoteUrl, null, null, "alice:token-a");
+        first.close();
+
+        String newSha = addUpstreamCommit("second commit");
+
+        Repository again = cache.getOrClone(remoteUrl, null, null, "alice:token-a");
+        assertTrue(hasObject(again, newSha), "With the cooldown elapsed the same principal must re-fetch");
+        again.close();
+    }
+
+    /**
+     * True when the object is physically present in the mirror. {@code Repository.resolve} is unsuitable here: given a
+     * full 40-character SHA it simply parses it and returns an ObjectId without consulting the object database, so it
+     * answers "is this a well-formed id", not "was this fetched".
+     */
+    private static boolean hasObject(Repository repo, String sha) throws Exception {
+        return repo.getObjectDatabase().has(ObjectId.fromString(sha));
+    }
+
+    /** Adds a commit to the upstream test repo and returns its SHA. */
+    private String addUpstreamCommit(String message) throws Exception {
+        File f = new File(remoteTempDir.toFile(), message.replace(' ', '-') + ".txt");
+        Files.writeString(f.toPath(), message);
+        remoteGit.add().addFilepattern(".").call();
+        return remoteGit
+                .commit()
+                .setAuthor(new PersonIdent("Dev", "dev@example.com"))
+                .setCommitter(new PersonIdent("Dev", "dev@example.com"))
+                .setMessage(message)
+                .call()
+                .getName();
     }
 
     @Test

--- a/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitReceiveCommand.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitReceiveCommand.java
@@ -186,7 +186,10 @@ public class SshGitReceiveCommand implements Command {
                     SshUpstreamTransport.forwardedAgent(agent, knownHostsFile, trustOnFirstUse);
             var pushTransport = new PushTransport.Ssh(resolvedUser, connectingFingerprint, transportConfig, liveness);
 
-            Repository localRepo = cache.getOrClone(upstreamUrl, null, transportConfig);
+            // The connecting key fingerprint is this session's authenticated identity, and so is the principal
+            // for the mirror cache's per-principal fetch cooldown — the forwarded agent is what authorizes
+            // upstream, and a different key must not inherit another key's verification.
+            Repository localRepo = cache.getOrClone(upstreamUrl, null, transportConfig, connectingFingerprint);
             localRepo.getConfig().setString("fogwall", null, "upstreamUrl", upstreamUrl);
             localRepo.getConfig().save();
 

--- a/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitUploadCommand.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitUploadCommand.java
@@ -16,6 +16,7 @@ import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
 import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
+import org.apache.sshd.server.session.ServerSession;
 import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.UploadPack;
@@ -91,15 +92,21 @@ public class SshGitUploadCommand implements Command {
     @Override
     public void start(ChannelSession channel, Environment env) {
         String sshUser = channel.getSession().getUsername();
+        // Resolved during public-key auth. This is the session's authenticated identity, and so the principal
+        // for the mirror cache's per-principal fetch cooldown.
+        String connectingFingerprint = (channel.getSession() instanceof ServerSession serverSession)
+                ? SshGitServer.getConnectingFingerprint(serverSession).orElse(null)
+                : null;
         // SSH_AUTH_SOCK is set on the channel env by MINA SSHD when the client's ssh -A forwarding
         // channel is established. Capture it here before handing off to the worker thread.
         String authSocket = env.getEnv().get(SshAgent.SSH_AUTHSOCKET_ENV_NAME);
-        Thread worker = new Thread(() -> runUploadPack(sshUser, authSocket), "ssh-git-upload-" + repoPath);
+        Thread worker = new Thread(
+                () -> runUploadPack(sshUser, connectingFingerprint, authSocket), "ssh-git-upload-" + repoPath);
         worker.setDaemon(true);
         worker.start();
     }
 
-    private void runUploadPack(String sshUser, String authSocket) {
+    private void runUploadPack(String sshUser, String connectingFingerprint, String authSocket) {
         int exitCode = 0;
         SshAgent agent = null;
         try {
@@ -146,7 +153,7 @@ public class SshGitUploadCommand implements Command {
 
             TransportConfigCallback transportConfig =
                     SshUpstreamTransport.forwardedAgent(agent, knownHostsFile, trustOnFirstUse);
-            Repository localRepo = cache.getOrClone(upstreamUrl, null, transportConfig);
+            Repository localRepo = cache.getOrClone(upstreamUrl, null, transportConfig, connectingFingerprint);
             localRepo.getConfig().setString("fogwall", null, "upstreamUrl", upstreamUrl);
             localRepo.getConfig().save();
 


### PR DESCRIPTION
## What

`LocalRepositoryCache`'s fetch cooldown is now keyed by `(repository, principal)`
instead of by repository alone, and a principal is recorded only once a fetch has
actually succeeded.

## Why

The cooldown skipped the upstream fetch whenever the mirror had been refreshed
within `fetchCooldownMs` (default 5s). That fetch is also the only thing on this
path that establishes whether the caller may access the repository:

- `BasicAuthChallengeFilter` deliberately does not challenge upload-pack, so public
  repos stay reachable without credentials.
- `CheckUserPushPermissionFilter` is constructed with `Set.of(HttpOperation.PUSH)` —
  there is no fogwall-side authorization on `FETCH` in either mode.
- `StoreAndForwardUploadPackFactory` returns a bare `UploadPack` with no checks.

So read authorization was delegated entirely to that upstream fetch — and the
cooldown made it conditional. Keyed on the repository alone, one principal's
authorization became transferable to any other principal arriving inside the
window: their credentials were passed to a fetch that never ran, and the mirror was
handed back regardless.

For a private repository that meant a caller with no access could be served content,
via upload-pack (full history — the S&F mirror is a depth-0 full clone) or via
receive-pack's unfiltered ref advertisement (branch names and tip SHAs), the latter
arriving before `CheckUserPushPermissionHook` runs at all. Any legitimate push or
fetch re-armed `lastFetchedAt`, so on an active repository the window recurred
continuously and an attacker only had to keep asking.

## How

- Cooldown timestamps are held per principal and purged once older than the cooldown,
  bounding the map by principals active in a single window.
- Recorded **only after** a successful fetch — reaching upstream is what marks a
  principal verified, and a failed fetch throws, so an unauthorized principal is
  never recorded and never skips the check next time.
- Principals: HTTP Basic `user:token` (the username alone is meaningless — GitHub and
  others ignore it, the token is the identity) or the SSH connecting key fingerprint.
  Hashed with SHA-256 before use so raw credentials never reach cache keys.
- Callers with no identity share one anonymous entry. Safe by construction: an
  anonymous hit can only reuse a previous *anonymous* fetch, which succeeded without
  credentials and therefore implies the repository is publicly readable.

`SshGitUploadCommand` now resolves the connecting fingerprint the same way
`SshGitReceiveCommand` already did, so SSH fetch gets the same treatment.

## Scope — what this does NOT do

Deliberately minimal. Still outstanding, tracked separately:

- No read authorization is added; it remains delegated to upstream. What changes is
  that the delegation now actually happens for every distinct principal.
- Receive-pack still advertises refs before fogwall's own permission hook runs. That
  needs a capability check ahead of the resolver — a servlet filter, since a
  pre-receive hook is structurally too late.
- The cache key still ignores the provider host, so same-named repos on different
  providers still collide.

## Testing

Four new cases in `LocalRepositoryCacheTest`, observing whether a fetch actually
occurred by adding a commit upstream and checking object presence in the mirror:

- a second principal inside the cooldown forces a real fetch
- the same principal inside the cooldown does not
- an anonymous warm-up does not satisfy an identified principal
- an elapsed cooldown re-fetches for the same principal

`:fogwall-core:test` 1117/1118 and `:fogwall-server:test` green; the one failure is a
pre-existing local Testcontainers/podman flake that passes in isolation and in CI.
`jacocoTestCoverageVerification` green on both modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)