### PR TITLE
fix(proxy): make transparent proxy work against private repos, and stop three false rejections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,24 @@ subprojects {
             finalizedBy jacocoTestReport
         }
 
+        // Print the full failure — message, cause chain and stack trace — to the console.
+        // Gradle's default prints only the exception type and line, so the assertion message is
+        // lost and the reason has to be recovered by parsing the XML or HTML report (or, in CI,
+        // downloading the report artifact). Applied via withType(Test) so it covers e2eTest as
+        // well as test, since e2e failures are the ones most often diagnosed from CI logs alone.
+        //
+        // showStandardStreams stays off deliberately: e2e tests emit hundreds of lines of
+        // application logging per test, which would bury the failure this is meant to surface.
+        tasks.withType(Test).configureEach {
+            testLogging {
+                events 'failed', 'skipped'
+                exceptionFormat 'full'
+                showCauses true
+                showExceptions true
+                showStackTraces true
+            }
+        }
+
         // Best-effort extraction of embedded META-INF/LICENSE, META-INF/NOTICE, and root
         // LICENSE/NOTICE file contents from this module's runtime dependency jars, keyed by
         // module coordinates. Maven POM metadata only gives a license *name* + a generic URL —

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/CommitInspectionService.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/CommitInspectionService.java
@@ -9,10 +9,12 @@ import java.util.Collections;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.LogCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.diff.RenameDetector;
+import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.PersonIdent;
@@ -78,16 +80,11 @@ public class CommitInspectionService {
             if (fromId != null && !isNullCommit(fromCommit)) {
                 revCommits = git.log().addRange(fromId, toId).call();
             } else {
-                // New branch - exclude commits reachable from any existing ref so we only
+                // New branch or new tag - exclude commits reachable from any existing ref so we only
                 // validate commits that are genuinely new in this push.  The local cache is a
                 // bare clone, so existing branch tips live under refs/heads/ (not refs/remotes/).
                 var logCmd = git.log().add(toId);
-                Collection<Ref> existingRefs = repository.getRefDatabase().getRefsByPrefix("refs/heads/");
-                for (Ref ref : existingRefs) {
-                    if (ref.getObjectId() != null) {
-                        logCmd.not(ref.getObjectId());
-                    }
-                }
+                excludeExistingRefs(repository, logCmd);
                 revCommits = logCmd.call();
             }
 
@@ -97,6 +94,27 @@ public class CommitInspectionService {
         }
 
         return commits;
+    }
+
+    /**
+     * Marks every commit already reachable from an existing ref as uninteresting, so the walk returns only what this
+     * push genuinely introduces.
+     *
+     * <p>Covers {@code refs/tags/*} as well as {@code refs/heads/*}. A commit reachable only from an existing tag is
+     * just as much "already upstream" as one on a branch — nothing new arrives by referencing it again — but excluding
+     * only branches made such a commit look new, so re-tagging it was reported as smuggled history. Annotated tags are
+     * peeled to their target commit; a tag pointing at a blob or tree has no commit to exclude and is skipped.
+     */
+    private static void excludeExistingRefs(Repository repository, LogCommand logCmd) throws IOException {
+        for (String prefix : new String[] {Constants.R_HEADS, Constants.R_TAGS}) {
+            for (Ref ref : repository.getRefDatabase().getRefsByPrefix(prefix)) {
+                if (ref.getObjectId() == null) continue;
+                ObjectId commitId = repository.resolve(ref.getName() + "^{commit}");
+                if (commitId != null) {
+                    logCmd.not(commitId);
+                }
+            }
+        }
     }
 
     /**

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/LocalRepositoryCache.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/LocalRepositoryCache.java
@@ -164,6 +164,59 @@ public class LocalRepositoryCache {
     }
 
     /**
+     * Fetches from upstream immediately, ignoring the cooldown, and deepens a shallow mirror to full history.
+     *
+     * <p>For callers that are about to make a decision a stale or truncated mirror would get <b>wrong</b>, rather than
+     * merely slightly out of date. The cooldown optimises for content freshness and the clone depth for clone cost;
+     * both are reasonable defaults that a reachability check cannot rely on, because "this commit is not reachable from
+     * any branch" is indistinguishable from "this mirror has not fetched recently" or "this mirror stops 100 commits
+     * back". Use this to remove those two explanations before concluding the third.
+     *
+     * <p>Unshallowing is not undone afterwards: the repository stays full for the rest of the process. That is
+     * deliberate — it makes the expense bounded per repository rather than repeatable on demand, so a caller cannot be
+     * induced into paying it over and over.
+     *
+     * <p>No-op when the repository is not cached yet; the next {@code getOrClone} will clone it fresh anyway.
+     *
+     * @return true if a fetch was performed
+     */
+    public boolean refreshNow(
+            String remoteUrl,
+            CredentialsProvider credentials,
+            TransportConfigCallback transportConfig,
+            String principal)
+            throws GitAPIException, IOException {
+        String cacheKey = getCacheKey(remoteUrl);
+        CachedRepository cached = cache.get(cacheKey);
+        if (cached == null || !cached.isValid()) {
+            return false;
+        }
+        cached.fetchLock.lock();
+        try {
+            log.info("Forcing upstream refresh for {} (cooldown bypassed, deepening to full history)", cacheKey);
+            try (Git git = Git.open(new File(cacheDirectory.toFile(), cacheKey))) {
+                var fetch = git.fetch()
+                        .setRemote("origin")
+                        .setRemoveDeletedRefs(true)
+                        .setCredentialsProvider(credentials);
+                if (transportConfig != null) fetch.setTransportConfigCallback(transportConfig);
+                if (cloneDepth > 0 && !cached.unshallowed) {
+                    // Only meaningful on a mirror that was cloned shallow; harmless but pointless otherwise.
+                    fetch.setUnshallow(true);
+                }
+                fetch.call();
+            }
+            cached.unshallowed = true;
+            // The fetch reached upstream with these credentials, so this principal is verified — same
+            // contract as refreshIfStale.
+            cached.lastFetchedByPrincipal.put(hashPrincipal(principal), System.currentTimeMillis());
+            return true;
+        } finally {
+            cached.fetchLock.unlock();
+        }
+    }
+
+    /**
      * Hashes a caller-supplied principal so raw credentials never live in the cache's keys or heap dumps. Mirrors the
      * SCM token cache, which likewise stores only a digest. A blank or absent principal collapses to a single shared
      * anonymous identity — safe because an anonymous caller can only ever benefit from a previous *anonymous* fetch,
@@ -396,6 +449,12 @@ public class LocalRepositoryCache {
          * cooldown, so the map is bounded by the number of distinct principals active within one cooldown window.
          */
         final Map<String, Long> lastFetchedByPrincipal = new ConcurrentHashMap<>();
