### PR TITLE
fix(config): let codeberg provider use a configured SSH uri

### DIFF
--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
@@ -1048,8 +1048,9 @@ public class JettyConfigurationBuilder {
             case "codeberg" -> {
                 return Optional.of(ForgejoProvider.builder()
                         .name(name)
-                        .uri(ForgejoProvider.CODEBERG)
+                        .uri(parsedUri != null ? parsedUri : ForgejoProvider.CODEBERG)
                         .pathSuffix(pathSuffix)
+                        .apiUri(parsedApiUri)
                         .apiToken(apiToken)
                         .build());
             }

--- a/fogwall-server/src/test/java/com/rbc/fogwall/jetty/config/JettyConfigurationBuilderTest.java
+++ b/fogwall-server/src/test/java/com/rbc/fogwall/jetty/config/JettyConfigurationBuilderTest.java
@@ -349,6 +349,18 @@ class JettyConfigurationBuilderTest {
     }
 
     @Test
+    void createProvider_codebergKey_withSshUri_usesCustomUri() {
+        // Regression test: codeberg previously ignored any configured uri and hardcoded the HTTPS default, which
+        // meant codeberg could never be used as an SSH provider (isHttpProvider() would always see https://).
+        var pc = new ProviderConfig();
+        pc.setUri("ssh://git@codeberg.org");
+        var providers = new JettyConfigurationBuilder(configWithSingleProvider("codeberg", pc)).buildProviders();
+        assertEquals(1, providers.size());
+        assertInstanceOf(ForgejoProvider.class, providers.get(0));
+        assertEquals(URI.create("ssh://git@codeberg.org"), providers.get(0).getUri());
+    }
+
+    @Test
     void createProvider_giteaKey_noUri_defaultsToGiteaCom() {
         var providers =
                 new JettyConfigurationBuilder(configWithSingleProvider("gitea", new ProviderConfig())).buildProviders();


### PR DESCRIPTION
## Summary
- The `codeberg` branch of `JettyConfigurationBuilder.createProvider()` always hardcoded `ForgejoProvider.CODEBERG` (`https://codeberg.org`) and never wired `apiUri`, so any configured `ssh://` uri was silently discarded.
- This is the same class of bug #447 fixed for gitea/gitlab/bitbucket, just missed for codeberg — meaning codeberg could never actually be used as an SSH provider.
- Fix: fall back to `ForgejoProvider.CODEBERG` only when no uri is configured, and pass through `apiUri` like the other providers.

## Test plan
- [x] Added regression test `createProvider_codebergKey_withSshUri_usesCustomUri`
- [x] `./gradlew :fogwall-server:test --tests "com.rbc.fogwall.jetty.config.JettyConfigurationBuilderTest" --rerun` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)