### PR TITLE
fix(approval): scope an approved re-push to the repository it was approved for

### DIFF
--- a/fogwall-core/src/main/java/com/rbc/fogwall/db/jdbc/JdbcPushStore.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/db/jdbc/JdbcPushStore.java
@@ -258,6 +258,10 @@ public class JdbcPushStore implements PushStore {
             sql.append(" AND status = :status");
             params.addValue("status", query.getStatus().name());
         }
+        if (query.getProvider() != null) {
+            sql.append(" AND provider = :provider");
+            params.addValue("provider", query.getProvider());
+        }
         if (query.getProject() != null) {
             sql.append(" AND project = :project");
             params.addValue("project", query.getProject());

--- a/fogwall-core/src/main/java/com/rbc/fogwall/db/model/PushQuery.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/db/model/PushQuery.java
@@ -8,6 +8,7 @@ import lombok.Data;
 @Builder
 public class PushQuery {
     private PushStatus status;
+    private String provider;
     private String project;
     private String repoName;
     private String branch;

--- a/fogwall-core/src/main/java/com/rbc/fogwall/db/mongo/MongoPushStore.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/db/mongo/MongoPushStore.java
@@ -72,6 +72,9 @@ public class MongoPushStore implements PushStore {
         if (query.getStatus() != null) {
             filters.add(Filters.eq("status", query.getStatus().name()));
         }
+        if (query.getProvider() != null) {
+            filters.add(Filters.eq("provider", query.getProvider()));
+        }
         if (query.getProject() != null) {
             filters.add(Filters.eq("project", query.getProject()));
         }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/AllowApprovedPushFilter.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/AllowApprovedPushFilter.java
@@ -63,8 +63,22 @@ public class AllowApprovedPushFilter extends AbstractFogwallFilter {
         String commitTo = details.getCommitTo();
         String branch = details.getBranch();
         String repoName = details.getRepoRef() != null ? details.getRepoRef().getName() : null;
+        String owner = details.getRepoRef() != null ? details.getRepoRef().getOwner() : null;
+        String provider = details.getProvider() != null ? details.getProvider().getProviderId() : null;
 
         if (commitTo == null || commitTo.isBlank()) {
+            return;
+        }
+
+        // An approval is granted for one repository on one provider, so the lookup must identify the
+        // repository the same way. Repo names like "app" and "common" recur across an estate; matching on
+        // the bare name would let an approval for acme/app satisfy a push to another org's app.
+        if (provider == null || owner == null || repoName == null) {
+            log.warn(
+                    "Not checking for prior approval: incomplete repository identity (provider={}, owner={}, repo={})",
+                    provider,
+                    owner,
+                    repoName);
             return;
         }
 
@@ -72,6 +86,8 @@ public class AllowApprovedPushFilter extends AbstractFogwallFilter {
         List<PushRecord> approved = pushStore.find(PushQuery.builder()
                 .commitTo(commitTo)
                 .branch(branch)
+                .provider(provider)
+                .project(owner)
                 .repoName(repoName)
                 .status(PushStatus.APPROVED)
                 .limit(1)

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/CheckUserPushPermissionFilter.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/CheckUserPushPermissionFilter.java
@@ -54,6 +54,11 @@ public class CheckUserPushPermissionFilter extends AbstractFogwallFilter {
     }
 
     @Override
+    public boolean skipWhenPreApproved() {
+        return false; // Whoever re-pushes approved content still has to be allowed to write here
+    }
+
+    @Override
     public void doHttpFilter(HttpServletRequest request, HttpServletResponse response) throws IOException {
         var requestDetails = (GitRequestDetails) request.getAttribute(GIT_REQUEST_ATTR);
         if (requestDetails == null) {

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/FogwallFilter.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/FogwallFilter.java
@@ -89,6 +89,15 @@ public interface FogwallFilter extends Filter {
         return true;
     }
 
+    /**
+     * Whether a prior approval for this content lets this filter be skipped. True for content validation, whose verdict
+     * an approval already covers. Authorization filters must override this to {@code false} — an approval says the
+     * content was judged acceptable, not that whoever is pushing it now may write to this repository.
+     */
+    default boolean skipWhenPreApproved() {
+        return true;
+    }
+
     @Override
     default void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
@@ -96,7 +105,7 @@ public interface FogwallFilter extends Filter {
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
         // Short-circuit if a prior filter pre-approved this push (e.g. AllowApprovedPushFilter)
-        if (Boolean.TRUE.equals(httpRequest.getAttribute(PRE_APPROVED_ATTR))) {
+        if (Boolean.TRUE.equals(httpRequest.getAttribute(PRE_APPROVED_ATTR)) && skipWhenPreApproved()) {
             chain.doFilter(request, response);
             return;
         }

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/UrlRuleAggregateFilter.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/UrlRuleAggregateFilter.java
@@ -66,6 +66,11 @@ public class UrlRuleAggregateFilter extends ProviderAwareFogwallFilter<FogwallPr
     }
 
     @Override
+    public boolean skipWhenPreApproved() {
+        return false; // Re-pushes must still match an allow rule
+    }
+
+    @Override
     public void doHttpFilter(HttpServletRequest request, HttpServletResponse response) throws IOException {
         var operation = determineOperation(request);
 

--- a/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/AllowApprovedPushFilterTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/AllowApprovedPushFilterTest.java
@@ -12,6 +12,7 @@ import com.rbc.fogwall.db.model.PushRecord;
 import com.rbc.fogwall.git.Commit;
 import com.rbc.fogwall.git.Contributor;
 import com.rbc.fogwall.git.GitRequestDetails;
+import com.rbc.fogwall.provider.GitHubProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.UUID;
@@ -29,13 +30,19 @@ class AllowApprovedPushFilterTest {
     }
 
     private static GitRequestDetails pushDetailsFor(String commitTo, String branch, String repoName) {
+        return pushDetailsFor(commitTo, branch, repoName, "owner", "github");
+    }
+
+    private static GitRequestDetails pushDetailsFor(
+            String commitTo, String branch, String repoName, String owner, String providerName) {
         GitRequestDetails details = new GitRequestDetails();
         details.setCommitTo(commitTo);
         details.setBranch(branch);
+        details.setProvider(GitHubProvider.builder().name(providerName).build());
         details.setRepoRef(GitRequestDetails.RepoRef.builder()
-                .owner("owner")
+                .owner(owner)
                 .name(repoName)
-                .slug("/owner/" + repoName)
+                .slug("/" + owner + "/" + repoName)
                 .build());
         details.getPushedCommits()
                 .add(Commit.builder()
@@ -73,6 +80,8 @@ class AllowApprovedPushFilterTest {
         PushRecord approved = PushRecord.builder()
                 .commitTo("deadbeef")
                 .branch("refs/heads/main")
+                .provider("github")
+                .project("owner")
                 .repoName("my-repo")
                 .build();
         store.save(approved);
@@ -113,6 +122,8 @@ class AllowApprovedPushFilterTest {
         PushRecord approved = PushRecord.builder()
                 .commitTo("aaaaaa")
                 .branch("refs/heads/main")
+                .provider("github")
+                .project("owner")
                 .repoName("repo")
                 .build();
         store.save(approved);
@@ -142,6 +153,8 @@ class AllowApprovedPushFilterTest {
         PushRecord approved = PushRecord.builder()
                 .commitTo("tagsha123")
                 .branch("refs/tags/v1.0")
+                .provider("github")
+                .project("owner")
                 .repoName("my-repo")
                 .build();
         store.save(approved);
@@ -159,6 +172,7 @@ class AllowApprovedPushFilterTest {
         GitRequestDetails details = new GitRequestDetails();
         details.setCommitTo("tagsha123");
         details.setBranch("refs/tags/v1.0");
+        details.setProvider(GitHubProvider.builder().name("github").build());
         details.setRepoRef(GitRequestDetails.RepoRef.builder()
                 .owner("owner")
                 .name("my-repo")
@@ -171,6 +185,81 @@ class AllowApprovedPushFilterTest {
         filter.doHttpFilter(req, resp);
 
         verify(req).setAttribute(PRE_APPROVED_ATTR, Boolean.TRUE);
+    }
+
+    /**
+     * The approval belongs to one repository on one provider. Repo names recur across an estate, so matching on the
+     * bare name alone would let an approval for one org's repo carry a push to another org's same-named repo.
+     */
+    @Test
+    void approvedRecordForSameRepoNameInAnotherOrg_doesNotSetPreApproved() throws Exception {
+        PushStore store = PushStoreFactory.h2InMemory("test-" + UUID.randomUUID());
+        PushRecord approved = PushRecord.builder()
+                .commitTo("deadbeef")
+                .branch("refs/heads/main")
+                .provider("github")
+                .project("acme")
+                .repoName("app")
+                .build();
+        store.save(approved);
+        store.approve(
+                approved.getId(),
+                Attestation.builder()
+                        .pushId(approved.getId())
+                        .type(Attestation.Type.APPROVAL)
+                        .reviewerUsername("admin")
+                        .build());
+
+        AllowApprovedPushFilter filter = new AllowApprovedPushFilter(store, "http://localhost:8080");
+        GitRequestDetails details = pushDetailsFor("deadbeef", "refs/heads/main", "app", "evil-org", "github");
+        HttpServletRequest req = mockPushRequest(details);
+
+        filter.doHttpFilter(req, mock(HttpServletResponse.class));
+
+        verify(req, never()).setAttribute(eq(PRE_APPROVED_ATTR), any());
+    }
+
+    /** Same owner and repo name, different configured provider — still a different repository. */
+    @Test
+    void approvedRecordOnAnotherProvider_doesNotSetPreApproved() throws Exception {
+        PushStore store = PushStoreFactory.h2InMemory("test-" + UUID.randomUUID());
+        PushRecord approved = PushRecord.builder()
+                .commitTo("deadbeef")
+                .branch("refs/heads/main")
+                .provider("github")
+                .project("acme")
+                .repoName("app")
+                .build();
+        store.save(approved);
+        store.approve(
+                approved.getId(),
+                Attestation.builder()
+                        .pushId(approved.getId())
+                        .type(Attestation.Type.APPROVAL)
+                        .reviewerUsername("admin")
+                        .build());
+
+        AllowApprovedPushFilter filter = new AllowApprovedPushFilter(store, "http://localhost:8080");
+        GitRequestDetails details = pushDetailsFor("deadbeef", "refs/heads/main", "app", "acme", "internal-gitea");
+        HttpServletRequest req = mockPushRequest(details);
+
+        filter.doHttpFilter(req, mock(HttpServletResponse.class));
+
+        verify(req, never()).setAttribute(eq(PRE_APPROVED_ATTR), any());
+    }
+
+    /** Without a full repository identity the lookup cannot be scoped, so it must not run at all. */
+    @Test
+    void missingProvider_skipsLookup() throws Exception {
+        PushStore store = mock(PushStore.class);
+        AllowApprovedPushFilter filter = new AllowApprovedPushFilter(store, "http://localhost:8080");
+        GitRequestDetails details = pushDetailsFor("deadbeef", "refs/heads/main", "app");
+        details.setProvider(null);
+        HttpServletRequest req = mockPushRequest(details);
+
+        filter.doHttpFilter(req, mock(HttpServletResponse.class));
+
+        verify(store, never()).find(any());
     }
 
     @Test

--- a/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/PreApprovedShortCircuitTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/PreApprovedShortCircuitTest.java
@@ -1,0 +1,80 @@
+package com.rbc.fogwall.servlet.filter;
+
+import static com.rbc.fogwall.servlet.FogwallServlet.GIT_REQUEST_ATTR;
+import static com.rbc.fogwall.servlet.FogwallServlet.PRE_APPROVED_ATTR;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.rbc.fogwall.git.GitRequestDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A prior approval is a judgement about content, so it may stand in for content validation. It says nothing about
+ * whether the person re-pushing that content is allowed to write here, so authorization filters must still run.
+ */
+class PreApprovedShortCircuitTest {
+
+    private static class RecordingFilter extends AbstractFogwallFilter {
+        final AtomicBoolean ran = new AtomicBoolean(false);
+        private final boolean skipWhenPreApproved;
+
+        RecordingFilter(boolean skipWhenPreApproved) {
+            super(100);
+            this.skipWhenPreApproved = skipWhenPreApproved;
+        }
+
+        @Override
+        public boolean skipWhenPreApproved() {
+            return skipWhenPreApproved;
+        }
+
+        @Override
+        public void doHttpFilter(HttpServletRequest request, HttpServletResponse response) {
+            ran.set(true);
+        }
+    }
+
+    private static HttpServletRequest preApprovedPushRequest() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getContentType()).thenReturn("application/x-git-receive-pack-request");
+        when(req.getRequestURI()).thenReturn("/proxy/github.com/owner/repo.git/git-receive-pack");
+        when(req.getAttribute(PRE_APPROVED_ATTR)).thenReturn(Boolean.TRUE);
+        when(req.getAttribute(GIT_REQUEST_ATTR)).thenReturn(new GitRequestDetails());
+        when(req.getHeaderNames()).thenReturn(java.util.Collections.emptyEnumeration());
+        return req;
+    }
+
+    @Test
+    void contentFilterIsSkippedWhenPreApproved() throws Exception {
+        RecordingFilter filter = new RecordingFilter(true);
+
+        filter.doFilter(preApprovedPushRequest(), mock(HttpServletResponse.class), mock(FilterChain.class));
+
+        assertFalse(filter.ran.get(), "A content filter's verdict is covered by the approval");
+    }
+
+    @Test
+    void authorizationFilterStillRunsWhenPreApproved() throws Exception {
+        RecordingFilter filter = new RecordingFilter(false);
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(preApprovedPushRequest(), mock(HttpServletResponse.class), chain);
+
+        assertTrue(filter.ran.get(), "Authorization is not something an approval can grant");
+        verify(chain).doFilter(any(), any());
+    }
+
+    @Test
+    void authorizationFiltersOptOutOfTheShortCircuit() {
+        assertFalse(
+                new CheckUserPushPermissionFilter(null, null).skipWhenPreApproved(),
+                "CheckUserPushPermissionFilter must re-check the pusher on a pre-approved re-push");
+        assertFalse(
+                new UrlRuleAggregateFilter(100, null, null).skipWhenPreApproved(),
+                "UrlRuleAggregateFilter must re-check the repository on a pre-approved re-push");
+    }
+}


### PR DESCRIPTION
Transparent proxy recognises an already-approved re-push by looking up an `APPROVED` record for the same commit and branch. It also matched on repository — but only on `RepoRef.getName()`, the bare name, with no owner and no provider.

**What that allowed**

An approval granted for `acme/app` at commit X on `main` also satisfied a push of commit X to `main` of **any** repository named `app`, under any owner, on any configured provider. Names like `app`, `api`, `common` and `platform` recur constantly across an estate.

Being recognised as pre-approved then short-circuited every remaining `FogwallFilter` — including `CheckUserPushPermissionFilter` and the URL rule filter. So the replay reused someone else's review *and* skipped the check for whether the pusher may write there at all.

The upstream push still authenticates with the client's own credentials, so this was never upstream privilege escalation. What was bypassable was fogwall's own layer — and an approval is a contextual judgement (a dependency sanctioned for one product, a reviewer who assessed one repo's risk profile) that doesn't transfer.

Store-and-forward doesn't have this: `ApprovalPreReceiveHook` checks the record found by `validationRecordId`, which is the record for *this* push.

**Changes**

- `AllowApprovedPushFilter` identifies the repository fully — provider, owner and name — and declines to run the lookup at all when any of the three is missing, rather than matching on a partial identity.
- `PushQuery` gains a `provider` field, implemented in `JdbcPushStore.buildWhere` and `MongoPushStore` (additive; existing callers unaffected).
- New `FogwallFilter.skipWhenPreApproved()`, defaulting to `true`. Content validation may stand down for approved content; authorization cannot. `CheckUserPushPermissionFilter` and `UrlRuleAggregateFilter` override it to `false`.

**Tests**

`AllowApprovedPushFilterTest` — replay across orgs, replay across providers, and the incomplete-identity guard. Existing fixtures updated to carry a full repository identity. New `PreApprovedShortCircuitTest` covers the short-circuit itself in both directions plus the two real authorization filters' opt-out.

**Not addressed here** — approvals still have no TTL, and are not bound to the principal they were granted for. Both are product decisions rather than key-scoping bugs; the principal binding in particular can't be done at this filter's order, since identity isn't resolved until order 150.