+
+        /**
+         * Set once {@link #refreshNow} has deepened this mirror to full history, so the expense is paid at most once
+         * per repository per process rather than on every request that takes the deepening path.
+         */
+        volatile boolean unshallowed = false;
 
         CachedRepository(Repository repository, String remoteUrl) {
             this.repository = repository;

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/CheckEmptyBranchFilter.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/CheckEmptyBranchFilter.java
@@ -57,6 +57,13 @@ public class CheckEmptyBranchFilter extends AbstractFogwallFilter {
             return;
         }
 
+        // An earlier filter (e.g. EnrichPushCommitsFilter) already failed and set a specific
+        // reason for why pushedCommits is empty — don't clobber it with a generic message here.
+        if (requestDetails.getResult() == GitRequestDetails.GitResult.ERROR) {
+            log.debug("Push already in ERROR state — skipping empty branch check");
+            return;
+        }
+
         var commits = requestDetails.getPushedCommits();
         if (commits != null && !commits.isEmpty()) {
             return;

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/EnrichPushCommitsFilter.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/EnrichPushCommitsFilter.java
@@ -1,5 +1,9 @@
 package com.rbc.fogwall.servlet.filter;
 
+import static com.rbc.fogwall.git.GitClientUtils.AnsiColor.RED;
+import static com.rbc.fogwall.git.GitClientUtils.SymbolCodes.NO_ENTRY;
+import static com.rbc.fogwall.git.GitClientUtils.format;
+import static com.rbc.fogwall.git.GitClientUtils.sym;
 import static com.rbc.fogwall.servlet.FogwallServlet.GIT_REQUEST_ATTR;
 
 import com.rbc.fogwall.git.Commit;
@@ -13,6 +17,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Base64;
 import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -20,8 +25,10 @@ import org.eclipse.jgit.lib.NullProgressMonitor;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectInserter;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.PackParser;
 import org.eclipse.jgit.transport.PacketLineIn;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 
 /**
  * Filter that enriches push requests with full commit information. Replicates fogwall's {@code writePack} approach:
@@ -76,8 +83,11 @@ public class EnrichPushCommitsFilter extends ProviderAwareFogwallFilter<FogwallP
             log.info("Enriching push commits from repository: {}", remoteUrl);
 
             // Step 1: Get or clone the upstream repo, then publish it on the request so downstream
-            // filters can use it without needing their own LocalRepositoryCache reference.
-            Repository repository = repositoryCache.getOrClone(remoteUrl);
+            // filters can use it without needing their own LocalRepositoryCache reference. The
+            // pushing client's own credentials are reused for the upstream clone/fetch so that
+            // private repos can be inspected — without them this silently degrades to an
+            // anonymous clone/fetch, which fails for any private repo.
+            Repository repository = repositoryCache.getOrClone(remoteUrl, extractCredentials(request));
             requestDetails.setLocalRepository(repository);
 
             // Step 2: Unpack the inflight push's pack data into the local clone.
@@ -100,16 +110,22 @@ public class EnrichPushCommitsFilter extends ProviderAwareFogwallFilter<FogwallP
                             requestDetails.getBranch(),
                             toCommit,
                             e.getMessage());
-                    requestDetails.setResult(GitRequestDetails.GitResult.ERROR);
-                    requestDetails.setReason("Push rejected: tag object could not be resolved."
-                            + " Ensure the tag object is included in the push.");
+                    errorAndSendError(
+                            requestDetails,
+                            request,
+                            response,
+                            "Push rejected: tag object could not be resolved. Ensure the tag object is included in"
+                                    + " the push.");
                     return;
                 }
                 if (peeled == null) {
                     log.warn("Tag push ({}) — {} did not resolve to a commit", requestDetails.getBranch(), toCommit);
-                    requestDetails.setResult(GitRequestDetails.GitResult.ERROR);
-                    requestDetails.setReason("Push rejected: tag object could not be resolved."
-                            + " Ensure the tag object is included in the push.");
+                    errorAndSendError(
+                            requestDetails,
+                            request,
+                            response,
+                            "Push rejected: tag object could not be resolved. Ensure the tag object is included in"
+                                    + " the push.");
                     return;
                 }
                 String peeledSha = peeled.getName();
@@ -120,9 +136,12 @@ public class EnrichPushCommitsFilter extends ProviderAwareFogwallFilter<FogwallP
                             "Tag push {} introduces {} unvalidated commit(s) — rejecting",
                             requestDetails.getBranch(),
                             commits.size());
-                    requestDetails.setResult(GitRequestDetails.GitResult.ERROR);
-                    requestDetails.setReason("Push rejected: the tag references commits that were not validated through"
-                            + " a branch push. Push the branch first, then re-create the tag.");
+                    errorAndSendError(
+                            requestDetails,
+                            request,
+                            response,
+                            "Push rejected: the tag references commits that were not validated through a branch"
+                                    + " push. Push the branch first, then re-create the tag.");
                 }
                 return;
             }
@@ -133,9 +152,12 @@ public class EnrichPushCommitsFilter extends ProviderAwareFogwallFilter<FogwallP
 
             if (commits.isEmpty()) {
                 log.warn("No commits found in range {}..{} — erroring push", fromCommit, toCommit);
-                requestDetails.setResult(GitRequestDetails.GitResult.ERROR);
-                requestDetails.setReason("Push error: the proxy could not inspect any commits in this push. "
-                        + "Please retry or contact your administrator.");
+                errorAndSendError(
+                        requestDetails,
+                        request,
+                        response,
+                        "Push error: the proxy could not inspect any commits in this push. Please retry or contact"
+                                + " your administrator.");
                 return;
             }
 
@@ -144,10 +166,28 @@ public class EnrichPushCommitsFilter extends ProviderAwareFogwallFilter<FogwallP
 
         } catch (Exception e) {
             log.error("Failed to enrich push commits", e);
-            requestDetails.setResult(GitRequestDetails.GitResult.ERROR);
-            requestDetails.setReason("Push error: commit inspection failed (" + e.getMessage() + "). "
-                    + "Please retry or contact your administrator.");
+            errorAndSendError(
+                    requestDetails,
+                    request,
+                    response,
+                    "Push error: commit inspection failed (" + e.getMessage() + "). Please retry or contact your"
+                            + " administrator.");
         }
+    }
+
+    /**
+     * Mark the push as {@link GitRequestDetails.GitResult#ERROR} and commit an error response to the client. Without
+     * sending the response here, downstream filters that only short-circuit on {@code REJECTED} would let the push fall
+     * through the rest of the chain uncommitted — and {@link PushFinalizerFilter} would then forward it upstream, since
+     * it only skips forwarding when the response is already committed.
+     */
+    private void errorAndSendError(
+            GitRequestDetails requestDetails, HttpServletRequest request, HttpServletResponse response, String reason)
+            throws IOException {
+        requestDetails.setResult(GitRequestDetails.GitResult.ERROR);
+        requestDetails.setReason(reason);
+        String title = sym(NO_ENTRY) + "  Push Blocked - Commit Inspection Failed";
+        sendGitError(request, response, format(title, reason, RED, null));
     }
 
     /**
@@ -230,6 +270,21 @@ public class EnrichPushCommitsFilter extends ProviderAwareFogwallFilter<FogwallP
             return pos;
         }
         return -1;
+    }
+
+    /** Extract the pushing client's Basic Auth credentials, for reuse against the upstream provider. */
+    private static CredentialsProvider extractCredentials(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Basic ")) return null;
+        try {
+            String decoded = new String(Base64.getDecoder()
+                    .decode(authHeader.substring("Basic ".length()).trim()));
+            int colon = decoded.indexOf(':');
+            if (colon < 0) return null;
+            return new UsernamePasswordCredentialsProvider(decoded.substring(0, colon), decoded.substring(colon + 1));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     private String constructRemoteUrl(GitRequestDetails requestDetails) {

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/EnrichPushCommitsFilter.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/EnrichPushCommitsFilter.java
@@ -17,6 +17,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Set;
@@ -87,7 +88,18 @@ public class EnrichPushCommitsFilter extends ProviderAwareFogwallFilter<FogwallP
             // pushing client's own credentials are reused for the upstream clone/fetch so that
             // private repos can be inspected — without them this silently degrades to an
             // anonymous clone/fetch, which fails for any private repo.
-            Repository repository = repositoryCache.getOrClone(remoteUrl, extractCredentials(request));
+            //
+            // The principal must be supplied alongside the credentials: the cache's fetch cooldown is
+            // keyed by (repository, principal), and passing credentials without an identity would leave
+            // every proxy caller sharing the anonymous entry — making one user's successful fetch
+            // satisfy the next user's request, which is the transferability the cooldown keying exists
+            // to prevent. Built from the full credential, not the username, because providers such as
+            // GitHub ignore the HTTP Basic username entirely.
+            String[] userPass = extractBasicAuth(request);
+            CredentialsProvider credentials =
+                    userPass == null ? null : new UsernamePasswordCredentialsProvider(userPass[0], userPass[1]);
+            String principal = userPass == null ? null : userPass[0] + ":" + userPass[1];
+            Repository repository = repositoryCache.getOrClone(remoteUrl, credentials, null, principal);
             requestDetails.setLocalRepository(repository);
 
             // Step 2: Unpack the inflight push's pack data into the local clone.
@@ -176,10 +188,14 @@ public class EnrichPushCommitsFilter extends ProviderAwareFogwallFilter<FogwallP
     }
 
     /**
-     * Mark the push as {@link GitRequestDetails.GitResult#ERROR} and commit an error response to the client. Without
-     * sending the response here, downstream filters that only short-circuit on {@code REJECTED} would let the push fall
-     * through the rest of the chain uncommitted — and {@link PushFinalizerFilter} would then forward it upstream, since
-     * it only skips forwarding when the response is already committed.
+     * Mark the push as {@link GitRequestDetails.GitResult#ERROR} and commit an error response to the client.
+     *
+     * <p>Forwarding is not the risk here: {@link PushFinalizerFilter} returns early on {@code ERROR} without changing
+     * the result, and {@code FogwallServlet.service()} proxies only when the result is {@code ALLOWED}, so an errored
+     * push is never sent upstream whether or not a response was written. The reason for committing a response is that
+     * nothing else will — the remaining filters skip an errored push, the finalizer returns without writing, and the
+     * proxy servlet declines to run — leaving the client with an empty reply and no explanation of why the push failed.
+     * Writing it here is what turns a silent failure into a diagnosable one.
      */
     private void errorAndSendError(
             GitRequestDetails requestDetails, HttpServletRequest request, HttpServletResponse response, String reason)
@@ -272,16 +288,25 @@ public class EnrichPushCommitsFilter extends ProviderAwareFogwallFilter<FogwallP
         return -1;
     }
 
-    /** Extract the pushing client's Basic Auth credentials, for reuse against the upstream provider. */
-    private static CredentialsProvider extractCredentials(HttpServletRequest request) {
+    /**
+     * Extract the pushing client's HTTP Basic credentials as {@code [username, secret]}, or {@code null} when the
+     * request carries none. Returns the parts rather than a {@link CredentialsProvider} so the caller can derive both
+     * the provider and the cache principal from a single parse of the header.
+     *
+     * <p>Decoded as UTF-8 explicitly: the platform default charset would make the outcome of authentication depend on
+     * the JVM's locale for any non-ASCII byte in the secret.
+     */
+    private static String[] extractBasicAuth(HttpServletRequest request) {
         String authHeader = request.getHeader("Authorization");
         if (authHeader == null || !authHeader.startsWith("Basic ")) return null;
         try {
-            String decoded = new String(Base64.getDecoder()
-                    .decode(authHeader.substring("Basic ".length()).trim()));
+            String decoded = new String(
+                    Base64.getDecoder()
+                            .decode(authHeader.substring("Basic ".length()).trim()),
+                    StandardCharsets.UTF_8);
             int colon = decoded.indexOf(':');
             if (colon < 0) return null;
-            return new UsernamePasswordCredentialsProvider(decoded.substring(0, colon), decoded.substring(colon + 1));
+            return new String[] {decoded.substring(0, colon), decoded.substring(colon + 1)};
         } catch (IllegalArgumentException e) {
             return null;
         }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/EnrichPushCommitsFilter.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/EnrichPushCommitsFilter.java
@@ -144,6 +144,22 @@ public class EnrichPushCommitsFilter extends ProviderAwareFogwallFilter<FogwallP
                 log.info("Tag push ({}) — peeled {} to commit {}", requestDetails.getBranch(), toCommit, peeledSha);
                 List<Commit> commits = CommitInspectionService.getCommitRange(repository, fromCommit, peeledSha);
                 if (!commits.isEmpty()) {
+                    // A non-empty range has three possible explanations, and only one of them is smuggling:
+                    //   1. the commits really did arrive via this tag, bypassing branch validation;
+                    //   2. the mirror has not re-fetched since they were forwarded upstream (fetch cooldown);
+                    //   3. the mirror is a shallow clone and they sit beyond its boundary.
+                    // The walk excludes commits reachable from refs/heads/* *in the mirror*, so (2) and (3) look
+                    // exactly like (1). Tagging a commit that has been upstream for months is an ordinary release
+                    // action and must not be reported as smuggling, so eliminate (2) and (3) — refresh and deepen —
+                    // before concluding (1). This costs a fetch only on the path that was about to reject.
+                    log.info(
+                            "Tag push ({}) — {} commit(s) look unvalidated; refreshing mirror before deciding",
+                            requestDetails.getBranch(),
+                            commits.size());
+                    repositoryCache.refreshNow(remoteUrl, credentials, null, principal);
+                    commits = CommitInspectionService.getCommitRange(repository, fromCommit, peeledSha);
+                }
+                if (!commits.isEmpty()) {
                     log.warn(
                             "Tag push {} introduces {} unvalidated commit(s) — rejecting",
                             requestDetails.getBranch(),

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/EnrichPushCommitsFilter.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/EnrichPushCommitsFilter.java
@@ -163,13 +163,15 @@ public class EnrichPushCommitsFilter extends ProviderAwareFogwallFilter<FogwallP
             List<Commit> commits = CommitInspectionService.getCommitRange(repository, fromCommit, toCommit);
 
             if (commits.isEmpty()) {
-                log.warn("No commits found in range {}..{} — erroring push", fromCommit, toCommit);
-                errorAndSendError(
-                        requestDetails,
-                        request,
-                        response,
-                        "Push error: the proxy could not inspect any commits in this push. Please retry or contact"
-                                + " your administrator.");
+                // Not an inspection failure: the walk succeeded and the range is genuinely empty, which is
+                // what a branch pushed with no new commits looks like. Leave the result untouched and let
+                // CheckEmptyBranchFilter report it — it names the condition accurately and its rejection
+                // carries the push-record link. Claiming it here as an error would replace a precise
+                // message with a vague one and drop that link.
+                log.debug(
+                        "No commits in range {}..{} — leaving the empty-branch check to report it",
+                        fromCommit,
+                        toCommit);
                 return;
             }
 

--- a/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/EnrichPushCommitsFilterTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/EnrichPushCommitsFilterTest.java
@@ -13,6 +13,8 @@ import com.rbc.fogwall.provider.GitHubProvider;
 import com.rbc.fogwall.servlet.RequestBodyWrapper;
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
@@ -85,6 +87,27 @@ class EnrichPushCommitsFilterTest {
      * what {@link EnrichPushCommitsFilter} expects: it reads the body via {@code getBody()} and the request details via
      * {@code getAttribute(GIT_REQUEST_ATTR)}.
      */
+    /** A response mock that can actually receive {@code sendGitError}'s output — mirrors CheckEmptyBranchFilterTest. */
+    private static HttpServletResponse fakeResponse() throws IOException {
+        HttpServletResponse mock = mock(HttpServletResponse.class);
+        when(mock.getOutputStream()).thenReturn(new ServletOutputStream() {
+            @Override
+            public void write(int b) {}
+
+            @Override
+            public void write(byte[] b, int off, int len) {}
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setWriteListener(WriteListener l) {}
+        });
+        return mock;
+    }
+
     private RequestBodyWrapper wrapRequest(byte[] body, GitRequestDetails details) throws IOException {
         HttpServletRequest inner = mock(HttpServletRequest.class);
         when(inner.getMethod()).thenReturn("POST");
@@ -160,7 +183,7 @@ class EnrichPushCommitsFilterTest {
         String fromSha = ObjectId.zeroId().name();
 
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any())).thenReturn(cacheRepo);
+        when(mockCache.getOrClone(any(), any())).thenReturn(cacheRepo);
 
         GitRequestDetails details = makeDetails(fromSha, toSha);
 
@@ -206,7 +229,7 @@ class EnrichPushCommitsFilterTest {
         Repository cacheRepo =
                 Git.init().setBare(true).setDirectory(cacheDir2.toFile()).call().getRepository();
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any())).thenReturn(cacheRepo);
+        when(mockCache.getOrClone(any(), any())).thenReturn(cacheRepo);
 
         GitRequestDetails details = makeDetails(fromSha, toSha);
 
@@ -290,7 +313,7 @@ class EnrichPushCommitsFilterTest {
         Repository cacheRepo =
                 Git.init().setBare(true).setDirectory(cacheDir2.toFile()).call().getRepository();
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any())).thenReturn(cacheRepo);
+        when(mockCache.getOrClone(any(), any())).thenReturn(cacheRepo);
 
         GitRequestDetails details = makeDetails(fromSha, toSha);
 
@@ -330,7 +353,7 @@ class EnrichPushCommitsFilterTest {
 
             // The push packet reports the tag object SHA as toCommit.
             LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-            when(mockCache.getOrClone(any())).thenReturn(cacheRepo);
+            when(mockCache.getOrClone(any(), any())).thenReturn(cacheRepo);
 
             GitRequestDetails details = makeDetails(ObjectId.zeroId().name(), tagId.getName());
             details.setBranch("refs/tags/v1.0.0");
@@ -363,7 +386,7 @@ class EnrichPushCommitsFilterTest {
         String commitSha = insertCommitAsUpstream(cacheRepo);
 
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any())).thenReturn(cacheRepo);
+        when(mockCache.getOrClone(any(), any())).thenReturn(cacheRepo);
 
         // Lightweight tag: toCommit is the commit SHA directly (no tag object).
         GitRequestDetails details = makeDetails(ObjectId.zeroId().name(), commitSha);
@@ -411,7 +434,7 @@ class EnrichPushCommitsFilterTest {
         Repository cacheRepo =
                 Git.init().setBare(true).setDirectory(cacheDir2.toFile()).call().getRepository();
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any())).thenReturn(cacheRepo);
+        when(mockCache.getOrClone(any(), any())).thenReturn(cacheRepo);
 
         // Lightweight tag pointing directly at the new commit.
         GitRequestDetails details = makeDetails(ObjectId.zeroId().name(), commitSha);
@@ -419,8 +442,7 @@ class EnrichPushCommitsFilterTest {
 
         RequestBodyWrapper request = wrapRequest(packOut.toByteArray(), details);
 
-        new EnrichPushCommitsFilter(new GitHubProvider("/proxy"), mockCache)
-                .doHttpFilter(request, mock(HttpServletResponse.class));
+        new EnrichPushCommitsFilter(new GitHubProvider("/proxy"), mockCache).doHttpFilter(request, fakeResponse());
 
         assertEquals(
                 GitRequestDetails.GitResult.ERROR, details.getResult(), "Tag push with new commits must be rejected");
@@ -440,7 +462,7 @@ class EnrichPushCommitsFilterTest {
         Repository emptyRepo =
                 Git.init().setBare(true).setDirectory(cacheDir3.toFile()).call().getRepository();
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any())).thenReturn(emptyRepo);
+        when(mockCache.getOrClone(any(), any())).thenReturn(emptyRepo);
 
         // A tag SHA that does not exist in the cache — simulates a missing/omitted tag object.
         GitRequestDetails details = makeDetails(ObjectId.zeroId().name(), "07697092d36d3323eaaf4be18b3a5b1f276ab0dc");
@@ -448,8 +470,7 @@ class EnrichPushCommitsFilterTest {
 
         RequestBodyWrapper request = wrapRequest(new byte[0], details);
 
-        new EnrichPushCommitsFilter(new GitHubProvider("/proxy"), mockCache)
-                .doHttpFilter(request, mock(HttpServletResponse.class));
+        new EnrichPushCommitsFilter(new GitHubProvider("/proxy"), mockCache).doHttpFilter(request, fakeResponse());
 
         assertEquals(
                 GitRequestDetails.GitResult.ERROR, details.getResult(), "Unresolvable tag object must be rejected");
@@ -479,14 +500,13 @@ class EnrichPushCommitsFilterTest {
     @Test
     void doHttpFilter_cacheThrows_errorsRequest() throws Exception {
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any())).thenThrow(new RuntimeException("network unreachable"));
+        when(mockCache.getOrClone(any(), any())).thenThrow(new RuntimeException("network unreachable"));
 
         GitRequestDetails details = makeDetails(ObjectId.zeroId().name(), "abc1234abc1234abc1234abc1234abc1234abc123");
 
         RequestBodyWrapper request = wrapRequest(new byte[0], details);
-        HttpServletResponse response = mock(HttpServletResponse.class);
 
-        new EnrichPushCommitsFilter(new GitHubProvider("/proxy"), mockCache).doHttpFilter(request, response);
+        new EnrichPushCommitsFilter(new GitHubProvider("/proxy"), mockCache).doHttpFilter(request, fakeResponse());
 
         assertEquals(GitRequestDetails.GitResult.ERROR, details.getResult());
         assertNotNull(details.getReason());
@@ -500,15 +520,14 @@ class EnrichPushCommitsFilterTest {
         Repository emptyRepo =
                 Git.init().setBare(true).setDirectory(cacheDir.toFile()).call().getRepository();
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any())).thenReturn(emptyRepo);
+        when(mockCache.getOrClone(any(), any())).thenReturn(emptyRepo);
 
         String toSha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
         GitRequestDetails details = makeDetails(ObjectId.zeroId().name(), toSha);
 
         RequestBodyWrapper request = wrapRequest(new byte[0], details);
-        HttpServletResponse response = mock(HttpServletResponse.class);
 
-        new EnrichPushCommitsFilter(new GitHubProvider("/proxy"), mockCache).doHttpFilter(request, response);
+        new EnrichPushCommitsFilter(new GitHubProvider("/proxy"), mockCache).doHttpFilter(request, fakeResponse());
 
         assertEquals(GitRequestDetails.GitResult.ERROR, details.getResult());
         assertNotNull(details.getReason());

--- a/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/EnrichPushCommitsFilterTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/EnrichPushCommitsFilterTest.java
@@ -20,16 +20,20 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Set;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.internal.storage.pack.PackWriter;
 import org.eclipse.jgit.lib.*;
+import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.PacketLineOut;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Integration tests for {@link EnrichPushCommitsFilter}.
@@ -172,6 +176,69 @@ class EnrichPushCommitsFilterTest {
     }
 
     /**
+     * The client's credentials must reach the upstream clone/fetch — without them a private repository fails with an
+     * upstream 404 that surfaces to the developer as "repository not found".
+     *
+     * <p>Just as importantly, a <b>principal</b> must be passed alongside them. The mirror cache keys its fetch
+     * cooldown by {@code (repository, principal)}; supplying credentials while leaving the principal null would put
+     * every proxy caller on the shared anonymous entry, letting one user's successful fetch satisfy the next user's
+     * request. The principal is built from the whole credential rather than the username because providers such as
+     * GitHub ignore the HTTP Basic username entirely.
+     */
+    @Test
+    void doHttpFilter_passesClientCredentialsAndPrincipalToCache() throws Exception {
+        Repository cacheRepo =
+                Git.init().setBare(true).setDirectory(cacheDir.toFile()).call().getRepository();
+        String toSha = insertCommit(cacheRepo);
+
+        LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
+        when(mockCache.getOrClone(any(), any(), any(), any())).thenReturn(cacheRepo);
+
+        GitRequestDetails details = makeDetails(ObjectId.zeroId().name(), toSha);
+        RequestBodyWrapper request = wrapRequest(new byte[0], details);
+        String basic = Base64.getEncoder().encodeToString("alice:ghp_secrettoken".getBytes(StandardCharsets.UTF_8));
+        when(((HttpServletRequest) request.getRequest()).getHeader("Authorization"))
+                .thenReturn("Basic " + basic);
+
+        new EnrichPushCommitsFilter(new GitHubProvider("/proxy"), mockCache)
+                .doHttpFilter(request, mock(HttpServletResponse.class));
+
+        ArgumentCaptor<CredentialsProvider> creds = ArgumentCaptor.forClass(CredentialsProvider.class);
+        ArgumentCaptor<String> principal = ArgumentCaptor.forClass(String.class);
+        verify(mockCache).getOrClone(any(), creds.capture(), any(), principal.capture());
+
+        assertNotNull(creds.getValue(), "Client credentials must be forwarded to the upstream clone/fetch");
+        assertEquals(
+                "alice:ghp_secrettoken",
+                principal.getValue(),
+                "Principal must be the full credential, so the cooldown cannot be shared between callers");
+    }
+
+    /** With no Authorization header the caller is genuinely anonymous — no credentials and no principal. */
+    @Test
+    void doHttpFilter_withoutAuthHeader_passesNoCredentialsOrPrincipal() throws Exception {
+        Repository cacheRepo =
+                Git.init().setBare(true).setDirectory(cacheDir.toFile()).call().getRepository();
+        String toSha = insertCommit(cacheRepo);
+
+        LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
+        when(mockCache.getOrClone(any(), any(), any(), any())).thenReturn(cacheRepo);
+
+        GitRequestDetails details = makeDetails(ObjectId.zeroId().name(), toSha);
+        RequestBodyWrapper request = wrapRequest(new byte[0], details);
+
+        new EnrichPushCommitsFilter(new GitHubProvider("/proxy"), mockCache)
+                .doHttpFilter(request, mock(HttpServletResponse.class));
+
+        ArgumentCaptor<CredentialsProvider> creds = ArgumentCaptor.forClass(CredentialsProvider.class);
+        ArgumentCaptor<String> principal = ArgumentCaptor.forClass(String.class);
+        verify(mockCache).getOrClone(any(), creds.capture(), any(), principal.capture());
+
+        assertNull(creds.getValue());
+        assertNull(principal.getValue());
+    }
+
+    /**
      * Happy path (no pack): commit objects are already in the bare cache (e.g. the cache was recently cloned). The
      * filter skips pack unpack because the request body is empty, but can still walk the commit range.
      */
@@ -183,7 +250,7 @@ class EnrichPushCommitsFilterTest {
         String fromSha = ObjectId.zeroId().name();
 
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any(), any())).thenReturn(cacheRepo);
+        when(mockCache.getOrClone(any(), any(), any(), any())).thenReturn(cacheRepo);
 
         GitRequestDetails details = makeDetails(fromSha, toSha);
 
@@ -229,7 +296,7 @@ class EnrichPushCommitsFilterTest {
         Repository cacheRepo =
                 Git.init().setBare(true).setDirectory(cacheDir2.toFile()).call().getRepository();
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any(), any())).thenReturn(cacheRepo);
+        when(mockCache.getOrClone(any(), any(), any(), any())).thenReturn(cacheRepo);
 
         GitRequestDetails details = makeDetails(fromSha, toSha);
 
@@ -313,7 +380,7 @@ class EnrichPushCommitsFilterTest {
         Repository cacheRepo =
                 Git.init().setBare(true).setDirectory(cacheDir2.toFile()).call().getRepository();
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any(), any())).thenReturn(cacheRepo);
+        when(mockCache.getOrClone(any(), any(), any(), any())).thenReturn(cacheRepo);
 
         GitRequestDetails details = makeDetails(fromSha, toSha);
 
@@ -353,7 +420,7 @@ class EnrichPushCommitsFilterTest {
 
             // The push packet reports the tag object SHA as toCommit.
             LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-            when(mockCache.getOrClone(any(), any())).thenReturn(cacheRepo);
+            when(mockCache.getOrClone(any(), any(), any(), any())).thenReturn(cacheRepo);
 
             GitRequestDetails details = makeDetails(ObjectId.zeroId().name(), tagId.getName());
             details.setBranch("refs/tags/v1.0.0");
@@ -386,7 +453,7 @@ class EnrichPushCommitsFilterTest {
         String commitSha = insertCommitAsUpstream(cacheRepo);
 
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any(), any())).thenReturn(cacheRepo);
+        when(mockCache.getOrClone(any(), any(), any(), any())).thenReturn(cacheRepo);
 
         // Lightweight tag: toCommit is the commit SHA directly (no tag object).
         GitRequestDetails details = makeDetails(ObjectId.zeroId().name(), commitSha);
@@ -434,7 +501,7 @@ class EnrichPushCommitsFilterTest {
         Repository cacheRepo =
                 Git.init().setBare(true).setDirectory(cacheDir2.toFile()).call().getRepository();
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any(), any())).thenReturn(cacheRepo);
+        when(mockCache.getOrClone(any(), any(), any(), any())).thenReturn(cacheRepo);
 
         // Lightweight tag pointing directly at the new commit.
         GitRequestDetails details = makeDetails(ObjectId.zeroId().name(), commitSha);
@@ -462,7 +529,7 @@ class EnrichPushCommitsFilterTest {
         Repository emptyRepo =
                 Git.init().setBare(true).setDirectory(cacheDir3.toFile()).call().getRepository();
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any(), any())).thenReturn(emptyRepo);
+        when(mockCache.getOrClone(any(), any(), any(), any())).thenReturn(emptyRepo);
 
         // A tag SHA that does not exist in the cache — simulates a missing/omitted tag object.
         GitRequestDetails details = makeDetails(ObjectId.zeroId().name(), "07697092d36d3323eaaf4be18b3a5b1f276ab0dc");
