### PR TITLE
fix(approval): fail closed when the approval gate cannot read its push record

### DIFF
--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/ApprovalPreReceiveHook.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/ApprovalPreReceiveHook.java
@@ -124,15 +124,27 @@ public class ApprovalPreReceiveHook implements PreReceiveHook {
     public void onPreReceive(ReceivePack rp, Collection<ReceiveCommand> commands) {
         OutputStream msgOut = rp.getMessageOutputStream();
 
+        // Fail closed on missing approval state. Both branches below mean the same thing: this hook cannot
+        // establish that the push was approved. Returning without rejecting would forward it upstream
+        // unapproved — silently disabling the control fogwall exists to provide, on nothing more than a
+        // transient store failure. The condition is self-concealing, because the record that failed to write
+        // is also the audit evidence of what happened, so the only trace would be a log line.
         String validationRecordId = pushContext != null ? pushContext.getValidationRecordId() : null;
         if (validationRecordId == null) {
-            log.warn("No validationRecordId in push context - skipping approval gate");
+            log.error("No validationRecordId in push context - rejecting push, approval state cannot be established");
+            sendAndFlush(
+                    rp, msgOut, color(RED, sym(NO_ENTRY) + "  Push blocked - approval state could not be recorded"));
+            rejectAll(commands, "Approval state unavailable - push record was not created");
             return;
         }
 
         var record = pushStore.findById(validationRecordId).orElse(null);
         if (record == null) {
-            log.warn("Validation record not found: {} - skipping approval gate", validationRecordId);
+            log.error(
+                    "Validation record not found: {} - rejecting push, approval state cannot be established",
+                    validationRecordId);
+            sendAndFlush(rp, msgOut, color(RED, sym(NO_ENTRY) + "  Push blocked - approval record could not be read"));
+            rejectAll(commands, "Approval state unavailable - push record " + validationRecordId + " not found");
             return;
         }
 

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/PushStorePersistenceHook.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/PushStorePersistenceHook.java
@@ -103,7 +103,14 @@ public class PushStorePersistenceHook {
     public PreReceiveHook validationResultHook(ValidationContext validationContext) {
         return (ReceivePack rp, Collection<ReceiveCommand> commands) -> {
             String pushId = pushContext != null ? pushContext.getPushId() : null;
-            if (pushId == null) return;
+            if (pushId == null) {
+                // The initial RECEIVED record was never created, so there is nothing to update and
+                // validationRecordId stays unset. ApprovalPreReceiveHook rejects the push on that basis —
+                // see its fail-closed guard — so this is logged loudly rather than passed over in silence.
+                log.error("No pushId in push context - validation result cannot be recorded; approval gate will"
+                        + " reject this push");
+                return;
+            }
 
             // Read resolvedUser and scmUsername from pushContext — both are set by CheckUserPushPermissionHook
             // (order 150) after preReceiveHook() ran, so they were not available when the RECEIVED record
@@ -252,7 +259,12 @@ public class PushStorePersistenceHook {
                             "Saved validation result record: id={}, status=PENDING (awaiting review)", record.getId());
                 });
             } catch (Exception e) {
-                log.error("Failed to save validation result record", e);
+                // Swallowed deliberately: this hook must not abort the chain mid-way. The security
+                // consequence is handled downstream — the failure leaves validationRecordId unset, and
+                // ApprovalPreReceiveHook fails closed on that, so the push is rejected rather than
+                // forwarded unapproved. Logged at error because the operator needs to see it: the record
+                // that failed to write is also the audit evidence of what happened.
+                log.error("Failed to save validation result record - approval gate will reject this push", e);
             }
         };
     }

--- a/fogwall-core/src/test/java/com/rbc/fogwall/git/ApprovalPreReceiveHookTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/git/ApprovalPreReceiveHookTest.java
@@ -59,9 +59,14 @@ class ApprovalPreReceiveHookTest {
                 .call();
     }
 
+    /**
+     * No validationRecordId means the push record was never written — the initial create failed, or
+     * {@code validationResultHook} could not save. The hook cannot establish that this push was approved, so it must
+     * reject. Returning normally would forward it upstream unapproved on nothing more than a transient store failure,
+     * and the missing record is also the audit evidence, so the bypass would leave no trace but a log line.
+     */
     @Test
