### PR TITLE
fix(cache): stop two providers hosting the same repo path from sharing one mirror

### DIFF
--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/ForwardingPostReceiveHook.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/ForwardingPostReceiveHook.java
@@ -89,7 +89,12 @@ public class ForwardingPostReceiveHook implements PostReceiveHook {
             log.debug("Using Bitbucket upstream username '{}' for forwarding credentials", upstreamUser);
         }
 
-        String upstreamUrl = repo.getConfig().getString("fogwall", null, "upstreamUrl");
+        // Prefer the URL this request resolved to. The mirror's own config is shared with every other request
+        // using the same mirror, so it is only a fallback for callers that never populated the push context.
+        String upstreamUrl = pushContext.getUpstreamUrl();
+        if (upstreamUrl == null) {
+            upstreamUrl = repo.getConfig().getString("fogwall", null, "upstreamUrl");
+        }
 
         if (upstreamUrl == null) {
             rp.sendMessage(color(RED, sym(NO_ENTRY) + "  ERROR - no upstream URL configured, cannot forward"));

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/LocalRepositoryCache.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/LocalRepositoryCache.java
@@ -389,23 +389,57 @@ public class LocalRepositoryCache {
     /**
      * Generate a cache key from a remote URL.
      *
+     * <p>One cache instance is shared by every configured provider, so the key must cover the whole remote and not just
+     * the path — otherwise {@code github.com/acme/app.git} and {@code gitea.internal/acme/app.git} are the same mirror.
+     * The readable prefix is for identifying the directory on disk; the digest of the full URL is what guarantees
+     * distinct remotes get distinct keys.
+     *
      * @param remoteUrl The remote URL
      * @return A safe cache key
      */
-    private String getCacheKey(String remoteUrl) {
+    String getCacheKey(String remoteUrl) {
         try {
             URIish uri = new URIish(remoteUrl);
-            String path = uri.getPath();
+            String path = uri.getPath() != null ? uri.getPath() : "";
             if (path.startsWith("/")) {
                 path = path.substring(1);
             }
             if (path.endsWith(".git")) {
                 path = path.substring(0, path.length() - 4);
             }
-            return path.replace("/", "_").replace("\\", "_");
+
+            StringBuilder readable = new StringBuilder();
+            if (uri.getHost() != null) {
+                readable.append(uri.getHost());
+                if (uri.getPort() > 0) {
+                    readable.append('-').append(uri.getPort());
+                }
+                readable.append('_');
+            }
+            readable.append(path);
+
+            return sanitizeKeySegment(readable.toString()) + "-" + shortDigest(remoteUrl);
         } catch (Exception e) {
             log.warn("Failed to parse remote URL, using hash as cache key: {}", remoteUrl);
-            return String.valueOf(remoteUrl.hashCode());
+            return "unparsed-" + shortDigest(remoteUrl);
+        }
+    }
+
+    /** Reduce a key to characters that are safe as a single directory name on every supported platform. */
+    private static String sanitizeKeySegment(String raw) {
+        String safe = raw.replaceAll("[^A-Za-z0-9._-]", "_");
+        return safe.length() > 100 ? safe.substring(0, 100) : safe;
+    }
+
+    /** First 12 hex chars of the SHA-256 of {@code value} — enough to keep distinct remotes in distinct directories. */
+    private static String shortDigest(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of()
+                    .formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)))
+                    .substring(0, 12);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
         }
     }
 

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/PushContext.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/PushContext.java
@@ -31,6 +31,10 @@ public class PushContext {
     private String pushToken;
     private String repoSlug;
 
+    // Where this push forwards to, resolved when the request opened its repository. Not read back off the mirror's
+    // own config at forward time — that config is shared with every concurrent request using the same mirror.
+    private String upstreamUrl;
+
     /**
      * Transport context for this push — carries pre-authenticated identity (SSH) and upstream transport configuration.
      * Defaults to {@link PushTransport#http()} so HTTP pushes need not set it explicitly.

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/PushStorePersistenceHook.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/PushStorePersistenceHook.java
@@ -423,8 +423,11 @@ public class PushStorePersistenceHook {
             pushContext.getTransport().auditMethod().ifPresent(builder::method);
         }
 
-        // Extract upstream URL and repo name from repo config (set by StoreAndForwardRepositoryResolver)
-        String upstreamUrl = repo.getConfig().getString("fogwall", null, "upstreamUrl");
+        // Upstream URL and repo name, taken from this request's context and falling back to the shared mirror config.
+        String upstreamUrl = pushContext != null ? pushContext.getUpstreamUrl() : null;
+        if (upstreamUrl == null) {
+            upstreamUrl = repo.getConfig().getString("fogwall", null, "upstreamUrl");
+        }
         if (upstreamUrl != null) {
             builder.upstreamUrl(upstreamUrl);
             // Parse repo name from upstream URL (e.g., "https://github.com/owner/repo.git" -> "repo")

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/StoreAndForwardReceivePackFactory.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/StoreAndForwardReceivePackFactory.java
@@ -200,16 +200,19 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
             repoSlug = slug;
         }
 
-        return buildReceivePack(db, creds, pushUser, pushToken, repoSlug, PushTransport.http());
+        String upstreamUrl = (String) req.getAttribute(StoreAndForwardRepositoryResolver.UPSTREAM_URL_ATTRIBUTE);
+
+        return buildReceivePack(db, creds, pushUser, pushToken, repoSlug, upstreamUrl, PushTransport.http());
     }
 
     /**
      * Builds a {@link ReceivePack} for an SSH push. The {@code transport} carries the {@link UserEntry} identified
      * during public-key authentication and the per-push SSH session factory for upstream forwarding.
      */
-    public ReceivePack createForSsh(Repository db, String pushUser, String repoSlug, PushTransport.Ssh transport)
+    public ReceivePack createForSsh(
+            Repository db, String pushUser, String repoSlug, String upstreamUrl, PushTransport.Ssh transport)
             throws ServiceNotEnabledException, ServiceNotAuthorizedException {
-        return buildReceivePack(db, null, pushUser, null, repoSlug, transport);
+        return buildReceivePack(db, null, pushUser, null, repoSlug, upstreamUrl, transport);
     }
 
     private ReceivePack buildReceivePack(
@@ -218,6 +221,7 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
             String pushUser,
             String pushToken,
             String repoSlug,
+            String upstreamUrl,
             PushTransport transport)
             throws ServiceNotEnabledException, ServiceNotAuthorizedException {
 
@@ -231,6 +235,7 @@ public class StoreAndForwardReceivePackFactory implements ReceivePackFactory<Htt
         pushContext.setPushUser(pushUser);
         pushContext.setPushToken(pushToken);
         pushContext.setRepoSlug(repoSlug);
+        pushContext.setUpstreamUrl(upstreamUrl);
         pushContext.setTransport(transport);
 
         // Persistence hook (records push to database)

--- a/fogwall-core/src/main/java/com/rbc/fogwall/git/StoreAndForwardRepositoryResolver.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/git/StoreAndForwardRepositoryResolver.java
@@ -29,6 +29,11 @@ public class StoreAndForwardRepositoryResolver implements RepositoryResolver<Htt
 
     public static final String CREDENTIALS_ATTRIBUTE = "com.rbc.fogwall.credentials";
 
+    /**
+     * Upstream URL this request resolved to, read by {@link StoreAndForwardReceivePackFactory} onto its PushContext.
+     */
+    public static final String UPSTREAM_URL_ATTRIBUTE = "com.rbc.fogwall.upstreamUrl";
+
     private final LocalRepositoryCache cache;
     private final FogwallProvider provider;
 
@@ -68,14 +73,10 @@ public class StoreAndForwardRepositoryResolver implements RepositoryResolver<Htt
 
         log.info("Opening store-and-forward repository: {} -> {}", name, cleanUpstreamUrl);
 
+        req.setAttribute(UPSTREAM_URL_ATTRIBUTE, cleanUpstreamUrl);
+
         try {
-            Repository repo = cache.getOrClone(cleanUpstreamUrl, creds, null, principal);
-
-            // Store the upstream URL so PostReceiveHook can find it
-            repo.getConfig().setString("fogwall", null, "upstreamUrl", cleanUpstreamUrl);
-            repo.getConfig().save();
-
-            return repo;
+            return cache.getOrClone(cleanUpstreamUrl, creds, null, principal);
         } catch (Exception e) {
             log.error("Failed to open repository: {} from upstream {}", name, cleanUpstreamUrl, e);
             throw new RepositoryNotFoundException(name, e);

--- a/fogwall-core/src/test/java/com/rbc/fogwall/git/LocalRepositoryCacheTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/git/LocalRepositoryCacheTest.java
@@ -232,4 +232,61 @@ class LocalRepositoryCacheTest {
         assertNull(cache.getCached(remoteUrl2));
         assertFalse(cacheTempDir.toFile().exists(), "Cache directory should be deleted after clear");
     }
+
+    @Test
+    void sameRepoPathOnDifferentProviders_getsSeparateMirrors() throws Exception {
+        LocalRepositoryCache cache = new LocalRepositoryCache(cacheTempDir, false);
+
+        String github = cache.getCacheKey("https://github.com/acme/app.git");
+        String internal = cache.getCacheKey("https://gitea.internal/acme/app.git");
+
+        assertNotEquals(
+                internal,
+                github,
+                "One cache is shared by every provider, so two providers hosting acme/app must not share a mirror");
+    }
+
+    @Test
+    void sameHostOnDifferentPortsOrSchemes_getsSeparateMirrors() throws Exception {
+        LocalRepositoryCache cache = new LocalRepositoryCache(cacheTempDir, false);
+
+        assertNotEquals(
+                cache.getCacheKey("https://scm.example.com:8443/acme/app.git"),
+                cache.getCacheKey("https://scm.example.com/acme/app.git"),
+                "Port is part of the remote's identity");
+        assertNotEquals(
+                cache.getCacheKey("ssh://scm.example.com/acme/app.git"),
+                cache.getCacheKey("https://scm.example.com/acme/app.git"),
+                "Scheme is part of the remote's identity");
+    }
+
+    @Test
+    void sameUrl_getsTheSameKey() throws Exception {
+        LocalRepositoryCache cache = new LocalRepositoryCache(cacheTempDir, false);
+
+        assertEquals(
+                cache.getCacheKey("https://github.com/acme/app.git"),
+                cache.getCacheKey("https://github.com/acme/app.git"),
+                "Key must be stable, or a warm mirror is never reused");
+    }
+
+    @Test
+    void cacheKey_isAlwaysASingleDirectoryName() throws Exception {
+        LocalRepositoryCache cache = new LocalRepositoryCache(cacheTempDir, false);
+
+        for (String url : new String[] {
+            "https://github.com/acme/app.git",
+            "https://github.com/acme/../../etc/passwd.git",
+            "https://github.com/acme/deeply/nested/group/app.git",
+            "not a url at all"
+        }) {
+            String key = cache.getCacheKey(url);
+            assertFalse(key.contains("/"), "Key must not contain a path separator: " + key);
+            assertFalse(key.contains("\\"), "Key must not contain a path separator: " + key);
+            assertEquals(
+                    key,
+                    new File(cacheTempDir.toFile(), key).getName(),
+                    "Key must resolve to a direct child of the cache directory: " + key);
+        }
+    }
 }

--- a/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitReceiveCommand.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/ssh/SshGitReceiveCommand.java
@@ -190,10 +190,9 @@ public class SshGitReceiveCommand implements Command {
             // for the mirror cache's per-principal fetch cooldown — the forwarded agent is what authorizes
             // upstream, and a different key must not inherit another key's verification.
             Repository localRepo = cache.getOrClone(upstreamUrl, null, transportConfig, connectingFingerprint);
-            localRepo.getConfig().setString("fogwall", null, "upstreamUrl", upstreamUrl);
-            localRepo.getConfig().save();
 
-            ReceivePack rp = route.receivePackFactory().createForSsh(localRepo, sshUser, repoSlug, pushTransport);
+            ReceivePack rp =
+                    route.receivePackFactory().createForSsh(localRepo, sshUser, repoSlug, upstreamUrl, pushTransport);
             rp.setBiDirectionalPipe(true); // factory defaults to false for HTTP; SSH is bidirectional
             rp.receive(in, out, err);
 


### PR DESCRIPTION
The local mirror cache keyed on the URL path alone, so `github.com/acme/app.git` and `gitea.internal/acme/app.git` both resolved to `acme_app` — in a cache shared by every configured provider.

**What that broke**

- **Wrong validation baseline.** "Which commits does this push add?" was answered against a different provider's refs, so commit-range enumeration and hidden-commit detection ran on the wrong repository.
- **Forwarding target could move.** `StoreAndForwardRepositoryResolver` wrote `fogwall.upstreamUrl` into the mirror's on-disk git config on every open, and `ForwardingPostReceiveHook` read it back at post-receive. With a colliding key both providers shared one config file, so a concurrent request could redirect an in-flight push to the other SCM.

**Changes**

- `LocalRepositoryCache.getCacheKey` now covers scheme, host, port and path, with a 12-hex digest of the full URL appended so distinct remotes cannot collide even where sanitising maps their readable parts together. The key is also asserted to always be a single directory name.
- The upstream URL travels on the request's `PushContext` instead of the shared mirror config. `StoreAndForwardRepositoryResolver` publishes it as a request attribute; `StoreAndForwardReceivePackFactory` puts it on the context; `ForwardingPostReceiveHook` and `PushStorePersistenceHook` read it from there, falling back to the mirror config. The SSH receive path passes it explicitly through `createForSsh`.

`createForSsh` gained an `upstreamUrl` parameter — `fogwall-core` internal API, no external contract.

**Tests**

Four cases in `LocalRepositoryCacheTest` covering provider separation, port/scheme separation, key stability, and the single-directory-name property.
