### PR TITLE
fix(proxy): cap push size and refuse Git LFS uploads

### DIFF
--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -758,6 +758,38 @@ proxy_request_buffering on;
 client_max_body_size 500m;
 ```
 
+### Sizing memory for pushes
+
+fogwall buffers each request body in memory for the life of the request, in both proxy modes — validation needs the
+whole pack before it can decide anything. Two settings bound that, and they multiply:
+
+| Setting                          | Default | Bounds                        |
+| -------------------------------- | ------- | ----------------------------- |
+| `server.max-push-bytes`          | 256 MiB | how large one push may be     |
+| `server.max-concurrent-requests` | 512     | how many run at the same time |
+
+The worst case is `max-push-bytes × concurrent large pushes`, so **raising `max-push-bytes` means raising the
+container's memory limit to match.** Do not set JVM heap flags to compensate: fogwall's image deliberately ships without
+`-Xmx` so the JVM sizes its heap from the container's cgroup limit (about 25% of it by default). Setting `-Xmx` yourself
+overrides that and pins the heap regardless of how the container is sized. Give the container more memory instead.
+
+A push over the limit is rejected before the body is read, so it costs no memory and the developer gets a clear message
+naming the limit rather than a timeout or a connection reset.
+
+**Interaction with `http.postBuffer`.** The client workaround above raises the threshold at which git switches to
+chunked encoding; it does not change how large a push may be. A push under `http.postBuffer` declares a
+`Content-Length`, which lets fogwall reject an over-size push without reading anything. Above it, the push is chunked
+and fogwall counts bytes as they arrive instead. Both paths enforce the same limit.
+
+**If 256 MiB is too small for your estate**, prefer these over raising the limit:
+
+- Seed one-off imports and repository migrations directly upstream, then let the proxy handle incremental pushes. A
+  migration is a coordinated, one-time event and does not need to be self-service.
+- Push large histories in stages — older commits first, then newer.
+- Keep large binaries out of git history in the first place. Note that **Git LFS is not currently supported through
+  fogwall** (see the User Guide); LFS uploads are refused because fogwall cannot inspect content that travels outside
+  the git protocol.
+
 ---
 
 ## Production checklist

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -143,6 +143,15 @@ server:
   # platform thread pool, capped by its own size).
   max-concurrent-requests: 512
 
+  # Largest request body fogwall will accept, in bytes. Applies to both proxy modes.
+  # An over-size push is rejected with a git error before the body is read, so it
+  # costs no memory. Set to 0 to disable the check — note that "unlimited" is still
+  # bounded by heap in practice, and absolutely by ~2GiB, since the body is buffered
+  # as a single array.
+  # Raising this needs a matching increase in container memory: the real bound is heap
+  # divided by concurrent pushes. See "Sizing memory for pushes" in the Admin Guide.
+  max-push-bytes: 268435456 # 256MiB
+
   # Base URL of the dashboard, used in links sent to clients via sideband messages.
   # Should include the /dashboard path prefix.
   # Defaults to http://localhost:<port>/dashboard if not set.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -536,6 +536,43 @@ time.
 
 Standard git error — the branch name in your push command does not match a local branch. Not a proxy issue.
 
+### Push blocked as too large
+
+fogwall accepts pushes up to a configured size — 256 MiB by default. Over that, the push is refused before any data is
+read:
+
+```text
+remote: ⛔  Push Blocked - Too Large
+remote: ❌  This push is 512 MiB; the limit is 256 MiB.
+```
+
+A push this large is usually one of three things: a binary or archive committed by mistake, generated build output that
+should be in `.gitignore`, or a large file's entire history still present after it was deleted in a later commit (git
+keeps every version). Check what is actually big:
+
+```shell
+git count-objects -vH
+git rev-list --objects --all | git cat-file --batch-check='%(objecttype) %(objectname) %(objectsize) %(rest)' \
+  | awk '$1=="blob" {print $3, $4}' | sort -rn | head
+```
+
+If the content genuinely belongs in the repository — a first push of a long-lived history, for example — talk to your
+administrator rather than trying to split it. A one-time import is normally seeded directly upstream instead of pushed
+through the proxy.
+
+### Git LFS pushes are rejected
+
+```text
+Git LFS is not supported through fogwall at this time.
+```
+
+Git LFS moves file content outside the git protocol, so fogwall never sees the bytes and cannot make any statement about
+them — secret scanning, content checks, and diff review would all inspect the small pointer file instead of the real
+content. Rather than pass content it cannot inspect, fogwall refuses the upload.
+
+Cloning and fetching repositories that already contain LFS objects is unaffected; only uploads are refused. If you need
+LFS for a repository, raise it with your administrator.
+
 ---
 
 ## Tips

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/PushTooLargeException.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/PushTooLargeException.java
@@ -1,0 +1,24 @@
+package com.rbc.fogwall.servlet;
+
+import java.io.IOException;
+import lombok.Getter;
+
+/**
+ * Thrown when a request body exceeds the configured maximum. Extends {@link IOException} so it propagates out of the
+ * servlet read path without widening any signatures; callers that want to report the limit to the client catch it
+ * specifically.
+ */
+@Getter
+public class PushTooLargeException extends IOException {
+
+    private final long limitBytes;
+
+    /** Bytes read before the limit was exceeded. Not the full body size — reading stops at the limit. */
+    private final long bytesRead;
+
+    public PushTooLargeException(long limitBytes, long bytesRead) {
+        super("Request body exceeds the configured maximum of " + limitBytes + " bytes");
+        this.limitBytes = limitBytes;
+        this.bytesRead = bytesRead;
+    }
+}

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/RequestBodyWrapper.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/RequestBodyWrapper.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -16,23 +17,54 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 public class RequestBodyWrapper extends HttpServletRequestWrapper {
 
+    /** Largest body this class can hold, since the body is a single array. */
+    public static final long ABSOLUTE_MAX_BYTES = Integer.MAX_VALUE - 8L;
+
+    private static final int CHUNK_SIZE = 64 * 1024;
+
     private final byte[] body;
 
-    /**
-     * Constructs a request object wrapping the given request.
-     *
-     * @param request The request to wrap
-     * @throws IllegalArgumentException if the request is null
-     */
+    /** Wraps {@code request}, buffering its body with no size limit. */
     public RequestBodyWrapper(HttpServletRequest request) throws IOException {
+        this(request, 0);
+    }
+
+    /**
+     * Wraps {@code request}, buffering its body up to {@code maxBytes}.
+     *
+     * @param maxBytes size limit in bytes; 0 means no configured limit, in which case {@link #ABSOLUTE_MAX_BYTES} still
+     *     applies because the body is held as one array
+     * @throws PushTooLargeException if the body exceeds the limit. Reading stops at that point rather than draining the
+     *     rest, so an over-size body costs only the limit in heap and not its full size.
+     */
+    public RequestBodyWrapper(HttpServletRequest request, long maxBytes) throws IOException {
         super(request);
+        long limit = maxBytes > 0 ? Math.min(maxBytes, ABSOLUTE_MAX_BYTES) : ABSOLUTE_MAX_BYTES;
         InputStream inputStream = request.getInputStream();
-        if (inputStream != null) {
-            body = inputStream.readAllBytes();
-        } else {
-            body = new byte[0];
-        }
+        body = inputStream != null ? readUpTo(inputStream, limit) : new byte[0];
         log.debug("RequestBodyWrapper: Content-Length={}, cached {} bytes", request.getContentLength(), body.length);
+    }
+
+    /**
+     * Reads {@code in} fully, failing as soon as more than {@code limit} bytes have arrived.
+     *
+     * <p>{@code Content-Length} is checked separately and earlier, but it cannot be relied on alone: git clients send
+     * push bodies with chunked transfer encoding, where no length is declared up front. This counting read is what
+     * actually bounds the allocation.
+     */
+    private static byte[] readUpTo(InputStream in, long limit) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] chunk = new byte[CHUNK_SIZE];
+        long total = 0;
+        int read;
+        while ((read = in.read(chunk)) != -1) {
+            total += read;
+            if (total > limit) {
+                throw new PushTooLargeException(limit, total);
+            }
+            buffer.write(chunk, 0, read);
+        }
+        return buffer.toByteArray();
     }
 
     @Override

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/LfsRejectionFilter.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/LfsRejectionFilter.java
@@ -1,0 +1,97 @@
+package com.rbc.fogwall.servlet.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Predicate;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Refuses Git LFS uploads, which fogwall cannot inspect.
+ *
+ * <p>LFS transfers file content out-of-band over its own HTTP API and leaves only a small text pointer in the pack, so
+ * every content filter in the chain would inspect the pointer and pass it while the actual bytes travelled a path
+ * fogwall never sees. Until LFS is modelled properly, refusing the upload is the honest answer: fogwall cannot make a
+ * statement about content it never received.
+ *
+ * <p>Downloads are deliberately allowed. Their request body is a small JSON document, and content validation applies to
+ * pushes rather than fetches, so blocking them would break clones of any repository that has ever used LFS without
+ * gaining anything.
+ *
+ * <p>Runs at {@link Integer#MIN_VALUE}, ahead of {@code ParseGitRequestFilter}, because that filter buffers the request
+ * body as its first action. Placed any later, an LFS upload would be read into heap before being refused.
+ */
+@Slf4j
+public class LfsRejectionFilter implements FogwallFilter {
+
+    /** Every LFS endpoint lives under this path segment, relative to the repository. */
+    private static final String LFS_PATH_SEGMENT = "/info/lfs/";
+
+    private static final String MEDIA_TYPE = "application/vnd.git-lfs+json";
+
+    private static final String MESSAGE = "Git LFS is not supported through fogwall at this time. "
+            + "LFS transfers file content outside the git protocol, so fogwall cannot validate it. "
+            + "Push the file directly instead, or contact an administrator if you need LFS for this repository.";
+
+    @Override
+    public int getOrder() {
+        return Integer.MIN_VALUE;
+    }
+
+    @Override
+    public Predicate<HttpServletRequest> shouldFilter() {
+        return LfsRejectionFilter::isLfsUpload;
+    }
+
+    /**
+     * Overridden because the inherited implementation calls {@code determineOperation}, which recognises only the three
+     * smart-HTTP operations and throws for anything else — an LFS request included.
+     */
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        if (!isLfsUpload(httpRequest)) {
+            chain.doFilter(request, response);
+            return;
+        }
+        reject(httpRequest, (HttpServletResponse) response);
+    }
+
+    @Override
+    public void doHttpFilter(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        reject(request, response);
+    }
+
+    /**
+     * An upload is anything under the LFS path that is not a download. The batch endpoint declares its intent in a JSON
+     * body we would have to read to inspect, so the direction is inferred from the method and path instead: GET is
+     * always a read, and object PUTs are always writes. A batch POST is treated as an upload because letting it through
+     * would only earn the client a rejection one request later, after it had negotiated hrefs.
+     */
+    private static boolean isLfsUpload(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        if (uri == null || !uri.contains(LFS_PATH_SEGMENT)) return false;
+        return !"GET".equalsIgnoreCase(request.getMethod());
+    }
+
+    /**
+     * Answers in the LFS client's own dialect. The batch API is plain JSON over HTTP rather than the git wire protocol,
+     * so a sideband packet would not render — git-lfs surfaces the {@code message} field to the user.
+     */
+    private void reject(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        log.warn("Refusing Git LFS upload: {} {}", request.getMethod(), request.getRequestURI());
+        if (response.isCommitted()) return;
+
+        byte[] payload = ("{\"message\":\"" + MESSAGE + "\"}").getBytes(StandardCharsets.UTF_8);
+        response.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
+        response.setContentType(MEDIA_TYPE);
+        response.setContentLength(payload.length);
+        response.getOutputStream().write(payload);
+    }
+}

--- a/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/ParseGitRequestFilter.java
+++ b/fogwall-core/src/main/java/com/rbc/fogwall/servlet/filter/ParseGitRequestFilter.java
@@ -11,6 +11,7 @@ import com.rbc.fogwall.git.GitRequestDetails;
 import com.rbc.fogwall.git.HttpOperation;
 import com.rbc.fogwall.git.RepoSlugValidator;
 import com.rbc.fogwall.provider.FogwallProvider;
+import com.rbc.fogwall.servlet.PushTooLargeException;
 import com.rbc.fogwall.servlet.RequestBodyWrapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -33,8 +34,16 @@ public class ParseGitRequestFilter extends ProviderAwareFogwallFilter<FogwallPro
 
     private static final int ORDER = Integer.MIN_VALUE + 1;
 
+    private final long maxPushBytes;
+
     public ParseGitRequestFilter(FogwallProvider provider) {
+        this(provider, 0);
+    }
+
+    /** @param maxPushBytes largest request body to accept, in bytes; 0 disables the check */
+    public ParseGitRequestFilter(FogwallProvider provider, long maxPushBytes) {
         super(ORDER, provider);
+        this.maxPushBytes = maxPushBytes;
     }
 
     @Override
@@ -42,8 +51,23 @@ public class ParseGitRequestFilter extends ProviderAwareFogwallFilter<FogwallPro
             throws IOException, ServletException {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
 
+        // Cheap pre-check: reject a declared over-size body without reading it at all. Clients using chunked
+        // encoding declare no length, so this is an optimisation and the wrapper's counting read is the
+        // actual bound.
+        long declared = httpRequest.getContentLengthLong();
+        if (maxPushBytes > 0 && declared > maxPushBytes) {
+            sendTooLarge(httpRequest, (HttpServletResponse) response, maxPushBytes, declared);
+            return;
+        }
+
         // Create the wrapper to capture the body
-        RequestBodyWrapper wrapper = new RequestBodyWrapper(httpRequest);
+        RequestBodyWrapper wrapper;
+        try {
+            wrapper = new RequestBodyWrapper(httpRequest, maxPushBytes);
+        } catch (PushTooLargeException e) {
+            sendTooLarge(httpRequest, (HttpServletResponse) response, e.getLimitBytes(), -1);
+            return;
+        }
 
         // Parse the git request details
         GitRequestDetails requestDetails = parse(wrapper);
@@ -75,6 +99,38 @@ public class ParseGitRequestFilter extends ProviderAwareFogwallFilter<FogwallPro
     @Override
     public void doHttpFilter(HttpServletRequest request, HttpServletResponse response) throws IOException {
         // no-op
+    }
+
+    /**
+     * Reports an over-size body to the git client.
+     *
+     * <p>Sent via {@code sendGitError} rather than an HTTP 413 because git only surfaces protocol-level errors to the
+     * user; a bare status code produces an opaque failure. {@code declared} is the client's {@code Content-Length}, or
+     * -1 when the limit was hit mid-read and the true size is unknown.
+     */
+    private void sendTooLarge(HttpServletRequest request, HttpServletResponse response, long limitBytes, long declared)
+            throws IOException {
+        log.warn(
+                "Rejecting request body over the {}-byte limit (declared {}): {}",
+                limitBytes,
+                declared >= 0 ? declared : "unknown, chunked",
+                request.getRequestURI());
+        String title = sym(NO_ENTRY) + "  Push Blocked - Too Large";
+        String sizeLine = declared >= 0
+                ? sym(CROSS_MARK) + "  This push is " + humanReadable(declared) + "; the limit is "
+                        + humanReadable(limitBytes) + "."
+                : sym(CROSS_MARK) + "  This push exceeds the " + humanReadable(limitBytes) + " limit.";
+        String message = sizeLine + "\n\n"
+                + "Large files usually mean binaries or generated output that don't belong in git history.\n"
+                + "If the content is genuinely needed, contact an administrator — a one-off import is normally\n"
+                + "seeded directly upstream rather than pushed through the proxy.";
+        sendGitError(request, response, GitClientUtils.format(title, message, RED, null));
+    }
+
+    private static String humanReadable(long bytes) {
+        if (bytes >= 1024L * 1024L * 1024L) return String.format("%.1f GiB", bytes / (1024.0 * 1024 * 1024));
+        if (bytes >= 1024L * 1024L) return String.format("%.0f MiB", bytes / (1024.0 * 1024));
+        return bytes + " bytes";
     }
 
     /**

--- a/fogwall-core/src/test/java/com/rbc/fogwall/servlet/RequestBodyWrapperTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/servlet/RequestBodyWrapperTest.java
@@ -1,0 +1,97 @@
+package com.rbc.fogwall.servlet;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class RequestBodyWrapperTest {
+
+    private static HttpServletRequest requestWithBody(byte[] body) throws IOException {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        ByteArrayInputStream backing = new ByteArrayInputStream(body);
+        when(req.getInputStream()).thenReturn(new ServletInputStream() {
+            @Override
+            public int read() {
+                return backing.read();
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) {
+                return backing.read(b, off, len);
+            }
+
+            @Override
+            public boolean isFinished() {
+                return backing.available() == 0;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener listener) {}
+        });
+        return req;
+    }
+
+    @Test
+    void bodyUnderTheLimitIsBufferedIntact() throws Exception {
+        byte[] body = new byte[1024];
+        for (int i = 0; i < body.length; i++) body[i] = (byte) i;
+
+        RequestBodyWrapper wrapper = new RequestBodyWrapper(requestWithBody(body), 4096);
+
+        assertArrayEquals(body, wrapper.getBody());
+    }
+
+    @Test
+    void bodyExactlyAtTheLimitIsAccepted() throws Exception {
+        byte[] body = new byte[2048];
+
+        RequestBodyWrapper wrapper = new RequestBodyWrapper(requestWithBody(body), 2048);
+
+        assertEquals(2048, wrapper.getBody().length);
+    }
+
+    @Test
+    void bodyOverTheLimitIsRejected() throws Exception {
+        HttpServletRequest req = requestWithBody(new byte[5000]);
+
+        PushTooLargeException e = assertThrows(PushTooLargeException.class, () -> new RequestBodyWrapper(req, 2048));
+
+        assertEquals(2048, e.getLimitBytes());
+    }
+
+    /** A chunked push declares no Content-Length, so the counting read is the only thing that can bound it. */
+    @Test
+    void limitAppliesWithNoContentLengthDeclared() throws Exception {
+        HttpServletRequest req = requestWithBody(new byte[300_000]);
+        when(req.getContentLengthLong()).thenReturn(-1L);
+
+        assertThrows(PushTooLargeException.class, () -> new RequestBodyWrapper(req, 65_536));
+    }
+
+    @Test
+    void zeroMeansNoConfiguredLimit() throws Exception {
+        byte[] body = new byte[300_000];
+
+        RequestBodyWrapper wrapper = new RequestBodyWrapper(requestWithBody(body), 0);
+
+        assertEquals(300_000, wrapper.getBody().length);
+    }
+
+    @Test
+    void emptyBodyIsFine() throws Exception {
+        RequestBodyWrapper wrapper = new RequestBodyWrapper(requestWithBody(new byte[0]), 2048);
+
+        assertEquals(0, wrapper.getBody().length);
+    }
+}

--- a/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/LfsRejectionFilterTest.java
+++ b/fogwall-core/src/test/java/com/rbc/fogwall/servlet/filter/LfsRejectionFilterTest.java
@@ -1,0 +1,119 @@
+package com.rbc.fogwall.servlet.filter;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class LfsRejectionFilterTest {
+
+    private static HttpServletRequest request(String method, String uri) {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getMethod()).thenReturn(method);
+        when(req.getRequestURI()).thenReturn(uri);
+        return req;
+    }
+
+    private static ServletOutputStream capturing(ByteArrayOutputStream sink) {
+        return new ServletOutputStream() {
+            @Override
+            public void write(int b) {
+                sink.write(b);
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setWriteListener(WriteListener listener) {}
+        };
+    }
+
+    @Test
+    void runsBeforeTheBodyIsBuffered() {
+        assertEquals(
+                Integer.MIN_VALUE,
+                new LfsRejectionFilter().getOrder(),
+                "Must precede ParseGitRequestFilter at MIN_VALUE + 1, which buffers the body first");
+    }
+
+    @Test
+    void batchUploadRequestIsRejected() throws Exception {
+        var out = new ByteArrayOutputStream();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        when(resp.getOutputStream()).thenReturn(capturing(out));
+        FilterChain chain = mock(FilterChain.class);
+
+        new LfsRejectionFilter()
+                .doFilter(request("POST", "/proxy/github.com/acme/app.git/info/lfs/objects/batch"), resp, chain);
+
+        verify(resp).setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
+        verify(resp).setContentType("application/vnd.git-lfs+json");
+        verify(chain, never()).doFilter(any(), any());
+        String body = out.toString(StandardCharsets.UTF_8);
+        assertTrue(body.contains("\"message\""), "git-lfs surfaces the message field: " + body);
+        assertTrue(body.contains("not supported"), body);
+    }
+
+    @Test
+    void objectUploadPutIsRejected() throws Exception {
+        var out = new ByteArrayOutputStream();
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        when(resp.getOutputStream()).thenReturn(capturing(out));
+        FilterChain chain = mock(FilterChain.class);
+
+        new LfsRejectionFilter()
+                .doFilter(request("PUT", "/proxy/github.com/acme/app.git/info/lfs/objects/abc123"), resp, chain);
+
+        verify(resp).setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    /** Downloads carry a small JSON body and are not content-validated, so refusing them would only break clones. */
+    @Test
+    void lfsDownloadIsAllowedThrough() throws Exception {
+        FilterChain chain = mock(FilterChain.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+
+        new LfsRejectionFilter()
+                .doFilter(request("GET", "/proxy/github.com/acme/app.git/info/lfs/objects/abc123"), resp, chain);
+
+        verify(chain).doFilter(any(), any());
+        verify(resp, never()).setStatus(anyInt());
+    }
+
+    @Test
+    void ordinaryGitRequestsPassThroughUntouched() throws Exception {
+        FilterChain chain = mock(FilterChain.class);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+
+        new LfsRejectionFilter()
+                .doFilter(request("POST", "/proxy/github.com/acme/app.git/git-receive-pack"), resp, chain);
+
+        verify(chain).doFilter(any(), any());
+        verify(resp, never()).setStatus(anyInt());
+    }
+
+    /** The filter must not consult determineOperation, which throws for any non-smart-HTTP request. */
+    @Test
+    void infoRefsIsNotMistakenForLfs() throws Exception {
+        FilterChain chain = mock(FilterChain.class);
+
+        new LfsRejectionFilter()
+                .doFilter(
+                        request("GET", "/proxy/github.com/acme/app.git/info/refs"),
+                        mock(HttpServletResponse.class),
+                        chain);
+
+        verify(chain).doFilter(any(), any());
+    }
+}

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/JettyConfigurationBuilder.java
@@ -120,6 +120,11 @@ public class JettyConfigurationBuilder {
         return config.getServer().getMaxConcurrentRequests();
     }
 
+    /** Returns the maximum accepted request body size in bytes (0 = no configured limit). */
+    public long getMaxPushBytes() {
+        return config.getServer().getMaxPushBytes();
+    }
+
     /** Returns the S&amp;F upstream connect timeout in seconds (0 = no timeout). */
     public int getUpstreamConnectTimeoutSeconds() {
         return config.getServer().getUpstreamConnectTimeoutSeconds();
@@ -500,6 +505,7 @@ public class JettyConfigurationBuilder {
                 getHeartbeatIntervalSeconds(),
                 getApprovalTimeoutSeconds(),
                 isFailFast(),
+                getMaxPushBytes(),
                 getUpstreamConnectTimeoutSeconds(),
                 getProxyConnectTimeoutSeconds(),
                 storeForwardCache,

--- a/fogwall-server/src/main/java/com/rbc/fogwall/config/ServerConfig.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/config/ServerConfig.java
@@ -58,6 +58,20 @@ public class ServerConfig {
     private int maxConcurrentRequests = 512;
 
     /**
+     * Maximum size in bytes of a request body fogwall will accept, applied to both proxy modes. Pushes over the limit
+     * are rejected with a git error before the body is read, so an over-size push costs no heap.
+     *
+     * <p>Defaults to 256 MiB. This is a resource bound rather than a policy check, so unlike the {@code *Settings}
+     * classes it defaults to an active value: a config that omits the key still gets protection. Set to 0 to disable
+     * the check, but note that "unlimited" is bounded by heap in practice and by {@code Integer.MAX_VALUE - 8}
+     * absolutely, since the body is held as a single {@code byte[]}.
+     *
+     * <p>The real bound on push size is heap divided by concurrent pushes, so raising this should come with a matching
+     * increase to the container memory limit — see {@link #getMaxConcurrentRequests()}.
+     */
+    private long maxPushBytes = 268435456L;
+
+    /**
      * Connection timeout in seconds for store-and-forward upstream pushes
      * ({@link org.eclipse.jgit.transport.Transport#setTimeout}). Set to 0 to use JGit's default (no timeout).
      * Enterprises with slow or inspecting middleboxes should set this to a generous value (e.g. 120) rather than

--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallContext.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallContext.java
@@ -36,6 +36,7 @@ public record FogwallContext(
         int heartbeatIntervalSeconds,
         int approvalTimeoutSeconds,
         boolean failFast,
+        long maxPushBytes,
         int upstreamConnectTimeoutSeconds,
         int proxyConnectTimeoutSeconds,
         LocalRepositoryCache storeForwardCache,

--- a/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallServletRegistrar.java
+++ b/fogwall-server/src/main/java/com/rbc/fogwall/jetty/FogwallServletRegistrar.java
@@ -105,6 +105,7 @@ public final class FogwallServletRegistrar {
                         fogwallContext.heartbeatIntervalSeconds(),
                         fogwallContext.approvalTimeoutSeconds(),
                         fogwallContext.failFast(),
+                        fogwallContext.maxPushBytes(),
                         fogwallContext.upstreamConnectTimeoutSeconds(),
                         fogwallContext.urlRuleRegistry(),
                         fogwallContext.fetchStore());
@@ -194,6 +195,7 @@ public final class FogwallServletRegistrar {
             int heartbeatIntervalSeconds,
             int approvalTimeoutSeconds,
             boolean failFast,
+            long maxPushBytes,
             int connectTimeoutSeconds,
             UrlRuleRegistry urlRuleRegistry,
             FetchStore fetchStore) {
@@ -231,12 +233,15 @@ public final class FogwallServletRegistrar {
         holder.setName("git-" + provider.getName());
         context.addServlet(holder, pushMapping);
 
+        context.addFilter(new FilterHolder(new LfsRejectionFilter()), pushMapping, EnumSet.of(DispatcherType.REQUEST));
         context.addFilter(
                 new FilterHolder(new SmartHttpErrorFilter()), pushMapping, EnumSet.of(DispatcherType.REQUEST));
         context.addFilter(
                 new FilterHolder(new BasicAuthChallengeFilter()), pushMapping, EnumSet.of(DispatcherType.REQUEST));
         context.addFilter(
-                new FilterHolder(new ParseGitRequestFilter(provider)), pushMapping, EnumSet.of(DispatcherType.REQUEST));
+                new FilterHolder(new ParseGitRequestFilter(provider, maxPushBytes)),
+                pushMapping,
+                EnumSet.of(DispatcherType.REQUEST));
         context.addFilter(
                 new FilterHolder(new UrlRuleAggregateFilter(100, provider, fetchStore, urlRuleRegistry)),
                 pushMapping,
@@ -296,6 +301,12 @@ public final class FogwallServletRegistrar {
         String urlPattern = PROXY_PATH_PREFIX + provider.servletPath() + "/*";
 
         // PushStoreAuditFilter wraps the entire chain via try-finally; must be registered first.
+        // Ahead of everything, including PushStoreAuditFilter: an LFS upload is refused before any body is read
+        // and before a push record is opened for a request fogwall will not process.
+        var lfsRejectionHolder = new FilterHolder(new LfsRejectionFilter());
+        lfsRejectionHolder.setAsyncSupported(true);
+        context.addFilter(lfsRejectionHolder, urlPattern, EnumSet.of(DispatcherType.REQUEST));
+
         var pushStoreAuditFilterHolder = new FilterHolder(new PushStoreAuditFilter(pushStore));
         pushStoreAuditFilterHolder.setAsyncSupported(true);
         context.addFilter(pushStoreAuditFilterHolder, urlPattern, EnumSet.of(DispatcherType.REQUEST));
@@ -303,7 +314,7 @@ public final class FogwallServletRegistrar {
         // Build the orderable filter list. Sorted by getOrder() before registration so the Jetty chain
         // execution order matches the documented order ranges in fogwallFilter.
         List<FogwallFilter> filters = new ArrayList<>();
-        filters.add(new ParseGitRequestFilter(provider));
+        filters.add(new ParseGitRequestFilter(provider, configBuilder.getMaxPushBytes()));
         filters.add(new EnrichPushCommitsFilter(provider, repositoryCache));
         filters.add(new AllowApprovedPushFilter(pushStore, serviceUrl));
 

--- a/fogwall-server/src/main/resources/fogwall.yml
+++ b/fogwall-server/src/main/resources/fogwall.yml
@@ -18,6 +18,13 @@ server:
   # to heap capacity and typical pack size — prefer adding instances over raising this limit when scaling out.
   # Set to 0 to disable virtual-thread dispatch (requests then run directly on the platform thread pool).
   max-concurrent-requests: 512
+  # Largest request body fogwall will accept, in bytes (default 256MiB). Applies to both proxy modes. An
+  # over-size push is rejected with a git error before the body is read, so it costs no memory. Content this
+  # large is almost always binaries or generated output that shouldn't be in git history; a genuine one-off
+  # import is better seeded directly upstream than pushed through the proxy.
+  # Raising this needs a matching increase in container memory — see max-concurrent-requests above, since the
+  # real bound is heap divided by concurrent pushes. Set to 0 to disable the check (still bounded by heap).
+  max-push-bytes: 268435456
   # HTTP session persistence backend. Options:
   #   none   — in-memory sessions (default); sessions are lost on restart and not shared across instances
   #   jdbc   — persisted to the configured JDBC database (h2-file or postgres);


### PR DESCRIPTION
## What was wrong

A push through either proxy mode was read into memory in full, with no limit. One large push could exhaust the heap and take the proxy down; a push over 2GiB failed with an opaque error rather than an explanation, because the body is held in a single array.

Both modes were affected, not only the transparent proxy — `ParseGitRequestFilter` is registered on the store-and-forward mapping too, so it buffered everything before JGit's streaming `ReceivePack` ever saw the request. One cap on that filter therefore covers both.

## The cap

`server.max-push-bytes`, default **256 MiB** — 2.5× the shipped `binary-blob.max-size-bytes` of 100 MiB, so the two settings tell a consistent story.

Enforced twice, because neither check is sufficient alone:

- a declared `Content-Length` over the limit is refused without reading anything;
- the read itself counts bytes and stops at the limit, since git switches to chunked encoding for larger pushes and declares no length at all.

Either way an over-size push costs no memory and the developer gets a message naming both the limit and the size. **Rejecting rather than spilling to disk is deliberate:** writing unvalidated pack data to disk relocates the problem instead of solving it.

No JVM flags were added. The image deliberately ships without `-Xmx` so the heap is sized from the container's cgroup limit; the Admin Guide documents the `max-push-bytes × max-concurrent-requests` relationship and says to raise container memory rather than pin the heap.

## Git LFS uploads are now refused

LFS carries file content outside the git protocol and leaves a ~130-byte pointer in the pack, so every content check — secret scanning, binary-blob, diff scan, content patterns — would inspect the pointer and pass it while the real bytes travelled a path fogwall never sees. fogwall could not have validated that content, so it no longer accepts it.

**This regresses nothing.** LFS was already unusable: such a request throws from `determineOperation`, which recognises only the three smart-HTTP operations, and returns a 500 — but only *after* its whole body was buffered. This turns an expensive, confusing failure into a deliberate one with an explanation.

Downloads still pass through. Their request body is a small JSON document, fetches are not content-validated, and refusing them would break clones of any repository that has ever used LFS.

Rejection runs at `Integer.MIN_VALUE`, ahead of the filter that buffers the body — placed any later, the heap cost would survive the fix. It replies `501` with `{"message": ...}` in the LFS client's own dialect, since that leg is plain JSON over HTTP and a git sideband packet would not render.

Making LFS a first-class citizen is a separate question worth deciding deliberately: inspecting content would mean rewriting the batch response's per-object `href` values and proxying the transfers, because providers commonly point those at object storage the proxy never touches.

## Tests

- `RequestBodyWrapperTest` — under/at/over the limit, no-`Content-Length` (chunked) enforcement, `0` meaning unlimited, empty body.
- `LfsRejectionFilterTest` — batch and object uploads refused with the right status and media type, downloads and ordinary git requests pass through, `/info/refs` not mistaken for LFS, and the order is pinned to `Integer.MIN_VALUE` with a comment explaining why.

## Docs

`CONFIGURATION.md` for the key; a new "Sizing memory for pushes" section in `ADMIN_GUIDE.md` covering the heap relationship and the `http.postBuffer` interaction; two new `USER_GUIDE.md` entries — what a too-large rejection looks like with commands to find the large objects, and why LFS is refused.