@@ -500,7 +567,7 @@ class EnrichPushCommitsFilterTest {
     @Test
     void doHttpFilter_cacheThrows_errorsRequest() throws Exception {
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any(), any())).thenThrow(new RuntimeException("network unreachable"));
+        when(mockCache.getOrClone(any(), any(), any(), any())).thenThrow(new RuntimeException("network unreachable"));
 
         GitRequestDetails details = makeDetails(ObjectId.zeroId().name(), "abc1234abc1234abc1234abc1234abc1234abc123");
 
@@ -520,7 +587,7 @@ class EnrichPushCommitsFilterTest {
         Repository emptyRepo =
                 Git.init().setBare(true).setDirectory(cacheDir.toFile()).call().getRepository();
         LocalRepositoryCache mockCache = mock(LocalRepositoryCache.class);
-        when(mockCache.getOrClone(any(), any())).thenReturn(emptyRepo);
+        when(mockCache.getOrClone(any(), any(), any(), any())).thenReturn(emptyRepo);
 
         String toSha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
         GitRequestDetails details = makeDetails(ObjectId.zeroId().name(), toSha);


### PR DESCRIPTION
## What this fixes

Six changes. The first makes transparent proxy usable against private repositories at all; the rest fix problems either introduced alongside it or exposed by it.

### 1. Proxy mode never sent credentials upstream

`EnrichPushCommitsFilter` called `getOrClone(remoteUrl)` — the anonymous form, with no credentials. Against a private repository the upstream clone returns 404, and the developer saw **"repository not found"**, which is indistinguishable from a typo in the remote URL. Transparent proxy simply could not validate pushes to private repos, and anyone smoke-testing against a public repo would see it working.

Hit in real use pushing to a private upstream.

### 2. …and now sends a cache principal with them

The mirror cache keys its fetch cooldown by `(repository, principal)` since #471. Passing credentials while leaving the principal unset would put every proxy caller on the shared *anonymous* entry, so one user's successful fetch would satisfy the next user's request — reintroducing on `proxyCache` exactly what #471 removed on `storeForwardCache`.

The principal is built from the whole credential rather than the username, because providers such as GitHub ignore the HTTP Basic username entirely — the token is what identifies the caller.

Caught by the compiler, not by review: #471 deleted the overloads that take credentials without a principal, so the original call site stopped building once this branch was rebased.

### 3. An empty commit range is not an inspection failure

Change 1 routed the empty-range case through `errorAndSendError` and taught `CheckEmptyBranchFilter` to stand down once the result is `ERROR`. Between them, the empty-branch condition was taken away from the filter that reports it properly, so `emptyBranch_rejected` started getting *"Commit Inspection Failed"* instead of naming the actual problem.

An empty range means the walk ran and legitimately found nothing — which is what a branch pushed with no new commits looks like. Leaving the result untouched hands it back to `CheckEmptyBranchFilter`, restoring both the accurate message and the push-record link.

### 4. Tag pushes wrongly reported as smuggling — stale or shallow mirror

The tag check rejects when commits reachable from the tagged commit aren't reachable from any branch, but it reads that from the local mirror. A non-empty result has three possible causes and only one is smuggling:

1. commits really did arrive via the tag, bypassing branch validation
2. the mirror hasn't re-fetched since they were forwarded upstream (fetch cooldown)
3. the mirror is a shallow clone and they sit beyond its boundary

(2) happens within seconds of an approved branch push, because `AllowApprovedPushFilter` short-circuits `EnrichPushCommitsFilter` on the re-push so nothing refreshes the mirror. (3) applies whenever the tagged commit is outside `proxyCache`'s shallow boundary — which is `DEFAULT_CLONE_DEPTH` generations of ancestry back from each branch tip, traversing all parents. That is not "the hundred most recent commits" and not a function of age, so **an operator cannot predict which of their commits fall outside it**.

Tagging a long-standing commit is an ordinary release action, and *"push the branch first"* is unactionable when the branch is already upstream.

Now a non-empty result triggers a refresh with the cooldown bypassed plus a deepen via `FetchCommand.setUnshallow`, and the walk is redone. Only a range that survives that is treated as smuggling. The fetch happens only on the path that was about to reject, so legitimate tags cost nothing, and the deepened state sticks so the expense is bounded to once per repository per process rather than being repeatable on demand.

### 5. Tag pushes wrongly reported as smuggling — commit only reachable from a tag

The "already upstream" list was built from branches only. A commit can be upstream without being on any branch, if the only thing pointing at it is a tag — after the branch was deleted, or when the commit sits on a branch this mirror doesn't have. Tags are now included, dereferenced to their target commit.

Scoped to `getCommitRange` deliberately. `findNewBranchBase` makes the same branches-only assumption, but it picks the starting point for the diff that gets scanned for secrets and blocked content, so widening it changes scanning coverage — a separate decision.

### 6. Test failures now explain themselves

Gradle's default test logging prints only the exception type and line, dropping the message. Diagnosing item 4 meant downloading a CI artifact and stripping HTML to recover an assertion message that had been available at the moment of failure. `exceptionFormat 'full'` puts it in the log, for `e2eTest` as well as `test`. `showStandardStreams` stays off — the e2e suite emits hundreds of log lines per test and would bury the failure.

## Why `tagPush_blockedThenApproved` was green before

It was passing for the wrong reason. With the range non-empty, the old code set `ERROR` without sending a response, and something further down the chain produced the push-record link the test extracts. The tag check has been misfiring; change 1's error reporting made it visible.

## Testing

- Two new tests capture the `getOrClone` arguments, so dropping the principal fails loudly rather than silently sharing a cooldown.
- Existing `EnrichPushCommitsFilterTest` stubbings updated to the 4-arg overload.
- Full `:fogwall-server:e2eTest` suite green locally against podman, including the whole `ProxyModeE2ETest` class.
- `:fogwall-core:test` green across the affected classes.

## Follow-ups filed

- #474 — annotated tag messages bypass content validation
- #476 — clone depth is hardcoded and diverges by mode; prefer a date-based bound
- #477 — selectable cache mode (shared / ephemeral / off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