-    void noValidationRecordId_skipsApprovalGate() throws Exception {
-        // No fogwall.validationRecordId set in repo config → hook is a no-op
+    void noValidationRecordId_rejectsPush() throws Exception {
         RevCommit c1 = createCommit("init");
         RevCommit c2 = createCommit("second");
         ReceivePack rp = new ReceivePack(repo);
@@ -69,12 +74,16 @@ class ApprovalPreReceiveHookTest {
 
         new ApprovalPreReceiveHook(pushStore, approvalGateway).onPreReceive(rp, List.of(cmd));
 
-        assertEquals(ReceiveCommand.Result.NOT_ATTEMPTED, cmd.getResult());
-        verifyNoInteractions(pushStore, approvalGateway);
+        assertEquals(
+                ReceiveCommand.Result.REJECTED_OTHER_REASON,
+                cmd.getResult(),
+                "a push whose approval state cannot be established must be rejected, not forwarded");
+        verifyNoInteractions(approvalGateway);
     }
 
+    /** Same reasoning when the id exists but the record cannot be read back — e.g. the store is unavailable. */
     @Test
-    void validationRecordNotInStore_skipsApprovalGate() throws Exception {
+    void validationRecordNotInStore_rejectsPush() throws Exception {
         String recordId = UUID.randomUUID().toString();
         PushContext pushContext = new PushContext();
         pushContext.setValidationRecordId(recordId);
@@ -88,7 +97,10 @@ class ApprovalPreReceiveHookTest {
         new ApprovalPreReceiveHook(pushStore, approvalGateway, Duration.ofMinutes(30), null, null, pushContext)
                 .onPreReceive(rp, List.of(cmd));
 
-        assertEquals(ReceiveCommand.Result.NOT_ATTEMPTED, cmd.getResult());
+        assertEquals(
+                ReceiveCommand.Result.REJECTED_OTHER_REASON,
+                cmd.getResult(),
+                "an unreadable approval record must block the push, not let it through");
         verifyNoInteractions(approvalGateway);
     }
 


### PR DESCRIPTION
## What

`ApprovalPreReceiveHook` now rejects the push when it cannot establish approval
state, instead of returning normally.

## Why

Two branches returned without rejecting:

```java
if (validationRecordId == null) {
    log.warn("No validationRecordId in push context - skipping approval gate");
    return;                     // push proceeds, unapproved
}
var record = pushStore.findById(validationRecordId).orElse(null);
if (record == null) {
    log.warn("Validation record not found: {} - skipping approval gate", validationRecordId);
    return;                     // same
}
```

Returning normally from a pre-receive hook lets the push through, so both paths
forwarded it upstream with **no approval** — silently disabling the control the
product exists to provide.

No attacker and no unusual configuration are required. `PushStorePersistenceHook`
has four ways to leave `validationRecordId` unset, all of which log and continue:
the initial record create failing (`:90`), a null `pushId`, `findById` returning
empty inside `ifPresent` (`:115`), and the swallowed catch around the
validation-result save (`:254`). A transient database error on any one of them was
enough.

The condition is **self-concealing**: the record that fails to write is also the
audit evidence of what happened. So the only trace of a bypassed approval was a log
line — on precisely the occasion when evidence matters most.

## Why fix it at the gate

Deliberately fixed at the consumer rather than at each of the four producers. The
gate is the single chokepoint through which every one of those causes flows, so this
covers them all, including any added later. The producers now log at `error` with
the consequence stated ("approval gate will reject this push") so an operator can
correlate the rejection with its cause.

## Scope

Store-and-forward only. `ApprovalPreReceiveHook` is a JGit pre-receive hook;
transparent proxy gates via `PushFinalizerFilter`, which derives `REVIEW` from
in-memory state with no store read and has no equivalent fail-open.

## Testing

Two existing tests asserted the old behaviour and are rewritten to require
rejection:

- `noValidationRecordId_skipsApprovalGate` → `noValidationRecordId_rejectsPush`
- `validationRecordNotInStore_skipsApprovalGate` → `validationRecordNotInStore_rejectsPush`

That the fail-open was codified in tests is a large part of why it survived two
audit passes rated Low — worth noting for anyone reviewing similar "skips X" test
names elsewhere.

`:fogwall-core:test` green across `*Approval*`, `*PushStore*` and `*StoreAndForward*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)